### PR TITLE
feat(cli): add webhook test command

### DIFF
--- a/cmd/rascal/main.go
+++ b/cmd/rascal/main.go
@@ -177,6 +177,8 @@ func newRootCmd() *cobra.Command {
 	repoCmd.GroupID = "integrations"
 	infraCmd := a.newInfraCmd()
 	infraCmd.GroupID = "integrations"
+	webhookCmd := a.newWebhookCmd()
+	webhookCmd.GroupID = "integrations"
 
 	doctorCmd := a.newDoctorCmd()
 	doctorCmd.GroupID = "utilities"
@@ -198,6 +200,7 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(logsCmd)
 	root.AddCommand(repoCmd)
 	root.AddCommand(infraCmd)
+	root.AddCommand(webhookCmd)
 	root.AddCommand(doctorCmd)
 	root.AddCommand(completionCmd)
 

--- a/cmd/rascal/testdata/help/root.golden
+++ b/cmd/rascal/testdata/help/root.golden
@@ -26,6 +26,7 @@ Logs:
 Integrations:
   infra       Infrastructure operations (provisioning/deploy)
   repo        Repository webhook/label operations
+  webhook     Webhook helpers
 
 Utilities:
   completion  Generate shell completion scripts

--- a/cmd/rascal/webhook.go
+++ b/cmd/rascal/webhook.go
@@ -1,0 +1,430 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/rtzll/rascal/internal/config"
+	ghapi "github.com/rtzll/rascal/internal/github"
+	"github.com/spf13/cobra"
+)
+
+const (
+	webhookTestDefaultEvent          = "issues"
+	webhookTestResponseSnippetLimit  = 200
+	webhookTestResponseBodyReadLimit = 64 * 1024
+)
+
+var webhookTestEvents = []string{
+	"issues",
+	"issue_comment",
+	"pull_request_review",
+	"pull_request",
+}
+
+type webhookTestInput struct {
+	ServerURL     string
+	Repo          string
+	Event         string
+	WebhookSecret string
+}
+
+func (a *app) newWebhookCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "webhook",
+		Short: "Webhook helpers",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(a.newWebhookTestCmd())
+	return cmd
+}
+
+func (a *app) newWebhookTestCmd() *cobra.Command {
+	var (
+		webhookSecret string
+		repo          string
+		event         string
+		dryRun        bool
+		verbose       bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "test",
+		Short: "Send a synthetic GitHub webhook to the server",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			resolved, err := resolveWebhookTestInput(webhookTestInput{
+				ServerURL:     a.cfg.ServerURL,
+				Repo:          repo,
+				Event:         event,
+				WebhookSecret: webhookSecret,
+			}, a.cfg)
+			if err != nil {
+				return err
+			}
+
+			payload, err := buildWebhookTestPayload(resolved.Event, resolved.Repo)
+			if err != nil {
+				return &cliError{
+					Code:    exitInput,
+					Message: err.Error(),
+					Hint:    fmt.Sprintf("use --event %s", strings.Join(webhookTestEvents, "|")),
+				}
+			}
+
+			signature := ghapi.SignatureSHA256([]byte(resolved.WebhookSecret), payload)
+			if signature == "" {
+				return &cliError{Code: exitInput, Message: "failed to sign payload", Hint: "check --webhook-secret"}
+			}
+
+			webhookURL := resolved.ServerURL + "/v1/webhooks/github"
+			deliveryID := webhookTestDeliveryID(dryRun)
+
+			headers := http.Header{}
+			headers.Set("Content-Type", "application/json")
+			headers.Set("User-Agent", "rascal-cli")
+			headers.Set("X-GitHub-Event", resolved.Event)
+			headers.Set("X-GitHub-Delivery", deliveryID)
+			headers.Set("X-Hub-Signature-256", signature)
+
+			payloadValue := any(string(payload))
+			if a.output == "json" {
+				payloadValue = json.RawMessage(payload)
+			}
+
+			out := map[string]any{
+				"webhook_url": webhookURL,
+				"repo":        resolved.Repo,
+				"event":       resolved.Event,
+				"dry_run":     dryRun,
+				"signature":   signature,
+				"delivery_id": deliveryID,
+				"payload":     payloadValue,
+			}
+
+			if dryRun {
+				if verbose {
+					out["request"] = map[string]any{
+						"method":  http.MethodPost,
+						"url":     webhookURL,
+						"headers": headerMap(headers),
+						"payload": payloadValue,
+					}
+				}
+				return a.emit(out, func() error {
+					return renderWebhookTestTable(a, webhookTestTableInput{
+						WebhookURL: webhookURL,
+						Repo:       resolved.Repo,
+						Event:      resolved.Event,
+						Signature:  signature,
+						DeliveryID: deliveryID,
+						Payload:    payload,
+						Verbose:    verbose,
+						DryRun:     true,
+						Headers:    headers,
+					})
+				})
+			}
+
+			client := &http.Client{Timeout: 30 * time.Second}
+			req, err := http.NewRequest(http.MethodPost, webhookURL, bytes.NewReader(payload))
+			if err != nil {
+				return &cliError{Code: exitRuntime, Message: "failed to build webhook request", Cause: err}
+			}
+			for key, values := range headers {
+				for _, value := range values {
+					req.Header.Add(key, value)
+				}
+			}
+
+			resp, err := client.Do(req)
+			if err != nil {
+				return &cliError{Code: exitServer, Message: "webhook request failed", Cause: err}
+			}
+			defer resp.Body.Close()
+
+			body, err := io.ReadAll(io.LimitReader(resp.Body, webhookTestResponseBodyReadLimit))
+			if err != nil {
+				return &cliError{Code: exitServer, Message: "failed to read webhook response", Cause: err}
+			}
+			reqID := strings.TrimSpace(resp.Header.Get("X-Request-ID"))
+			snippet := webhookResponseSnippet(body, webhookTestResponseSnippetLimit)
+
+			out["status"] = resp.StatusCode
+			out["status_text"] = resp.Status
+			if reqID != "" {
+				out["request_id"] = reqID
+			}
+			if snippet != "" {
+				out["response_snippet"] = snippet
+			}
+			if verbose {
+				out["request"] = map[string]any{
+					"method":  http.MethodPost,
+					"url":     webhookURL,
+					"headers": headerMap(headers),
+					"payload": payloadValue,
+				}
+				out["response"] = map[string]any{
+					"status":  resp.Status,
+					"headers": headerMap(resp.Header),
+					"body":    strings.TrimSpace(string(body)),
+				}
+			}
+
+			err = a.emit(out, func() error {
+				return renderWebhookTestTable(a, webhookTestTableInput{
+					WebhookURL: webhookURL,
+					Repo:       resolved.Repo,
+					Event:      resolved.Event,
+					Signature:  signature,
+					DeliveryID: deliveryID,
+					Payload:    payload,
+					Verbose:    verbose,
+					DryRun:     false,
+					Headers:    headers,
+					Response: &webhookTestTableResponse{
+						Status:    resp.Status,
+						RequestID: reqID,
+						Snippet:   snippet,
+						Headers:   resp.Header,
+						Body:      body,
+					},
+				})
+			})
+			if err != nil {
+				return err
+			}
+			if resp.StatusCode >= 300 {
+				return &cliError{Code: exitServer, Message: fmt.Sprintf("webhook response status %d", resp.StatusCode), RequestID: reqID}
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&webhookSecret, "webhook-secret", "", "GitHub webhook secret (or RASCAL_GITHUB_WEBHOOK_SECRET)")
+	cmd.Flags().StringVar(&repo, "repo", "", "repository in OWNER/REPO form")
+	cmd.Flags().StringVar(&event, "event", webhookTestDefaultEvent, "event template: issues|issue_comment|pull_request_review|pull_request")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print payload/signature without sending")
+	cmd.Flags().BoolVar(&verbose, "verbose", false, "print full request/response")
+	return cmd
+}
+
+type webhookTestTableInput struct {
+	WebhookURL string
+	Repo       string
+	Event      string
+	Signature  string
+	DeliveryID string
+	Payload    []byte
+	Headers    http.Header
+	Verbose    bool
+	DryRun     bool
+	Response   *webhookTestTableResponse
+}
+
+type webhookTestTableResponse struct {
+	Status    string
+	RequestID string
+	Snippet   string
+	Headers   http.Header
+	Body      []byte
+}
+
+func renderWebhookTestTable(a *app, input webhookTestTableInput) error {
+	if a.quiet {
+		return nil
+	}
+	fmt.Printf("webhook: %s\n", input.WebhookURL)
+	fmt.Printf("repo: %s\n", input.Repo)
+	fmt.Printf("event: %s\n", input.Event)
+	fmt.Printf("signature: %s\n", input.Signature)
+	fmt.Printf("delivery_id: %s\n", input.DeliveryID)
+	if input.DryRun {
+		fmt.Printf("dry_run: true\n")
+	} else if input.Response != nil {
+		fmt.Printf("status: %s\n", input.Response.Status)
+		if input.Response.RequestID != "" {
+			fmt.Printf("request_id: %s\n", input.Response.RequestID)
+		}
+		if input.Response.Snippet != "" {
+			fmt.Printf("response: %s\n", input.Response.Snippet)
+		}
+	}
+	if input.DryRun {
+		fmt.Printf("payload:\n%s\n", input.Payload)
+	}
+	if input.Verbose {
+		fmt.Printf("\nrequest:\n")
+		fmt.Printf("%s %s\n", http.MethodPost, input.WebhookURL)
+		for _, line := range formatHeaderLines(input.Headers) {
+			fmt.Println(line)
+		}
+		fmt.Printf("payload:\n%s\n", input.Payload)
+		if input.Response != nil {
+			fmt.Printf("\nresponse:\n")
+			fmt.Printf("status: %s\n", input.Response.Status)
+			for _, line := range formatHeaderLines(input.Response.Headers) {
+				fmt.Println(line)
+			}
+			if len(input.Response.Body) > 0 {
+				fmt.Printf("body:\n%s\n", strings.TrimSpace(string(input.Response.Body)))
+			}
+		}
+	}
+	return nil
+}
+
+func resolveWebhookTestInput(in webhookTestInput, cfg config.ClientConfig) (webhookTestInput, error) {
+	out := webhookTestInput{}
+	out.ServerURL = strings.TrimRight(strings.TrimSpace(firstNonEmpty(in.ServerURL, cfg.ServerURL)), "/")
+	out.Repo = strings.TrimSpace(firstNonEmpty(in.Repo, cfg.DefaultRepo))
+	out.Event = strings.ToLower(strings.TrimSpace(in.Event))
+	if out.Event == "" {
+		out.Event = webhookTestDefaultEvent
+	}
+	out.WebhookSecret = firstNonEmpty(strings.TrimSpace(in.WebhookSecret), strings.TrimSpace(os.Getenv("RASCAL_GITHUB_WEBHOOK_SECRET")), strings.TrimSpace(os.Getenv("GITHUB_WEBHOOK_SECRET")))
+
+	if out.ServerURL == "" {
+		return out, &cliError{Code: exitInput, Message: "missing server url", Hint: "pass --server-url or set RASCAL_SERVER_URL"}
+	}
+	if out.Repo == "" {
+		return out, &cliError{Code: exitInput, Message: "repo is required", Hint: "pass --repo or set --default-repo"}
+	}
+	if out.WebhookSecret == "" {
+		return out, &cliError{Code: exitInput, Message: "missing webhook secret", Hint: "pass --webhook-secret or set RASCAL_GITHUB_WEBHOOK_SECRET"}
+	}
+
+	return out, nil
+}
+
+func buildWebhookTestPayload(event, repo string) ([]byte, error) {
+	payload, err := buildWebhookTestEvent(event, repo)
+	if err != nil {
+		return nil, err
+	}
+	return json.MarshalIndent(payload, "", "  ")
+}
+
+func buildWebhookTestEvent(event, repo string) (any, error) {
+	const (
+		issueNumber = 123
+		commentID   = 456
+		reviewID    = 789
+		prNumber    = 123
+		baseBranch  = "main"
+		headBranch  = "rascal/webhook-test"
+		actorLogin  = "rascal-tester"
+	)
+
+	switch event {
+	case "issues":
+		return ghapi.IssuesEvent{
+			Action: "labeled",
+			Label:  ghapi.Label{Name: "rascal"},
+			Issue: ghapi.Issue{
+				Number:      issueNumber,
+				Title:       "Rascal webhook test issue",
+				Body:        "Synthetic webhook payload from rascal webhook test.",
+				PullRequest: nil,
+			},
+			Repository: ghapi.Repository{FullName: repo},
+			Sender:     ghapi.User{Login: actorLogin},
+		}, nil
+	case "issue_comment":
+		return ghapi.IssueCommentEvent{
+			Action: "created",
+			Issue: ghapi.Issue{
+				Number:      issueNumber,
+				Title:       "Rascal webhook test PR",
+				Body:        "Synthetic PR for webhook test.",
+				PullRequest: map[string]any{"url": "https://example.com/pull/123"},
+			},
+			Comment: ghapi.Comment{
+				ID:   commentID,
+				Body: "Synthetic comment from rascal webhook test.",
+				User: ghapi.User{Login: actorLogin},
+			},
+			Repository: ghapi.Repository{FullName: repo},
+			Sender:     ghapi.User{Login: actorLogin},
+		}, nil
+	case "pull_request_review":
+		pr := ghapi.PullRequest{Number: prNumber, Merged: false}
+		pr.Base.Ref = baseBranch
+		pr.Head.Ref = headBranch
+		return ghapi.PullRequestReviewEvent{
+			Action: "submitted",
+			Review: ghapi.Review{
+				ID:    reviewID,
+				Body:  "Synthetic review from rascal webhook test.",
+				State: "commented",
+				User:  ghapi.User{Login: actorLogin},
+			},
+			PullRequest: pr,
+			Repository:  ghapi.Repository{FullName: repo},
+			Sender:      ghapi.User{Login: actorLogin},
+		}, nil
+	case "pull_request":
+		pr := ghapi.PullRequest{Number: prNumber, Merged: false}
+		pr.Base.Ref = baseBranch
+		pr.Head.Ref = headBranch
+		return ghapi.PullRequestEvent{
+			Action:      "opened",
+			PullRequest: pr,
+			Repository:  ghapi.Repository{FullName: repo},
+			Sender:      ghapi.User{Login: actorLogin},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported event %q", event)
+	}
+}
+
+func webhookTestDeliveryID(dryRun bool) string {
+	if dryRun {
+		return "rascal-test-delivery"
+	}
+	return fmt.Sprintf("rascal-test-%d", time.Now().UTC().UnixNano())
+}
+
+func webhookResponseSnippet(body []byte, limit int) string {
+	if limit <= 0 {
+		limit = webhookTestResponseSnippetLimit
+	}
+	trimmed := strings.TrimSpace(string(body))
+	if trimmed == "" {
+		return ""
+	}
+	if len(trimmed) <= limit {
+		return trimmed
+	}
+	return trimmed[:limit] + "..."
+}
+
+func headerMap(h http.Header) map[string]string {
+	out := make(map[string]string, len(h))
+	for key, values := range h {
+		out[key] = strings.Join(values, ", ")
+	}
+	return out
+}
+
+func formatHeaderLines(h http.Header) []string {
+	keys := make([]string, 0, len(h))
+	for key := range h {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	lines := make([]string, 0, len(keys))
+	for _, key := range keys {
+		lines = append(lines, fmt.Sprintf("%s: %s", key, strings.Join(h[key], ", ")))
+	}
+	return lines
+}

--- a/cmd/rascal/webhook_test.go
+++ b/cmd/rascal/webhook_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/rtzll/rascal/internal/config"
+	ghapi "github.com/rtzll/rascal/internal/github"
+)
+
+func TestResolveWebhookTestInputMissingSecret(t *testing.T) {
+	t.Setenv("RASCAL_GITHUB_WEBHOOK_SECRET", "")
+	t.Setenv("GITHUB_WEBHOOK_SECRET", "")
+
+	_, err := resolveWebhookTestInput(webhookTestInput{
+		ServerURL: "http://localhost:8080",
+		Repo:      "owner/repo",
+		Event:     "issues",
+	}, config.ClientConfig{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	ce, ok := err.(*cliError)
+	if !ok {
+		t.Fatalf("expected cliError, got %T", err)
+	}
+	if ce.Message != "missing webhook secret" {
+		t.Fatalf("unexpected message: %q", ce.Message)
+	}
+}
+
+func TestResolveWebhookTestInputMissingRepo(t *testing.T) {
+	_, err := resolveWebhookTestInput(webhookTestInput{
+		ServerURL:     "http://localhost:8080",
+		WebhookSecret: "secret",
+		Event:         "issues",
+	}, config.ClientConfig{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	ce, ok := err.(*cliError)
+	if !ok {
+		t.Fatalf("expected cliError, got %T", err)
+	}
+	if ce.Message != "repo is required" {
+		t.Fatalf("unexpected message: %q", ce.Message)
+	}
+}
+
+func TestBuildWebhookTestPayloadTemplates(t *testing.T) {
+	repo := "acme/widgets"
+	cases := []struct {
+		event string
+		check func(*testing.T, []byte)
+	}{
+		{
+			event: "issues",
+			check: func(t *testing.T, payload []byte) {
+				var ev ghapi.IssuesEvent
+				if err := json.Unmarshal(payload, &ev); err != nil {
+					t.Fatalf("unmarshal issues: %v", err)
+				}
+				if ev.Action != "labeled" {
+					t.Fatalf("unexpected action: %q", ev.Action)
+				}
+				if ev.Label.Name != "rascal" {
+					t.Fatalf("unexpected label: %q", ev.Label.Name)
+				}
+				if ev.Issue.PullRequest != nil {
+					t.Fatal("expected issue to not be a pull request")
+				}
+				if ev.Repository.FullName != repo {
+					t.Fatalf("unexpected repo: %q", ev.Repository.FullName)
+				}
+			},
+		},
+		{
+			event: "issue_comment",
+			check: func(t *testing.T, payload []byte) {
+				var ev ghapi.IssueCommentEvent
+				if err := json.Unmarshal(payload, &ev); err != nil {
+					t.Fatalf("unmarshal issue_comment: %v", err)
+				}
+				if ev.Action != "created" {
+					t.Fatalf("unexpected action: %q", ev.Action)
+				}
+				if ev.Issue.PullRequest == nil {
+					t.Fatal("expected pull_request marker")
+				}
+				if ev.Comment.ID == 0 {
+					t.Fatal("expected comment id")
+				}
+				if ev.Repository.FullName != repo {
+					t.Fatalf("unexpected repo: %q", ev.Repository.FullName)
+				}
+			},
+		},
+		{
+			event: "pull_request_review",
+			check: func(t *testing.T, payload []byte) {
+				var ev ghapi.PullRequestReviewEvent
+				if err := json.Unmarshal(payload, &ev); err != nil {
+					t.Fatalf("unmarshal pull_request_review: %v", err)
+				}
+				if ev.Action != "submitted" {
+					t.Fatalf("unexpected action: %q", ev.Action)
+				}
+				if ev.Review.ID == 0 {
+					t.Fatal("expected review id")
+				}
+				if ev.PullRequest.Number == 0 {
+					t.Fatal("expected pull request number")
+				}
+				if ev.Repository.FullName != repo {
+					t.Fatalf("unexpected repo: %q", ev.Repository.FullName)
+				}
+			},
+		},
+		{
+			event: "pull_request",
+			check: func(t *testing.T, payload []byte) {
+				var ev ghapi.PullRequestEvent
+				if err := json.Unmarshal(payload, &ev); err != nil {
+					t.Fatalf("unmarshal pull_request: %v", err)
+				}
+				if ev.Action != "opened" {
+					t.Fatalf("unexpected action: %q", ev.Action)
+				}
+				if ev.PullRequest.Number == 0 {
+					t.Fatal("expected pull request number")
+				}
+				if ev.Repository.FullName != repo {
+					t.Fatalf("unexpected repo: %q", ev.Repository.FullName)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		payload, err := buildWebhookTestPayload(tc.event, repo)
+		if err != nil {
+			t.Fatalf("build payload %s: %v", tc.event, err)
+		}
+		tc.check(t, payload)
+	}
+}
+
+func TestBuildWebhookTestPayloadUnknownEvent(t *testing.T) {
+	if _, err := buildWebhookTestPayload("unknown", "owner/repo"); err == nil {
+		t.Fatal("expected error for unknown event")
+	}
+}

--- a/internal/github/webhook.go
+++ b/internal/github/webhook.go
@@ -16,6 +16,16 @@ func EventType(h http.Header) string {
 	return strings.TrimSpace(h.Get("X-GitHub-Event"))
 }
 
+// SignatureSHA256 returns a GitHub-style X-Hub-Signature-256 header value.
+func SignatureSHA256(secret, payload []byte) string {
+	if len(secret) == 0 {
+		return ""
+	}
+	mac := hmac.New(sha256.New, secret)
+	_, _ = mac.Write(payload)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
 // VerifySignatureSHA256 validates GitHub's X-Hub-Signature-256 header.
 func VerifySignatureSHA256(secret, payload []byte, signatureHeader string) bool {
 	if len(secret) == 0 {

--- a/internal/github/webhook_test.go
+++ b/internal/github/webhook_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -23,6 +24,20 @@ func TestVerifySignatureSHA256(t *testing.T) {
 	}
 	if VerifySignatureSHA256(secret, payload, fmt.Sprintf("sha256=%s", stringsRepeat("0", 64))) {
 		t.Fatal("expected invalid signature to fail")
+	}
+}
+
+func TestSignatureSHA256MatchesVerify(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("top-secret")
+	payload := []byte(`{"hello":"world"}`)
+	sig := SignatureSHA256(secret, payload)
+	if !strings.HasPrefix(sig, "sha256=") {
+		t.Fatalf("expected sha256 prefix, got %q", sig)
+	}
+	if !VerifySignatureSHA256(secret, payload, sig) {
+		t.Fatal("expected signature to verify")
 	}
 }
 


### PR DESCRIPTION
Add rascal webhook test with synthetic GitHub payloads, signature generation, and verbose output.

Automated changes from Rascal run run_6bd8522387079538.

<details><summary>Run Details</summary>

```

    __( O)>  ● new session · codex gpt-5.2-codex
   \____)    20260301_1 · /work/repo
     L L     goose is ready
{"type":"message","message":{"id":null,"role":"assistant","created":1772389567,"content":[{"type":"text","text":"**Summary**\n- Added `rascal webhook test` with synthetic GitHub payloads, signature generation, dry-run, and verbose request/response output.\n- Added signature helper and unit tests for signature generation, payload construction, and error handling.\n- Updated root help snapshot to include the new `webhook` command.\n\n**Tests**\n- `go test ./...`\n\n**Files**\n- `cmd/rascal/webhook.go`\n- `cmd/rascal/webhook_test.go`\n- `cmd/rascal/main.go`\n- `internal/github/webhook.go`\n- `internal/github/webhook_test.go`\n- `cmd/rascal/testdata/help/root.golden`\n\n**Next steps**\n1. Try a dry run: `rascal webhook test --dry-run --repo OWNER/REPO --webhook-secret \"$SECRET\"`.\n2. Send a live test with verbose output: `rascal webhook test --event issues --verbose`."}],"metadata":{"userVisible":true,"agentVisible":true}}}
{"type":"complete","total_tokens":4025824}
```

</details>

Closes #9

---

Rascal run took 17m 25s