### PR TITLE
refactor(cli): fold issue runs into run --issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ GITHUB_RUNTIME_TOKEN=...
 
 ```bash
 ./bin/rascal run -t "..."
-./bin/rascal issue OWNER/REPO#123
+./bin/rascal run --issue OWNER/REPO#123
 ./bin/rascal ps
 ./bin/rascal logs <run_id> --follow
 ./bin/rascal open <run_id>

--- a/cmd/rascal/main.go
+++ b/cmd/rascal/main.go
@@ -157,8 +157,6 @@ func newRootCmd() *cobra.Command {
 
 	runCmd := a.newRunCmd()
 	runCmd.GroupID = "runs"
-	issueCmd := a.newIssueCmd()
-	issueCmd.GroupID = "runs"
 	psCmd := a.newPSCmd()
 	psCmd.GroupID = "runs"
 	openCmd := a.newOpenCmd()
@@ -189,7 +187,6 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(configCmd)
 	root.AddCommand(authCmd)
 	root.AddCommand(runCmd)
-	root.AddCommand(issueCmd)
 	root.AddCommand(psCmd)
 	root.AddCommand(openCmd)
 	root.AddCommand(retryCmd)
@@ -881,19 +878,53 @@ rascal deploy --host 203.0.113.10 --skip-env-upload --skip-auth-upload
 }
 
 func (a *app) newRunCmd() *cobra.Command {
-	var repo, task, baseBranch string
+	var repo, task, baseBranch, issueRef string
 	var debug bool
 	cmd := &cobra.Command{
 		Use:   "run",
-		Short: "Start an ad-hoc run",
-		Long:  "Start a run for a repository/task pair. The repository must be in OWNER/REPO form.",
+		Short: "Start a run",
+		Long:  "Start a run for a repository/task pair, or create a run from an issue reference. The repository must be in OWNER/REPO form.",
 		Example: strings.TrimSpace(`
 rascal run -R OWNER/REPO -t "Fix flaky tests"
 rascal run --repo OWNER/REPO --task "Refactor parser" --output json
+rascal run --issue OWNER/REPO#123
 `),
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := a.requireServerAuth(); err != nil {
 				return err
+			}
+			issueRef = strings.TrimSpace(issueRef)
+			if issueRef != "" {
+				if cmd.Flags().Changed("repo") || cmd.Flags().Changed("task") || cmd.Flags().Changed("base-branch") {
+					return &cliError{Code: exitInput, Message: "--issue cannot be combined with --repo, --task, or --base-branch"}
+				}
+				repo, issueNumber, err := parseIssueRef(issueRef)
+				if err != nil {
+					return &cliError{Code: exitInput, Message: err.Error()}
+				}
+				payload := map[string]any{
+					"repo":         repo,
+					"issue_number": issueNumber,
+					"debug":        debug,
+				}
+				resp, err := a.client.doJSON(http.MethodPost, "/v1/tasks/issue", payload)
+				if err != nil {
+					return &cliError{Code: exitServer, Message: "request failed", Cause: err}
+				}
+				defer resp.Body.Close()
+				if resp.StatusCode >= 300 {
+					return decodeServerError(resp)
+				}
+				var out struct {
+					Run state.Run `json:"run"`
+				}
+				if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+					return &cliError{Code: exitServer, Message: "failed to decode server response", Cause: err}
+				}
+				return a.emit(map[string]any{"run": out.Run}, func() error {
+					a.println("issue run created: %s (%s)", out.Run.ID, out.Run.Status)
+					return nil
+				})
 			}
 			repo = firstNonEmpty(strings.TrimSpace(repo), a.cfg.DefaultRepo)
 			task = strings.TrimSpace(task)
@@ -931,54 +962,7 @@ rascal run --repo OWNER/REPO --task "Refactor parser" --output json
 	cmd.Flags().StringVarP(&repo, "repo", "R", "", "repository in OWNER/REPO form")
 	cmd.Flags().StringVarP(&task, "task", "t", "", "task text")
 	cmd.Flags().StringVarP(&baseBranch, "base-branch", "b", "main", "base branch")
-	cmd.Flags().BoolVar(&debug, "debug", true, "stream detailed agent execution logs (use --debug=false to reduce verbosity)")
-	return cmd
-}
-
-func (a *app) newIssueCmd() *cobra.Command {
-	var debug bool
-	cmd := &cobra.Command{
-		Use:   "issue OWNER/REPO#123",
-		Short: "Start a run from an issue",
-		Long:  "Create a run using an issue reference in OWNER/REPO#NUMBER form.",
-		Example: strings.TrimSpace(`
-rascal issue OWNER/REPO#123
-rascal issue OWNER/REPO#123 --output json
-`),
-		Args: cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
-			if err := a.requireServerAuth(); err != nil {
-				return err
-			}
-			repo, issueNumber, err := parseIssueRef(args[0])
-			if err != nil {
-				return &cliError{Code: exitInput, Message: err.Error()}
-			}
-			payload := map[string]any{
-				"repo":         repo,
-				"issue_number": issueNumber,
-				"debug":        debug,
-			}
-			resp, err := a.client.doJSON(http.MethodPost, "/v1/tasks/issue", payload)
-			if err != nil {
-				return &cliError{Code: exitServer, Message: "request failed", Cause: err}
-			}
-			defer resp.Body.Close()
-			if resp.StatusCode >= 300 {
-				return decodeServerError(resp)
-			}
-			var out struct {
-				Run state.Run `json:"run"`
-			}
-			if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-				return &cliError{Code: exitServer, Message: "failed to decode server response", Cause: err}
-			}
-			return a.emit(map[string]any{"run": out.Run}, func() error {
-				a.println("issue run created: %s (%s)", out.Run.ID, out.Run.Status)
-				return nil
-			})
-		},
-	}
+	cmd.Flags().StringVar(&issueRef, "issue", "", "issue reference in OWNER/REPO#NUMBER form")
 	cmd.Flags().BoolVar(&debug, "debug", true, "stream detailed agent execution logs (use --debug=false to reduce verbosity)")
 	return cmd
 }

--- a/cmd/rascal/main_test.go
+++ b/cmd/rascal/main_test.go
@@ -232,7 +232,7 @@ func TestBootstrapAndInfraDefaults(t *testing.T) {
 	}
 }
 
-func TestRunIssueRetryDebugDefaults(t *testing.T) {
+func TestRunRetryDebugDefaults(t *testing.T) {
 	root := newRootCmd()
 
 	runCmd, _, err := root.Find([]string{"run"})
@@ -243,20 +243,110 @@ func TestRunIssueRetryDebugDefaults(t *testing.T) {
 		t.Fatalf("run default debug = %q, want true", got)
 	}
 
-	issueCmd, _, err := root.Find([]string{"issue"})
-	if err != nil {
-		t.Fatalf("issue command missing: %v", err)
-	}
-	if got := issueCmd.Flags().Lookup("debug").DefValue; got != "true" {
-		t.Fatalf("issue default debug = %q, want true", got)
-	}
-
 	retryCmd, _, err := root.Find([]string{"retry"})
 	if err != nil {
 		t.Fatalf("retry command missing: %v", err)
 	}
 	if got := retryCmd.Flags().Lookup("debug").DefValue; got != "true" {
 		t.Fatalf("retry default debug = %q, want true", got)
+	}
+}
+
+func TestRunIssueCreatesIssueRunPayload(t *testing.T) {
+	var payload map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/v1/tasks/issue" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"run": map[string]any{
+				"id":     "run_issue",
+				"status": "queued",
+			},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	a := &app{
+		cfg: config.ClientConfig{
+			ServerURL: srv.URL,
+			APIToken:  "test-token",
+			Transport: "http",
+		},
+		client: apiClient{
+			baseURL:   srv.URL,
+			token:     "test-token",
+			http:      srv.Client(),
+			transport: "http",
+		},
+		output: "json",
+	}
+
+	cmd := a.newRunCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"--issue", "owner/repo#123"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("run --issue: %v", err)
+	}
+
+	if payload["repo"] != "owner/repo" {
+		t.Fatalf("unexpected repo payload: %v", payload["repo"])
+	}
+	if payload["issue_number"] != float64(123) {
+		t.Fatalf("unexpected issue number payload: %v", payload["issue_number"])
+	}
+	if payload["debug"] != true {
+		t.Fatalf("unexpected debug payload: %v", payload["debug"])
+	}
+}
+
+func TestRunIssueInvalidFormat(t *testing.T) {
+	a := &app{
+		cfg: config.ClientConfig{
+			APIToken: "test-token",
+		},
+	}
+	cmd := a.newRunCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"--issue", "owner/repo"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for invalid issue ref")
+	}
+	if !strings.Contains(err.Error(), "invalid issue ref") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunIssueMutualExclusion(t *testing.T) {
+	a := &app{
+		cfg: config.ClientConfig{
+			APIToken: "test-token",
+		},
+	}
+	cmd := a.newRunCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"--issue", "owner/repo#42", "--task", "Fix it"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for mutually exclusive flags")
+	}
+	if !strings.Contains(err.Error(), "--issue cannot be combined") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/cmd/rascal/testdata/help/root.golden
+++ b/cmd/rascal/testdata/help/root.golden
@@ -13,11 +13,10 @@ Setup:
 
 Runs:
   cancel      Cancel a queued or running run
-  issue       Start a run from an issue
   open        Open PR URL for a run in your browser
   ps          List recent runs
   retry       Create a new run from an existing run
-  run         Start an ad-hoc run
+  run         Start a run
   task        Show task status/details
 
 Logs:

--- a/cmd/rascal/testdata/help/run.golden
+++ b/cmd/rascal/testdata/help/run.golden
@@ -1,4 +1,4 @@
-Start a run for a repository/task pair. The repository must be in OWNER/REPO form.
+Start a run for a repository/task pair, or create a run from an issue reference. The repository must be in OWNER/REPO form.
 
 Usage:
   rascal run [flags]
@@ -6,11 +6,13 @@ Usage:
 Examples:
 rascal run -R OWNER/REPO -t "Fix flaky tests"
 rascal run --repo OWNER/REPO --task "Refactor parser" --output json
+rascal run --issue OWNER/REPO#123
 
 Flags:
   -b, --base-branch string   base branch (default "main")
       --debug                stream detailed agent execution logs (use --debug=false to reduce verbosity) (default true)
   -h, --help                 help for run
+      --issue string         issue reference in OWNER/REPO#NUMBER form
   -R, --repo string          repository in OWNER/REPO form
   -t, --task string          task text
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -20,7 +20,7 @@ Ad-hoc task:
 Issue-driven task:
 
 ```bash
-./bin/rascal issue OWNER/REPO#123
+./bin/rascal run --issue OWNER/REPO#123
 ```
 
 ## Monitor Runs


### PR DESCRIPTION
Remove the top-level issue command and route issue runs through the run subcommand with validation and tests.

Automated changes from Rascal run run_757fdacc07a2f5e1.

<details><summary>Run Details</summary>

```

    __( O)>  ● new session · codex gpt-5.2-codex
   \____)    20260301_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: "/usr/bin/codex"
Model: gpt-5.2-codex
Reasoning effort: high
Skip git check: false
Prompt length: 1959 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Response Guidelines

Use Markdown formatting for all responses.

Human: <info-msg>
It is currently 2026-03-01 20:30:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

</info-msg>
# Rascal Run Instructions

Run ID: run_757fdacc07a2f5e1
Task ID: rtzll/rascal#7
Repository: rtzll/rascal
Issue: #7

## Task

refactor(cli): consolidate issue runs into 'rascal run --issue' and remove top-level 'issue' command

Simplify the CLI by using a single entrypoint for all run creation.

Scope:

- Add --issue OWNER/REPO#123 to rascal run.
- Keep existing run --repo/--task flow unchanged.
- Make --issue mutually exclusive with --repo and --task combinations that conflict.
- Route run --issue through the same backend behavior currently used for issue-triggered runs.
- Remove top-level rascal issue command and related wiring.
- Update help text, examples, docs, and shell completions.
- Add/adjust tests for:
    - valid --issue parsing
    - invalid format handling
    - mutual exclusivity validation
    - parity of created run payload/behavior\

Acceptance criteria:

- rascal run --issue rtzll/rascal#123 creates the same kind of run as before.
- rascal issue ... no longer appears in CLI/help.
- go test ./... passes.

## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run tests or explain why tests could not run.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label 'rascal' on issue #7


Assistant: 
Image files: 0
============================
{"type":"message","message":{"id":null,"role":"assistant","created":1772397570,"content":[{"type":"text","text":"**Todo**\n- [x] Add `rascal run --issue` flow with mutual exclusivity and issue-run backend routing.\n- [x] Remove top-level `rascal issue` command wiring.\n- [x] Update help text/examples/docs and golden snapshots.\n- [x] Add tests for valid parsing, invalid format, exclusivity, and payload parity.\n- [x] Run `go test ./...`.\n\n**Summary**\n- Consolidated issue-triggered runs into `rascal run --issue`, reusing the existing `/v1/tasks/issue` backend and removing the standalone issue command. `cmd/rascal/main.go`\n- Updated CLI help text/goldens and docs to reflect the new entrypoint. `cmd/rascal/testdata/help/root.golden`, `cmd/rascal/testdata/help/run.golden`, `docs/commands.md`, `README.md`\n- Added CLI tests for `--issue` parsing, invalid format, mutual exclusivity, and payload parity. `cmd/rascal/main_test.go`\n- Wrote commit message template in `/rascal-meta/commit_message.txt`.\n\n**Tests**\n- `go test ./...`"}],"metadata":{"userVisible":true,"agentVisible":true}}}
{"type":"complete","total_tokens":2293547}
```

</details>

Closes #7

---

Rascal run took 9m 18s