### PR TITLE
refactor(cli): consolidate config resolution

### DIFF
--- a/cmd/rascal/config_resolver.go
+++ b/cmd/rascal/config_resolver.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+const (
+	configSourceFlag     = "flag"
+	configSourceEnv      = "env"
+	configSourceConfig   = "config"
+	configSourceDefault  = "default"
+	configSourceUnset    = "unset"
+	configSourceResolved = "resolved"
+)
+
+type resolvedString struct {
+	value  string
+	source string
+}
+
+type configResolver struct {
+	v *viper.Viper
+}
+
+func newConfigResolver(path string) (*configResolver, error) {
+	v := viper.New()
+	v.SetConfigFile(path)
+	v.SetConfigType("toml")
+	v.SetDefault("server_url", "http://127.0.0.1:8080")
+	v.SetEnvPrefix("RASCAL")
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	v.AutomaticEnv()
+
+	if err := v.ReadInConfig(); err != nil {
+		var notFound viper.ConfigFileNotFoundError
+		if !errors.As(err, &notFound) && !os.IsNotExist(err) {
+			return nil, err
+		}
+	}
+
+	return &configResolver{v: v}, nil
+}
+
+func (r *configResolver) stringValue(key string) string {
+	return strings.TrimSpace(r.v.GetString(key))
+}
+
+func (r *configResolver) intValue(key string) int {
+	return r.v.GetInt(key)
+}
+
+func (r *configResolver) resolveString(flagValue, envKey, configKey, fallbackSource string) resolvedString {
+	flagValue = strings.TrimSpace(flagValue)
+	if flagValue != "" {
+		return resolvedString{value: flagValue, source: configSourceFlag}
+	}
+
+	envValue := strings.TrimSpace(os.Getenv(envKey))
+	configValue := strings.TrimSpace(r.v.GetString(configKey))
+	if envValue != "" {
+		return resolvedString{value: configValue, source: configSourceEnv}
+	}
+	if r.v.InConfig(configKey) {
+		return resolvedString{value: configValue, source: configSourceConfig}
+	}
+	return resolvedString{value: configValue, source: fallbackSource}
+}

--- a/cmd/rascal/main.go
+++ b/cmd/rascal/main.go
@@ -201,78 +201,43 @@ func newRootCmd() *cobra.Command {
 }
 
 func (a *app) initConfig() error {
-	v := viper.New()
-	v.SetConfigFile(a.configPath)
-	v.SetConfigType("toml")
-	v.SetDefault("server_url", "http://127.0.0.1:8080")
-	v.SetEnvPrefix("RASCAL")
-	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-	v.AutomaticEnv()
-
-	if err := v.ReadInConfig(); err != nil {
-		var notFound viper.ConfigFileNotFoundError
-		if !errors.As(err, &notFound) && !os.IsNotExist(err) {
-			return &cliError{
-				Code:    exitConfig,
-				Message: "failed to read config",
-				Hint:    fmt.Sprintf("fix %s or run `rascal init`", a.configPath),
-				Cause:   err,
-			}
+	resolver, err := newConfigResolver(a.configPath)
+	if err != nil {
+		return &cliError{
+			Code:    exitConfig,
+			Message: "failed to read config",
+			Hint:    fmt.Sprintf("fix %s or run `rascal init`", a.configPath),
+			Cause:   err,
 		}
 	}
-	a.cfg = config.ClientConfig{
-		ServerURL:   strings.TrimSpace(v.GetString("server_url")),
-		APIToken:    strings.TrimSpace(v.GetString("api_token")),
-		DefaultRepo: strings.TrimSpace(v.GetString("default_repo")),
-		Host:        strings.TrimSpace(v.GetString("host")),
-		Domain:      strings.TrimSpace(v.GetString("domain")),
-		Transport:   strings.TrimSpace(v.GetString("transport")),
-		SSHHost:     strings.TrimSpace(v.GetString("ssh_host")),
-		SSHUser:     strings.TrimSpace(v.GetString("ssh_user")),
-		SSHKey:      strings.TrimSpace(v.GetString("ssh_key")),
-		SSHPort:     v.GetInt("ssh_port"),
+
+	transportFlag := strings.TrimSpace(a.transportFlag)
+	if transportFlag != "" {
+		transportFlag = strings.ToLower(transportFlag)
 	}
 
-	if strings.TrimSpace(a.serverURLFlag) != "" {
-		a.cfg.ServerURL = strings.TrimSpace(a.serverURLFlag)
-		a.serverSource = "flag"
-	} else if strings.TrimSpace(os.Getenv("RASCAL_SERVER_URL")) != "" {
-		a.serverSource = "env"
-	} else if v.InConfig("server_url") {
-		a.serverSource = "config"
-	} else {
-		a.serverSource = "default"
+	server := resolver.resolveString(a.serverURLFlag, "RASCAL_SERVER_URL", "server_url", configSourceDefault)
+	token := resolver.resolveString(a.apiTokenFlag, "RASCAL_API_TOKEN", "api_token", configSourceUnset)
+	repo := resolver.resolveString(a.defaultRepoFlag, "RASCAL_DEFAULT_REPO", "default_repo", configSourceUnset)
+	transport := resolver.resolveString(transportFlag, "RASCAL_TRANSPORT", "transport", configSourceDefault)
+
+	a.cfg = config.ClientConfig{
+		ServerURL:   server.value,
+		APIToken:    token.value,
+		DefaultRepo: repo.value,
+		Host:        resolver.stringValue("host"),
+		Domain:      resolver.stringValue("domain"),
+		Transport:   transport.value,
+		SSHHost:     resolver.stringValue("ssh_host"),
+		SSHUser:     resolver.stringValue("ssh_user"),
+		SSHKey:      resolver.stringValue("ssh_key"),
+		SSHPort:     resolver.intValue("ssh_port"),
 	}
-	if strings.TrimSpace(a.apiTokenFlag) != "" {
-		a.cfg.APIToken = strings.TrimSpace(a.apiTokenFlag)
-		a.tokenSource = "flag"
-	} else if strings.TrimSpace(os.Getenv("RASCAL_API_TOKEN")) != "" {
-		a.tokenSource = "env"
-	} else if v.InConfig("api_token") {
-		a.tokenSource = "config"
-	} else {
-		a.tokenSource = "unset"
-	}
-	if strings.TrimSpace(a.defaultRepoFlag) != "" {
-		a.cfg.DefaultRepo = strings.TrimSpace(a.defaultRepoFlag)
-		a.repoSource = "flag"
-	} else if strings.TrimSpace(os.Getenv("RASCAL_DEFAULT_REPO")) != "" {
-		a.repoSource = "env"
-	} else if v.InConfig("default_repo") {
-		a.repoSource = "config"
-	} else {
-		a.repoSource = "unset"
-	}
-	if strings.TrimSpace(a.transportFlag) != "" {
-		a.cfg.Transport = strings.ToLower(strings.TrimSpace(a.transportFlag))
-		a.transportSource = "flag"
-	} else if strings.TrimSpace(os.Getenv("RASCAL_TRANSPORT")) != "" {
-		a.transportSource = "env"
-	} else if v.InConfig("transport") {
-		a.transportSource = "config"
-	} else {
-		a.transportSource = "default"
-	}
+
+	a.serverSource = server.source
+	a.tokenSource = token.source
+	a.repoSource = repo.source
+	a.transportSource = transport.source
 	if strings.TrimSpace(a.sshHostFlag) != "" {
 		a.cfg.SSHHost = strings.TrimSpace(a.sshHostFlag)
 	}
@@ -314,8 +279,8 @@ func (a *app) initConfig() error {
 		sshKey:    strings.TrimSpace(a.cfg.SSHKey),
 		sshPort:   a.cfg.SSHPort,
 	}
-	if a.transportSource == "default" {
-		a.transportSource = "resolved"
+	if a.transportSource == configSourceDefault {
+		a.transportSource = configSourceResolved
 	}
 
 	switch strings.ToLower(strings.TrimSpace(a.output)) {

--- a/cmd/rascal/main_test.go
+++ b/cmd/rascal/main_test.go
@@ -128,7 +128,196 @@ func TestRootFlagsDoNotExposeDeadFlags(t *testing.T) {
 	}
 }
 
-func TestRootHasGitHubAndInfraCommands(t *testing.T) {
+func TestInitConfigResolutionSources(t *testing.T) {
+	type flags struct {
+		serverURL   string
+		apiToken    string
+		defaultRepo string
+		transport   string
+	}
+
+	type want struct {
+		serverURL         string
+		apiToken          string
+		defaultRepo       string
+		transport         string
+		serverSource      string
+		apiTokenSource    string
+		defaultRepoSource string
+		transportSource   string
+	}
+
+	cases := []struct {
+		name          string
+		configContent string
+		env           map[string]string
+		flags         flags
+		want          want
+	}{
+		{
+			name: "flags override env and config",
+			configContent: `
+server_url = "http://from-config"
+api_token = "token-config"
+default_repo = "config/repo"
+transport = "ssh"
+`,
+			env: map[string]string{
+				"RASCAL_SERVER_URL":   "http://from-env",
+				"RASCAL_API_TOKEN":    "token-env",
+				"RASCAL_DEFAULT_REPO": "env/repo",
+				"RASCAL_TRANSPORT":    "http",
+			},
+			flags: flags{
+				serverURL:   "http://from-flag",
+				apiToken:    "token-flag",
+				defaultRepo: "flag/repo",
+				transport:   "HTTP",
+			},
+			want: want{
+				serverURL:         "http://from-flag",
+				apiToken:          "token-flag",
+				defaultRepo:       "flag/repo",
+				transport:         "http",
+				serverSource:      configSourceFlag,
+				apiTokenSource:    configSourceFlag,
+				defaultRepoSource: configSourceFlag,
+				transportSource:   configSourceFlag,
+			},
+		},
+		{
+			name: "env overrides config",
+			configContent: `
+server_url = "http://from-config"
+api_token = "token-config"
+default_repo = "config/repo"
+transport = "ssh"
+`,
+			env: map[string]string{
+				"RASCAL_SERVER_URL":   "http://from-env",
+				"RASCAL_API_TOKEN":    "token-env",
+				"RASCAL_DEFAULT_REPO": "env/repo",
+				"RASCAL_TRANSPORT":    "http",
+			},
+			want: want{
+				serverURL:         "http://from-env",
+				apiToken:          "token-env",
+				defaultRepo:       "env/repo",
+				transport:         "http",
+				serverSource:      configSourceEnv,
+				apiTokenSource:    configSourceEnv,
+				defaultRepoSource: configSourceEnv,
+				transportSource:   configSourceEnv,
+			},
+		},
+		{
+			name: "config used without env or flags",
+			configContent: `
+server_url = "http://from-config"
+api_token = "token-config"
+default_repo = "config/repo"
+transport = "ssh"
+`,
+			want: want{
+				serverURL:         "http://from-config",
+				apiToken:          "token-config",
+				defaultRepo:       "config/repo",
+				transport:         "ssh",
+				serverSource:      configSourceConfig,
+				apiTokenSource:    configSourceConfig,
+				defaultRepoSource: configSourceConfig,
+				transportSource:   configSourceConfig,
+			},
+		},
+		{
+			name: "defaults and unset when nothing provided",
+			want: want{
+				serverURL:         "http://127.0.0.1:8080",
+				apiToken:          "",
+				defaultRepo:       "",
+				transport:         "auto",
+				serverSource:      configSourceDefault,
+				apiTokenSource:    configSourceUnset,
+				defaultRepoSource: configSourceUnset,
+				transportSource:   configSourceResolved,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			configPath := filepath.Join(t.TempDir(), "config.toml")
+			if strings.TrimSpace(tc.configContent) != "" {
+				if err := os.WriteFile(configPath, []byte(tc.configContent), 0o600); err != nil {
+					t.Fatalf("write config: %v", err)
+				}
+			}
+
+			setEnvForTest(t, "RASCAL_SERVER_URL", tc.env)
+			setEnvForTest(t, "RASCAL_API_TOKEN", tc.env)
+			setEnvForTest(t, "RASCAL_DEFAULT_REPO", tc.env)
+			setEnvForTest(t, "RASCAL_TRANSPORT", tc.env)
+
+			a := &app{
+				configPath:      configPath,
+				serverURLFlag:   tc.flags.serverURL,
+				apiTokenFlag:    tc.flags.apiToken,
+				defaultRepoFlag: tc.flags.defaultRepo,
+				transportFlag:   tc.flags.transport,
+			}
+
+			if err := a.initConfig(); err != nil {
+				t.Fatalf("initConfig: %v", err)
+			}
+
+			if a.cfg.ServerURL != tc.want.serverURL {
+				t.Fatalf("server_url = %q, want %q", a.cfg.ServerURL, tc.want.serverURL)
+			}
+			if a.cfg.APIToken != tc.want.apiToken {
+				t.Fatalf("api_token = %q, want %q", a.cfg.APIToken, tc.want.apiToken)
+			}
+			if a.cfg.DefaultRepo != tc.want.defaultRepo {
+				t.Fatalf("default_repo = %q, want %q", a.cfg.DefaultRepo, tc.want.defaultRepo)
+			}
+			if a.cfg.Transport != tc.want.transport {
+				t.Fatalf("transport = %q, want %q", a.cfg.Transport, tc.want.transport)
+			}
+			if a.serverSource != tc.want.serverSource {
+				t.Fatalf("server_source = %q, want %q", a.serverSource, tc.want.serverSource)
+			}
+			if a.tokenSource != tc.want.apiTokenSource {
+				t.Fatalf("api_token_source = %q, want %q", a.tokenSource, tc.want.apiTokenSource)
+			}
+			if a.repoSource != tc.want.defaultRepoSource {
+				t.Fatalf("default_repo_source = %q, want %q", a.repoSource, tc.want.defaultRepoSource)
+			}
+			if a.transportSource != tc.want.transportSource {
+				t.Fatalf("transport_source = %q, want %q", a.transportSource, tc.want.transportSource)
+			}
+		})
+	}
+}
+
+func setEnvForTest(t *testing.T, key string, values map[string]string) {
+	t.Helper()
+	prev, had := os.LookupEnv(key)
+	if val, ok := values[key]; ok {
+		if err := os.Setenv(key, val); err != nil {
+			t.Fatalf("setenv %s: %v", key, err)
+		}
+	} else if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("unsetenv %s: %v", key, err)
+	}
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(key, prev)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	})
+}
+
+func TestRootHasRepoAndInfraCommands(t *testing.T) {
 	root := newRootCmd()
 	if _, _, err := root.Find([]string{"deploy"}); err != nil {
 		t.Fatalf("deploy command missing: %v", err)


### PR DESCRIPTION
Introduce a shared resolver for config precedence and add tests for source reporting.

Automated changes from Rascal run run_a6133f7d9392fb69.

<details><summary>Run Details</summary>

```

    __( O)>  ● new session · codex gpt-5.2-codex
   \____)    20260302_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: "/usr/bin/codex"
Model: gpt-5.2-codex
Reasoning effort: high
Skip git check: false
Prompt length: 1636 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Response Guidelines

Use Markdown formatting for all responses.

Human: <info-msg>
It is currently 2026-03-02 07:14:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

</info-msg>
# Rascal Run Instructions

Run ID: run_a6133f7d9392fb69
Task ID: rtzll/rascal#16
Repository: rtzll/rascal
Issue: #16

## Task

refactor(cli): consolidate config value resolution helpers

## Goal
Standardize config resolution in CLI to reduce drift and improve explainability.

## Scope
- Introduce shared resolver for precedence: `flags > env > config > inferred/default`.
- Ensure source metadata is consistently available for doctor/config output.
- Replace per-command ad-hoc resolution where feasible.

## Acceptance Criteria
- Resolution behavior is unchanged unless explicitly documented.
- Repeated resolution snippets are removed.
- Tests cover precedence and source reporting.
- `go test ./...` passes.

## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run tests or explain why tests could not run.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label 'rascal' on issue #16


Assistant: 
Image files: 0
============================
{"type":"message","message":{"id":null,"role":"assistant","created":1772436450,"content":[{"type":"text","text":"**TODO**\n- [x] Introduce a shared resolver for `flags > env > config > inferred/default` precedence.\n- [x] Standardize and expose source metadata for config/doctor output.\n- [x] Remove duplicated per-field resolution logic in CLI init.\n- [x] Add tests covering precedence and source reporting.\n- [x] Run `go test ./...`.\n- [x] Write conventional commit message to `/rascal-meta/commit_message.txt`.\n\n**Summary**\n- Added a shared config resolver with explicit source constants and reused it in `initConfig` to centralize precedence handling. \n- Kept existing behavior while consolidating resolution logic and source tagging.\n- Added tests to validate precedence and source reporting.\n\n**Tests**\n- `go test ./...`\n\n**Files Updated**\n- `cmd/rascal/config_resolver.go`\n- `cmd/rascal/main.go`\n- `cmd/rascal/main_test.go`\n- `/rascal-meta/commit_message.txt`\n\nIf you want, I can also extend source reporting to SSH-related fields in `rascal config view` and `rascal doctor`."}],"metadata":{"userVisible":true,"agentVisible":true}}}
{"type":"complete","total_tokens":3025997}
```

</details>

Closes #16

---

Rascal run took 12m 42s