### PR TITLE
docs: note deploy redeploy usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ and ship PRs.
 `rascal` (CLI) -> `rascald` (orchestrator API) -> runner container -> branch +
 PR on GitHub.
 
-## Quickstart (10 Minutes)
+## Getting Started (10 Minutes)
 
 1. Build the CLI:
 
@@ -45,6 +45,8 @@ GITHUB_RUNTIME_TOKEN=...
 ```bash
 ./bin/rascal doctor --host <server_ip>
 ```
+
+To redeploy the daemon on an existing server, run `./bin/rascal deploy --host <server_ip>`.
 
 5. Run first task:
 


### PR DESCRIPTION
Document redeploying the daemon via the deploy command in Getting Started.

Automated changes from Rascal run run_2ab0d9684f161456.