### PR TITLE
feat(cli): infer repo from git remote

### DIFF
--- a/cmd/rascal/main.go
+++ b/cmd/rascal/main.go
@@ -929,7 +929,8 @@ rascal run --issue OWNER/REPO#123
 					return nil
 				})
 			}
-			repo = firstNonEmpty(strings.TrimSpace(repo), a.cfg.DefaultRepo)
+			var inferredRepo bool
+			repo, inferredRepo = resolveRepo(strings.TrimSpace(repo), a.cfg.DefaultRepo, inferRepoFromGitRemote)
 			task = strings.TrimSpace(task)
 			baseBranch = firstNonEmpty(strings.TrimSpace(baseBranch), "main")
 			if repo == "" || task == "" {
@@ -957,6 +958,9 @@ rascal run --issue OWNER/REPO#123
 				return &cliError{Code: exitServer, Message: "failed to decode server response", Cause: err}
 			}
 			return a.emit(map[string]any{"run": out.Run}, func() error {
+				if inferredRepo {
+					a.println("hint: using repo from git remote: %s", repo)
+				}
 				a.println("run created: %s (%s)", out.Run.ID, out.Run.Status)
 				return nil
 			})
@@ -2635,6 +2639,74 @@ func openURLInBrowser(rawURL string) error {
 		cmd = exec.Command("xdg-open", rawURL)
 	}
 	return cmd.Run()
+}
+
+func resolveRepo(explicit, defaultRepo string, infer func() string) (string, bool) {
+	explicit = strings.TrimSpace(explicit)
+	if explicit != "" {
+		return explicit, false
+	}
+	defaultRepo = strings.TrimSpace(defaultRepo)
+	if defaultRepo != "" {
+		return defaultRepo, false
+	}
+	if infer == nil {
+		return "", false
+	}
+	inferred := strings.TrimSpace(infer())
+	if inferred == "" {
+		return "", false
+	}
+	return inferred, true
+}
+
+func inferRepoFromGitRemote() string {
+	remote, err := gitRemoteOrigin()
+	if err != nil {
+		return ""
+	}
+	repo, ok := parseGitHubRepoFromRemote(remote)
+	if !ok {
+		return ""
+	}
+	return repo
+}
+
+func gitRemoteOrigin() (string, error) {
+	cmd := exec.Command("git", "remote", "get-url", "origin")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func parseGitHubRepoFromRemote(remote string) (string, bool) {
+	remote = strings.TrimSpace(remote)
+	if remote == "" {
+		return "", false
+	}
+	var path string
+	switch {
+	case strings.HasPrefix(remote, "git@github.com:"):
+		path = strings.TrimPrefix(remote, "git@github.com:")
+	case strings.HasPrefix(remote, "https://github.com/"):
+		path = strings.TrimPrefix(remote, "https://github.com/")
+	case strings.HasPrefix(remote, "http://github.com/"):
+		path = strings.TrimPrefix(remote, "http://github.com/")
+	default:
+		return "", false
+	}
+	path = strings.TrimSuffix(path, ".git")
+	path = strings.TrimSuffix(path, "/")
+	parts := strings.Split(path, "/")
+	if len(parts) != 2 {
+		return "", false
+	}
+	if strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return "", false
+	}
+	return parts[0] + "/" + parts[1], true
 }
 
 func firstNonEmpty(values ...string) string {

--- a/cmd/rascal/main_test.go
+++ b/cmd/rascal/main_test.go
@@ -489,6 +489,110 @@ func TestGoarchFromHetznerArchitecture(t *testing.T) {
 	}
 }
 
+func TestResolveRepoPrecedence(t *testing.T) {
+	t.Parallel()
+
+	t.Run("explicit wins", func(t *testing.T) {
+		t.Parallel()
+		called := false
+		repo, inferred := resolveRepo("explicit/repo", "default/repo", func() string {
+			called = true
+			return "git/repo"
+		})
+		if called {
+			t.Fatal("expected infer not called for explicit repo")
+		}
+		if inferred {
+			t.Fatal("expected inferred=false for explicit repo")
+		}
+		if repo != "explicit/repo" {
+			t.Fatalf("unexpected repo: %q", repo)
+		}
+	})
+
+	t.Run("default wins", func(t *testing.T) {
+		t.Parallel()
+		called := false
+		repo, inferred := resolveRepo("", "default/repo", func() string {
+			called = true
+			return "git/repo"
+		})
+		if called {
+			t.Fatal("expected infer not called for default repo")
+		}
+		if inferred {
+			t.Fatal("expected inferred=false for default repo")
+		}
+		if repo != "default/repo" {
+			t.Fatalf("unexpected repo: %q", repo)
+		}
+	})
+
+	t.Run("git inference used", func(t *testing.T) {
+		t.Parallel()
+		called := false
+		repo, inferred := resolveRepo("", "", func() string {
+			called = true
+			return "git/repo"
+		})
+		if !called {
+			t.Fatal("expected infer called when explicit/default missing")
+		}
+		if !inferred {
+			t.Fatal("expected inferred=true for git repo")
+		}
+		if repo != "git/repo" {
+			t.Fatalf("unexpected repo: %q", repo)
+		}
+	})
+
+	t.Run("empty inference ignored", func(t *testing.T) {
+		t.Parallel()
+		repo, inferred := resolveRepo("", "", func() string { return "" })
+		if inferred {
+			t.Fatal("expected inferred=false when inference is empty")
+		}
+		if repo != "" {
+			t.Fatalf("expected empty repo, got %q", repo)
+		}
+	})
+}
+
+func TestParseGitHubRepoFromRemote(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		input  string
+		want   string
+		expect bool
+	}{
+		{name: "ssh git suffix", input: "git@github.com:owner/repo.git", want: "owner/repo", expect: true},
+		{name: "ssh no suffix", input: "git@github.com:owner/repo", want: "owner/repo", expect: true},
+		{name: "https git suffix", input: "https://github.com/owner/repo.git", want: "owner/repo", expect: true},
+		{name: "https no suffix", input: "https://github.com/owner/repo", want: "owner/repo", expect: true},
+		{name: "https trailing slash", input: "https://github.com/owner/repo/", want: "owner/repo", expect: true},
+		{name: "non github", input: "https://gitlab.com/owner/repo.git", want: "", expect: false},
+		{name: "missing repo", input: "git@github.com:owner", want: "", expect: false},
+		{name: "extra path", input: "git@github.com:owner/repo/extra", want: "", expect: false},
+		{name: "empty", input: "", want: "", expect: false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := parseGitHubRepoFromRemote(tc.input)
+			if ok != tc.expect {
+				t.Fatalf("parseGitHubRepoFromRemote(%q) ok=%t want %t", tc.input, ok, tc.expect)
+			}
+			if got != tc.want {
+				t.Fatalf("parseGitHubRepoFromRemote(%q) = %q want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestResolveTransport(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Add git remote parsing for GitHub URLs and fall back to it when --repo and default repo are missing. Includes tests for URL parsing and precedence.

Automated changes from Rascal run run_750e6508aacdb58f.

<details><summary>Run Details</summary>

```

    __( O)>  ● new session · codex gpt-5.2-codex
   \____)    20260301_1 · /work/repo
     L L     goose is ready
{"type":"message","message":{"id":null,"role":"assistant","created":1772388346,"content":[{"type":"text","text":"**Todo**\n- [x] Add git-remote inference fallback for missing `--repo` while preserving precedence.\n- [x] Parse supported GitHub remote URL forms and ignore invalid/non-GitHub remotes.\n- [x] Emit a short hint in table output when a repo is inferred.\n- [x] Add unit tests for URL parsing and precedence behavior.\n- [x] Run tests.\n- [x] Write `/rascal-meta/commit_message.txt`.\n\n**Summary**\n- `rascal run` now falls back to the current `origin` GitHub remote when `--repo` and default repo are missing, with a short table-mode hint.\n- Added parsing and precedence tests to cover the new behavior.\n\n**Changes**\n- `cmd/rascal/main.go` adds repo resolution with git inference and a table-only hint.\n- `cmd/rascal/main_test.go` adds tests for GitHub URL parsing and precedence.\n- `/rascal-meta/commit_message.txt` added.\n\n**Tests**\n- `go test ./...`\n\nIf you want, I can also extend the same repo inference to `rascal repo` subcommands or `bootstrap`."}],"metadata":{"userVisible":true,"agentVisible":true}}}
{"type":"complete","total_tokens":2017027}
```

</details>

Closes #10

---

Rascal run took 8m 29s