### PR TITLE
feat: show status changes during logs follow

### DIFF
--- a/cmd/rascal/main.go
+++ b/cmd/rascal/main.go
@@ -1025,6 +1025,7 @@ func (a *app) newLogsCmd() *cobra.Command {
 			sigCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 			defer stop()
 			last := ""
+			lastStatus := state.RunStatus("")
 			for {
 				body, err := fetch()
 				if err != nil {
@@ -1033,6 +1034,15 @@ func (a *app) newLogsCmd() *cobra.Command {
 				if since > 0 {
 					body = filterLogsSince(body, time.Now().Add(-since))
 				}
+				run, err := a.fetchRun(args[0])
+				if err != nil {
+					return err
+				}
+				statusLine, updatedStatus := renderStatusChangeLine(lastStatus, run.Status)
+				if statusLine != "" {
+					_, _ = io.WriteString(os.Stdout, statusLine)
+				}
+				lastStatus = updatedStatus
 				if strings.HasPrefix(body, last) {
 					diff := strings.TrimPrefix(body, last)
 					if diff != "" {
@@ -1998,6 +2008,16 @@ func filterLogsSince(input string, since time.Time) string {
 		out = append(out, line)
 	}
 	return strings.Join(out, "\n")
+}
+
+func renderStatusChangeLine(previous, current state.RunStatus) (string, state.RunStatus) {
+	if current == "" {
+		return "", previous
+	}
+	if current == previous {
+		return "", previous
+	}
+	return fmt.Sprintf("== status: %s ==\n", current), current
 }
 
 func parseIssueRef(input string) (string, int, error) {

--- a/cmd/rascal/main_test.go
+++ b/cmd/rascal/main_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/rtzll/rascal/internal/state"
 )
 
 func TestMaskSecret(t *testing.T) {
@@ -415,4 +417,61 @@ func captureStdout(fn func() error) (string, error) {
 	data, _ := io.ReadAll(r)
 	_ = r.Close()
 	return string(data), err
+}
+
+func TestRenderStatusChangeLineInitial(t *testing.T) {
+	t.Parallel()
+
+	line, updated := renderStatusChangeLine("", state.StatusQueued)
+	if line == "" {
+		t.Fatal("expected status line for initial status")
+	}
+	if !strings.Contains(line, "queued") {
+		t.Fatalf("expected status line to include queued, got %q", line)
+	}
+	if !strings.HasSuffix(line, "\n") {
+		t.Fatalf("expected status line to end with newline, got %q", line)
+	}
+	if updated != state.StatusQueued {
+		t.Fatalf("expected updated status queued, got %q", updated)
+	}
+}
+
+func TestRenderStatusChangeLineNoChange(t *testing.T) {
+	t.Parallel()
+
+	line, updated := renderStatusChangeLine(state.StatusRunning, state.StatusRunning)
+	if line != "" {
+		t.Fatalf("expected no line for unchanged status, got %q", line)
+	}
+	if updated != state.StatusRunning {
+		t.Fatalf("expected updated status to remain running, got %q", updated)
+	}
+}
+
+func TestRenderStatusChangeLineTransition(t *testing.T) {
+	t.Parallel()
+
+	line, updated := renderStatusChangeLine(state.StatusQueued, state.StatusRunning)
+	if line == "" {
+		t.Fatal("expected status line for transition")
+	}
+	if !strings.Contains(line, "running") {
+		t.Fatalf("expected status line to include running, got %q", line)
+	}
+	if updated != state.StatusRunning {
+		t.Fatalf("expected updated status running, got %q", updated)
+	}
+}
+
+func TestRenderStatusChangeLineEmptyCurrent(t *testing.T) {
+	t.Parallel()
+
+	line, updated := renderStatusChangeLine(state.StatusRunning, "")
+	if line != "" {
+		t.Fatalf("expected no line for empty current status, got %q", line)
+	}
+	if updated != state.StatusRunning {
+		t.Fatalf("expected updated status to remain running, got %q", updated)
+	}
 }


### PR DESCRIPTION
Automated changes from Rascal run run_35363484775e8256.