### PR TITLE
docs(readme): align quickstart setup flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,35 +18,90 @@ PR on GitHub.
 
 ## Quickstart (10 Minutes)
 
-1. Build the CLI:
+Build the CLI:
 
 ```bash
 go build -o ./bin/rascal ./cmd/rascal
 ```
 
-2. Create `./.rascal.env` with required tokens:
+Ensure Codex auth exists (one time):
+
+```bash
+codex login
+```
+
+Create `./.rascal.env` with required tokens:
 
 ```bash
 HCLOUD_TOKEN=...
 GITHUB_ADMIN_TOKEN=...
 GITHUB_RUNTIME_TOKEN=...
+RASCAL_API_TOKEN=...
+WEBHOOK_SECRET=...
 ```
 
-3. Bootstrap:
+Setup flow:
+
+1. Initialize local config:
 
 ```bash
-./bin/rascal bootstrap \
-  --repo OWNER/REPO \
+./bin/rascal init \
+  --server-url https://rascal.example.com \
+  --api-token "$RASCAL_API_TOKEN" \
+  --default-repo OWNER/REPO \
+  --non-interactive
+```
+
+2. Provision + deploy:
+
+```bash
+./bin/rascal infra up \
+  --provision \
+  --hcloud-token "$HCLOUD_TOKEN" \
+  --github-runtime-token "$GITHUB_RUNTIME_TOKEN" \
+  --webhook-secret "$WEBHOOK_SECRET" \
+  --api-token "$RASCAL_API_TOKEN" \
   --domain rascal.example.com
+```
+
+Existing host alternative:
+
+```bash
+./bin/rascal infra deploy-existing \
+  --host YOUR_SERVER_IP \
+  --github-runtime-token "$GITHUB_RUNTIME_TOKEN" \
+  --webhook-secret "$WEBHOOK_SECRET" \
+  --api-token "$RASCAL_API_TOKEN" \
+  --domain rascal.example.com
+```
+
+3. Configure GitHub:
+
+```bash
+./bin/rascal github setup OWNER/REPO \
+  --github-token "$GITHUB_ADMIN_TOKEN" \
+  --webhook-secret "$WEBHOOK_SECRET"
 ```
 
 4. Verify:
 
 ```bash
-./bin/rascal doctor --host <server_ip>
+./bin/rascal doctor --host YOUR_SERVER_IP
 ```
 
-5. Run first task:
+Optional convenience (single command):
+
+```bash
+./bin/rascal bootstrap \
+  --repo OWNER/REPO \
+  --domain rascal.example.com \
+  --github-admin-token "$GITHUB_ADMIN_TOKEN" \
+  --github-runtime-token "$GITHUB_RUNTIME_TOKEN" \
+  --webhook-secret "$WEBHOOK_SECRET" \
+  --api-token "$RASCAL_API_TOKEN"
+```
+
+Run first task:
 
 ```bash
 ./bin/rascal run -t "Add a short CONTRIBUTING.md section for local dev setup"


### PR DESCRIPTION
Update the quickstart to match init -> infra -> github -> doctor, add explicit env vars, and keep bootstrap as an optional convenience path.

Automated changes from Rascal run run_8ce237912913191b.

<details><summary>Run Details</summary>

```

    __( O)>  ● new session · codex gpt-5.2-codex
   \____)    20260303_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: "/usr/bin/codex"
Model: gpt-5.2-codex
Reasoning effort: high
Skip git check: false
Prompt length: 1906 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Response Guidelines

Use Markdown formatting for all responses.

Human: <info-msg>
It is currently 2026-03-03 08:29:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

</info-msg>
# Rascal Run Instructions

Run ID: run_8ce237912913191b
Task ID: rtzll/rascal#54
Repository: rtzll/rascal
Issue: #54

## Task

docs(readme): align quickstart with focused setup flow

## Problem
The canonical CLI setup flow has evolved (`init -> infra -> github -> doctor`), but README quickstart still reflects older/less-focused paths.

## Goal
Make README the clear entrypoint for first-time users with one canonical setup flow, while keeping `bootstrap` documented as convenience.

## Scope
- Update quickstart to:
  1. `rascal init`
  2. `rascal infra up` (or `infra deploy-existing`)
  3. `rascal github setup`
  4. `rascal doctor`
- Keep `rascal bootstrap` documented as optional convenience path.
- Ensure examples use consistent flag wording and OWNER/REPO style.

## Acceptance Criteria
- README quickstart matches current CLI command model.
- New user can follow quickstart without reading deeper docs.
- `go test ./...` still passes (docs change should not break tests).

## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run tests or explain why tests could not run.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label 'rascal' on issue #54


Assistant: 
Image files: 0
============================
{"type":"message","message":{"id":null,"role":"assistant","created":1772527085,"content":[{"type":"text","text":"**Todo**\n- [x] Update README quickstart to the canonical `init -> infra -> github -> doctor` flow.\n- [x] Keep `bootstrap` documented as an optional convenience path.\n- [x] Normalize examples with consistent flags and `OWNER/REPO` placeholders.\n- [x] Run tests (`go test ./...`) — failed (see Tests).\n- [x] Write commit message to `/rascal-meta/commit_message.txt`.\n\n**Summary**\n- Updated the Quickstart to match the new setup flow, added explicit env vars (`RASCAL_API_TOKEN`, `WEBHOOK_SECRET`), and kept `bootstrap` as an optional single-command path in `README.md`.\n- Wrote commit message in `/rascal-meta/commit_message.txt`.\n\n**Tests**\n- `go test ./...` failed: `TestCanceledRunDoesNotTransitionToSuccess` timed out waiting for “server idle” in `github.com/rtzll/rascal/cmd/rascald`.\n\n**Next Steps**\n1. I can rerun just the failing test (`go test ./cmd/rascald -run TestCanceledRunDoesNotTransitionToSuccess -count=1`) to check if it’s flaky.\n2. I can investigate the timeout in `cmd/rascald` if you want a deeper fix."}],"metadata":{"userVisible":true,"agentVisible":true}}}
{"type":"complete","total_tokens":1530137}
```

</details>

Closes #54

---

Rascal run took 8m 21s