### PR TITLE
refactor(runner): add env builder for docker runner

### DIFF
--- a/internal/runner/docker.go
+++ b/internal/runner/docker.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -41,33 +40,9 @@ func (l DockerLauncher) Start(ctx context.Context, spec Spec) (Result, error) {
 
 	_, _ = fmt.Fprintf(logFile, "[%s] starting docker runner image=%s run_id=%s\n", time.Now().UTC().Format(time.RFC3339), l.Image, spec.RunID)
 
-	envPairs := map[string]string{
-		"RASCAL_RUN_ID":                spec.RunID,
-		"RASCAL_TASK_ID":               spec.TaskID,
-		"RASCAL_TASK":                  spec.Task,
-		"RASCAL_REPO":                  spec.Repo,
-		"RASCAL_BASE_BRANCH":           spec.BaseBranch,
-		"RASCAL_HEAD_BRANCH":           spec.HeadBranch,
-		"RASCAL_TRIGGER":               spec.Trigger,
-		"RASCAL_GOOSE_DEBUG":           strconv.FormatBool(spec.Debug),
-		"RASCAL_CONTEXT":               spec.Context,
-		"RASCAL_CONTEXT_JSON":          "/rascal-meta/context.json",
-		"RASCAL_ISSUE_NUMBER":          strconv.Itoa(spec.IssueNumber),
-		"RASCAL_PR_NUMBER":             strconv.Itoa(spec.PRNumber),
-		"CODEX_HOME":                   "/rascal-meta/codex",
-		"GOOSE_PATH_ROOT":              "/rascal-meta/goose",
-		"GOOSE_PROVIDER":               "codex",
-		"GOOSE_MODEL":                  "gpt-5.2-codex",
-		"GOOSE_MODE":                   "auto",
-		"GOOSE_DISABLE_KEYRING":        "1",
-		"GOOSE_DISABLE_SESSION_NAMING": "true",
-		"GOOSE_CONTEXT_STRATEGY":       "summarize",
-		"GH_PROMPT_DISABLED":           "1",
-		"GIT_TERMINAL_PROMPT":          "0",
-	}
-	if strings.TrimSpace(l.GitHubToken) != "" {
-		envPairs["GH_TOKEN"] = l.GitHubToken
-	}
+	envPairs := NewEnvBuilder(spec).
+		WithGitHubToken(l.GitHubToken).
+		Build()
 
 	args := []string{"run", "--rm", "--name", sanitizeContainerName("rascal-" + spec.RunID)}
 	envKeys := make([]string, 0, len(envPairs))

--- a/internal/runner/env.go
+++ b/internal/runner/env.go
@@ -1,0 +1,80 @@
+package runner
+
+import (
+	"strconv"
+	"strings"
+)
+
+const (
+	envRunID                  = "RASCAL_RUN_ID"
+	envTaskID                 = "RASCAL_TASK_ID"
+	envTask                   = "RASCAL_TASK"
+	envRepo                   = "RASCAL_REPO"
+	envBaseBranch             = "RASCAL_BASE_BRANCH"
+	envHeadBranch             = "RASCAL_HEAD_BRANCH"
+	envTrigger                = "RASCAL_TRIGGER"
+	envGooseDebug             = "RASCAL_GOOSE_DEBUG"
+	envContext                = "RASCAL_CONTEXT"
+	envContextJSON            = "RASCAL_CONTEXT_JSON"
+	envIssueNumber            = "RASCAL_ISSUE_NUMBER"
+	envPRNumber               = "RASCAL_PR_NUMBER"
+	envCodexHome              = "CODEX_HOME"
+	envGoosePathRoot          = "GOOSE_PATH_ROOT"
+	envGooseProvider          = "GOOSE_PROVIDER"
+	envGooseModel             = "GOOSE_MODEL"
+	envGooseMode              = "GOOSE_MODE"
+	envGooseDisableKeyring    = "GOOSE_DISABLE_KEYRING"
+	envGooseDisableSessNaming = "GOOSE_DISABLE_SESSION_NAMING"
+	envGooseContextStrategy   = "GOOSE_CONTEXT_STRATEGY"
+	envGHPromptDisabled       = "GH_PROMPT_DISABLED"
+	envGitTerminalPrompt      = "GIT_TERMINAL_PROMPT"
+	envGHToken                = "GH_TOKEN"
+)
+
+// EnvBuilder assembles the container environment for a run.
+type EnvBuilder struct {
+	spec        Spec
+	githubToken string
+}
+
+func NewEnvBuilder(spec Spec) *EnvBuilder {
+	return &EnvBuilder{spec: spec}
+}
+
+func (b *EnvBuilder) WithGitHubToken(token string) *EnvBuilder {
+	b.githubToken = token
+	return b
+}
+
+func (b *EnvBuilder) Build() map[string]string {
+	env := map[string]string{
+		envRunID:                  b.spec.RunID,
+		envTaskID:                 b.spec.TaskID,
+		envTask:                   b.spec.Task,
+		envRepo:                   b.spec.Repo,
+		envBaseBranch:             b.spec.BaseBranch,
+		envHeadBranch:             b.spec.HeadBranch,
+		envTrigger:                b.spec.Trigger,
+		envGooseDebug:             strconv.FormatBool(b.spec.Debug),
+		envContext:                b.spec.Context,
+		envContextJSON:            "/rascal-meta/context.json",
+		envIssueNumber:            strconv.Itoa(b.spec.IssueNumber),
+		envPRNumber:               strconv.Itoa(b.spec.PRNumber),
+		envCodexHome:              "/rascal-meta/codex",
+		envGoosePathRoot:          "/rascal-meta/goose",
+		envGooseProvider:          "codex",
+		envGooseModel:             "gpt-5.2-codex",
+		envGooseMode:              "auto",
+		envGooseDisableKeyring:    "1",
+		envGooseDisableSessNaming: "true",
+		envGooseContextStrategy:   "summarize",
+		envGHPromptDisabled:       "1",
+		envGitTerminalPrompt:      "0",
+	}
+
+	if strings.TrimSpace(b.githubToken) != "" {
+		env[envGHToken] = b.githubToken
+	}
+
+	return env
+}

--- a/internal/runner/env_test.go
+++ b/internal/runner/env_test.go
@@ -1,0 +1,70 @@
+package runner
+
+import "testing"
+
+func TestEnvBuilderBuild(t *testing.T) {
+	t.Parallel()
+
+	spec := Spec{
+		RunID:       "run-123",
+		TaskID:      "task-456",
+		Repo:        "org/repo",
+		Task:        "do-the-thing",
+		BaseBranch:  "main",
+		HeadBranch:  "feature",
+		Trigger:     "manual",
+		Debug:       true,
+		IssueNumber: 42,
+		PRNumber:    7,
+		Context:     "context",
+	}
+
+	env := NewEnvBuilder(spec).WithGitHubToken("token").Build()
+
+	checks := map[string]string{
+		envRunID:                  "run-123",
+		envTaskID:                 "task-456",
+		envTask:                   "do-the-thing",
+		envRepo:                   "org/repo",
+		envBaseBranch:             "main",
+		envHeadBranch:             "feature",
+		envTrigger:                "manual",
+		envGooseDebug:             "true",
+		envContext:                "context",
+		envContextJSON:            "/rascal-meta/context.json",
+		envIssueNumber:            "42",
+		envPRNumber:               "7",
+		envCodexHome:              "/rascal-meta/codex",
+		envGoosePathRoot:          "/rascal-meta/goose",
+		envGooseProvider:          "codex",
+		envGooseModel:             "gpt-5.2-codex",
+		envGooseMode:              "auto",
+		envGooseDisableKeyring:    "1",
+		envGooseDisableSessNaming: "true",
+		envGooseContextStrategy:   "summarize",
+		envGHPromptDisabled:       "1",
+		envGitTerminalPrompt:      "0",
+		envGHToken:                "token",
+	}
+
+	for key, expected := range checks {
+		got, ok := env[key]
+		if !ok {
+			t.Fatalf("missing env key %q", key)
+		}
+		if got != expected {
+			t.Fatalf("env %q = %q, want %q", key, got, expected)
+		}
+	}
+}
+
+func TestEnvBuilderBuildSkipsEmptyGitHubToken(t *testing.T) {
+	t.Parallel()
+
+	spec := Spec{RunID: "run-1"}
+	env := NewEnvBuilder(spec).WithGitHubToken("  \t\n").Build()
+
+	if _, ok := env[envGHToken]; ok {
+		t.Fatalf("expected GH_TOKEN to be omitted")
+	}
+}


### PR DESCRIPTION
Centralize env assembly for docker launcher and cover required keys in tests.

Automated changes from Rascal run run_f5c85ffb423f410b.

Closes #19