### PR TITLE
refactor(cli): reuse infra/github helpers in bootstrap

### DIFF
--- a/cmd/rascal/infra.go
+++ b/cmd/rascal/infra.go
@@ -40,6 +40,52 @@ type hcloudProvisionResult struct {
 	ProvisionedAt string `json:"provisioned_at"`
 }
 
+type hetznerProvisionInput struct {
+	Token         string
+	Name          string
+	ServerType    string
+	Location      string
+	Image         string
+	SSHKeyName    string
+	SSHPublicPath string
+	FirewallName  string
+	ApplyFirewall bool
+	Timeout       time.Duration
+}
+
+func resolveHetznerProvisionConfig(input hetznerProvisionInput) (hcloudProvisionConfig, time.Duration, error) {
+	cfg := hcloudProvisionConfig{
+		Token:         strings.TrimSpace(input.Token),
+		ServerName:    firstNonEmpty(strings.TrimSpace(input.Name), fmt.Sprintf("rascal-%d", time.Now().UTC().Unix())),
+		ServerType:    firstNonEmpty(strings.TrimSpace(input.ServerType), "cx23"),
+		Location:      firstNonEmpty(strings.TrimSpace(input.Location), "fsn1"),
+		Image:         firstNonEmpty(strings.TrimSpace(input.Image), "ubuntu-24.04"),
+		SSHKeyName:    firstNonEmpty(strings.TrimSpace(input.SSHKeyName), "rascal"),
+		SSHPublicPath: firstNonEmpty(strings.TrimSpace(input.SSHPublicPath), "~/.ssh/id_ed25519.pub"),
+		FirewallName:  firstNonEmpty(strings.TrimSpace(input.FirewallName), "rascal-fw"),
+		ApplyFirewall: input.ApplyFirewall,
+	}
+	timeout := input.Timeout
+	if timeout <= 0 {
+		timeout = 8 * time.Minute
+	}
+	publicPath, err := expandPath(cfg.SSHPublicPath)
+	if err != nil {
+		return hcloudProvisionConfig{}, 0, err
+	}
+	cfg.SSHPublicPath = publicPath
+	return cfg, timeout, nil
+}
+
+func runHetznerProvision(cfg hcloudProvisionConfig, timeout time.Duration) (hcloudProvisionResult, error) {
+	if timeout <= 0 {
+		timeout = 8 * time.Minute
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return provisionHetznerServer(ctx, cfg)
+}
+
 func (a *app) newInfraCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "infra",
@@ -81,36 +127,23 @@ func (a *app) newInfraProvisionHetznerCmd() *cobra.Command {
 			if token == "" {
 				return &cliError{Code: exitInput, Message: "missing Hetzner token", Hint: "set --token or HCLOUD_TOKEN"}
 			}
-			name = firstNonEmpty(strings.TrimSpace(name), fmt.Sprintf("rascal-%d", time.Now().UTC().Unix()))
-			serverType = firstNonEmpty(strings.TrimSpace(serverType), "cx23")
-			location = firstNonEmpty(strings.TrimSpace(location), "fsn1")
-			image = firstNonEmpty(strings.TrimSpace(image), "ubuntu-24.04")
-			sshKeyName = firstNonEmpty(strings.TrimSpace(sshKeyName), "rascal")
-			sshPublicPath = firstNonEmpty(strings.TrimSpace(sshPublicPath), "~/.ssh/id_ed25519.pub")
-			firewallName = firstNonEmpty(strings.TrimSpace(firewallName), "rascal-fw")
-			if timeout <= 0 {
-				timeout = 8 * time.Minute
-			}
-
-			publicPath, err := expandPath(sshPublicPath)
-			if err != nil {
-				return &cliError{Code: exitInput, Message: "invalid ssh public key path", Cause: err}
-			}
-
-			ctx, cancel := context.WithTimeout(context.Background(), timeout)
-			defer cancel()
-
-			out, err := provisionHetznerServer(ctx, hcloudProvisionConfig{
+			cfg, timeout, err := resolveHetznerProvisionConfig(hetznerProvisionInput{
 				Token:         token,
-				ServerName:    name,
+				Name:          name,
 				ServerType:    serverType,
 				Location:      location,
 				Image:         image,
 				SSHKeyName:    sshKeyName,
-				SSHPublicPath: publicPath,
+				SSHPublicPath: sshPublicPath,
 				FirewallName:  firewallName,
 				ApplyFirewall: applyFirewall,
+				Timeout:       timeout,
 			})
+			if err != nil {
+				return &cliError{Code: exitInput, Message: "invalid ssh public key path", Cause: err}
+			}
+
+			out, err := runHetznerProvision(cfg, timeout)
 			if err != nil {
 				return &cliError{Code: exitRuntime, Message: "hetzner provisioning failed", Cause: err}
 			}
@@ -189,24 +222,15 @@ rascal infra up --provision --hcloud-token "$HCLOUD_TOKEN" --github-runtime-toke
 				if hcloudToken == "" {
 					return &cliError{Code: exitInput, Message: "missing Hetzner token", Hint: "set --hcloud-token or HCLOUD_TOKEN"}
 				}
-				name = firstNonEmpty(strings.TrimSpace(name), fmt.Sprintf("rascal-%d", time.Now().UTC().Unix()))
-				publicPath, err := expandPath("~/.ssh/id_ed25519.pub")
+				cfg, timeout, err := resolveHetznerProvisionConfig(hetznerProvisionInput{
+					Token:         hcloudToken,
+					Name:          name,
+					ApplyFirewall: true,
+				})
 				if err != nil {
 					return &cliError{Code: exitInput, Message: "invalid default ssh public key path", Cause: err}
 				}
-				ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
-				defer cancel()
-				out, err := provisionHetznerServer(ctx, hcloudProvisionConfig{
-					Token:         hcloudToken,
-					ServerName:    name,
-					ServerType:    "cx23",
-					Location:      "fsn1",
-					Image:         "ubuntu-24.04",
-					SSHKeyName:    "rascal",
-					SSHPublicPath: publicPath,
-					FirewallName:  "rascal-fw",
-					ApplyFirewall: true,
-				})
+				out, err := runHetznerProvision(cfg, timeout)
 				if err != nil {
 					return &cliError{Code: exitRuntime, Message: "hetzner provisioning failed", Cause: err}
 				}
@@ -351,6 +375,7 @@ type deployExistingInput struct {
 	SSHKey             string
 	SSHPort            int
 	GOARCH             string
+	ProvisionedArch    string
 	APIToken           string
 	GitHubRuntimeToken string
 	WebhookSecret      string
@@ -359,19 +384,29 @@ type deployExistingInput struct {
 	RunnerImage        string
 	SkipEnvUpload      bool
 	SkipAuthUpload     bool
+	SkipIfHealthy      bool
+	RawErrors          bool
 }
 
 type deployExistingResult struct {
-	Host      string
-	ServerURL string
-	APIToken  string
+	Host            string
+	ServerURL       string
+	APIToken        string
+	DeployPerformed bool
 }
+
+var (
+	deployToExistingHostFn        = deployToExistingHost
+	runRemoteDoctorFn             = runRemoteDoctor
+	remoteCaddyDomainConfiguredFn = remoteCaddyDomainConfigured
+)
 
 func (a *app) runDeployExisting(input deployExistingInput) (deployExistingResult, error) {
 	host := strings.TrimSpace(input.Host)
 	sshUser := strings.TrimSpace(input.SSHUser)
 	sshKey := strings.TrimSpace(input.SSHKey)
 	goarch := strings.TrimSpace(input.GOARCH)
+	provisionedArch := strings.TrimSpace(input.ProvisionedArch)
 	codexAuthPath := strings.TrimSpace(input.CodexAuthPath)
 	domain := firstNonEmpty(strings.TrimSpace(input.Domain), strings.TrimSpace(a.cfg.Domain))
 	runnerImage := firstNonEmpty(strings.TrimSpace(input.RunnerImage), "rascal-runner:latest")
@@ -426,17 +461,41 @@ func (a *app) runDeployExisting(input deployExistingInput) (deployExistingResult
 
 	resolvedGoarch := goarch
 	if resolvedGoarch == "" {
-		detected, err := detectRemoteGOARCH(deployConfig{
-			Host:       host,
-			SSHUser:    firstNonEmpty(sshUser, "root"),
-			SSHKeyPath: sshKey,
-			SSHPort:    sshPort,
-		})
-		if err != nil {
-			return deployExistingResult{}, &cliError{Code: exitRuntime, Message: "auto-detect goarch failed", Hint: "set --goarch explicitly", Cause: err}
+		switch {
+		case provisionedArch != "":
+			detected, ok := goarchFromHetznerArchitecture(provisionedArch)
+			if ok {
+				resolvedGoarch = detected
+				a.println("detected goarch: %s (hcloud architecture: %s)", resolvedGoarch, provisionedArch)
+				break
+			}
+			detected, err := detectRemoteGOARCH(deployConfig{
+				Host:       host,
+				SSHUser:    firstNonEmpty(sshUser, "root"),
+				SSHKeyPath: sshKey,
+				SSHPort:    sshPort,
+			})
+			if err != nil {
+				return deployExistingResult{}, fmt.Errorf("auto-detect goarch: unable to map Hetzner architecture %q and ssh detection failed: %w", provisionedArch, err)
+			}
+			resolvedGoarch = detected
+			a.println("detected goarch: %s (remote host)", resolvedGoarch)
+		default:
+			detected, err := detectRemoteGOARCH(deployConfig{
+				Host:       host,
+				SSHUser:    firstNonEmpty(sshUser, "root"),
+				SSHKeyPath: sshKey,
+				SSHPort:    sshPort,
+			})
+			if err != nil {
+				if input.RawErrors {
+					return deployExistingResult{}, fmt.Errorf("auto-detect goarch: %w", err)
+				}
+				return deployExistingResult{}, &cliError{Code: exitRuntime, Message: "auto-detect goarch failed", Hint: "set --goarch explicitly", Cause: err}
+			}
+			resolvedGoarch = detected
+			a.println("detected goarch: %s (remote host)", resolvedGoarch)
 		}
-		resolvedGoarch = detected
-		a.println("detected goarch: %s (remote host)", resolvedGoarch)
 	}
 
 	cfg := deployConfig{
@@ -459,8 +518,40 @@ func (a *app) runDeployExisting(input deployExistingInput) (deployExistingResult
 		UploadEnvFile:      !input.SkipEnvUpload,
 		UploadCodexAuth:    !input.SkipAuthUpload,
 	}
-	if err := deployToExistingHost(cfg); err != nil {
-		return deployExistingResult{}, &cliError{Code: exitRuntime, Message: "deploy failed", Cause: err}
+	healthyExisting := false
+	if input.SkipIfHealthy {
+		if st, err := runRemoteDoctorFn(deployConfig{
+			Host:       cfg.Host,
+			SSHUser:    cfg.SSHUser,
+			SSHKeyPath: cfg.SSHKeyPath,
+			SSHPort:    cfg.SSHPort,
+		}); err == nil {
+			caddyOK := st.CaddyInstalled || strings.TrimSpace(domain) == ""
+			if caddyOK && strings.TrimSpace(domain) != "" {
+				configured, err := remoteCaddyDomainConfiguredFn(deployConfig{
+					Host:       cfg.Host,
+					SSHUser:    cfg.SSHUser,
+					SSHKeyPath: cfg.SSHKeyPath,
+					SSHPort:    cfg.SSHPort,
+				}, domain)
+				if err != nil || !configured {
+					caddyOK = false
+				}
+			}
+			healthyExisting = st.RascalService && st.DockerInstalled && st.SQLiteInstalled && caddyOK && st.EnvFilePresent && st.AuthRuntimeSynced && st.CodexAuthPresent && st.RunnerImagePresent
+		}
+	}
+	deployPerformed := false
+	if !healthyExisting {
+		if err := deployToExistingHostFn(cfg); err != nil {
+			if input.RawErrors {
+				return deployExistingResult{}, err
+			}
+			return deployExistingResult{}, &cliError{Code: exitRuntime, Message: "deploy failed", Cause: err}
+		}
+		deployPerformed = true
+	} else if input.SkipIfHealthy {
+		a.println("existing deployment detected on %s; skipping deploy", host)
 	}
 
 	serverURL := firstNonEmpty(strings.TrimSpace(a.cfg.ServerURL), "http://"+host+":8080")
@@ -468,9 +559,10 @@ func (a *app) runDeployExisting(input deployExistingInput) (deployExistingResult
 		serverURL = "https://" + domain
 	}
 	return deployExistingResult{
-		Host:      host,
-		ServerURL: serverURL,
-		APIToken:  apiToken,
+		Host:            host,
+		ServerURL:       serverURL,
+		APIToken:        apiToken,
+		DeployPerformed: deployPerformed,
 	}, nil
 }
 

--- a/cmd/rascal/infra_test.go
+++ b/cmd/rascal/infra_test.go
@@ -51,3 +51,57 @@ func TestNormalizeAuthorizedPublicKey(t *testing.T) {
 		}
 	}
 }
+
+func TestRunDeployExistingSkipsHealthyHost(t *testing.T) {
+	origRunRemoteDoctor := runRemoteDoctorFn
+	origDeploy := deployToExistingHostFn
+	origCaddy := remoteCaddyDomainConfiguredFn
+	t.Cleanup(func() {
+		runRemoteDoctorFn = origRunRemoteDoctor
+		deployToExistingHostFn = origDeploy
+		remoteCaddyDomainConfiguredFn = origCaddy
+	})
+
+	runRemoteDoctorFn = func(cfg deployConfig) (remoteDoctorStatus, error) {
+		return remoteDoctorStatus{
+			Host:               cfg.Host,
+			RascalService:      true,
+			DockerInstalled:    true,
+			SQLiteInstalled:    true,
+			CaddyInstalled:     true,
+			EnvFilePresent:     true,
+			AuthRuntimeSynced:  true,
+			CodexAuthPresent:   true,
+			RunnerImagePresent: true,
+		}, nil
+	}
+	remoteCaddyDomainConfiguredFn = func(cfg deployConfig, domain string) (bool, error) {
+		return true, nil
+	}
+	deployCalled := false
+	deployToExistingHostFn = func(cfg deployConfig) error {
+		deployCalled = true
+		return nil
+	}
+
+	a := &app{}
+	result, err := a.runDeployExisting(deployExistingInput{
+		Host:           "203.0.113.10",
+		SSHPort:        22,
+		GOARCH:         "amd64",
+		Domain:         "rascal.example.com",
+		SkipEnvUpload:  true,
+		SkipAuthUpload: true,
+		SkipIfHealthy:  true,
+		RawErrors:      true,
+	})
+	if err != nil {
+		t.Fatalf("runDeployExisting failed: %v", err)
+	}
+	if deployCalled {
+		t.Fatal("expected deploy to be skipped for healthy host")
+	}
+	if result.DeployPerformed {
+		t.Fatal("expected DeployPerformed=false for healthy host")
+	}
+}

--- a/cmd/rascal/main.go
+++ b/cmd/rascal/main.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pelletier/go-toml/v2"
 	"github.com/rtzll/rascal/internal/config"
 	deployengine "github.com/rtzll/rascal/internal/deploy"
-	ghapi "github.com/rtzll/rascal/internal/github"
 	"github.com/rtzll/rascal/internal/state"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -688,24 +687,14 @@ func (a *app) newBootstrapCmd() *cobra.Command {
 				if hcloudToken == "" {
 					return fmt.Errorf("no host configured: pass --host, configure `host` in config, or set --hcloud-token")
 				}
-				publicKeyPath, err := expandPath("~/.ssh/id_ed25519.pub")
+				cfg, timeout, err := resolveHetznerProvisionConfig(hetznerProvisionInput{
+					Token:         hcloudToken,
+					ApplyFirewall: true,
+				})
 				if err != nil {
 					return fmt.Errorf("expand default ssh public key path: %w", err)
 				}
-				serverName := fmt.Sprintf("rascal-%d", time.Now().UTC().Unix())
-				ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
-				defer cancel()
-				out, err := provisionHetznerServer(ctx, hcloudProvisionConfig{
-					Token:         hcloudToken,
-					ServerName:    serverName,
-					ServerType:    "cx23",
-					Location:      "fsn1",
-					Image:         "ubuntu-24.04",
-					SSHKeyName:    "rascal",
-					SSHPublicPath: publicKeyPath,
-					FirewallName:  "rascal-fw",
-					ApplyFirewall: true,
-				})
+				out, err := runHetznerProvision(cfg, timeout)
 				if err != nil {
 					return fmt.Errorf("hcloud provision: %w", err)
 				}
@@ -730,96 +719,35 @@ func (a *app) newBootstrapCmd() *cobra.Command {
 
 			deployPerformed := false
 			if shouldDeploy {
-				resolvedGoarch := ""
-				switch {
-				case provisionOut != nil:
-					detected, ok := goarchFromHetznerArchitecture(provisionOut.Architecture)
-					if ok {
-						resolvedGoarch = detected
-						a.println("detected goarch: %s (hcloud architecture: %s)", resolvedGoarch, provisionOut.Architecture)
-						break
-					}
-					detected, err := detectRemoteGOARCH(deployConfig{
-						Host:       host,
-						SSHUser:    firstNonEmpty(sshUser, "root"),
-						SSHKeyPath: sshKey,
-						SSHPort:    sshPort,
-					})
-					if err != nil {
-						return fmt.Errorf("auto-detect goarch: unable to map Hetzner architecture %q and ssh detection failed: %w", provisionOut.Architecture, err)
-					}
-					resolvedGoarch = detected
-					a.println("detected goarch: %s (remote host)", resolvedGoarch)
-				default:
-					detected, err := detectRemoteGOARCH(deployConfig{
-						Host:       host,
-						SSHUser:    firstNonEmpty(sshUser, "root"),
-						SSHKeyPath: sshKey,
-						SSHPort:    sshPort,
-					})
-					if err != nil {
-						return fmt.Errorf("auto-detect goarch: %w", err)
-					}
-					resolvedGoarch = detected
-					a.println("detected goarch: %s (remote host)", resolvedGoarch)
-				}
-
-				deployCfg := deployConfig{
+				input := deployExistingInput{
 					Host:               host,
-					SSHUser:            firstNonEmpty(sshUser, "root"),
-					SSHKeyPath:         sshKey,
+					SSHUser:            sshUser,
+					SSHKey:             sshKey,
 					SSHPort:            sshPort,
-					Domain:             domain,
+					ProvisionedArch:    "",
 					APIToken:           apiToken,
-					WebhookSecret:      webhookSecret,
 					GitHubRuntimeToken: githubRuntimeToken,
+					WebhookSecret:      webhookSecret,
 					CodexAuthPath:      expandedAuthPath,
-					RunnerMode:         "docker",
-					RunnerImage:        "rascal-runner:latest",
-					ServerListenAddr:   ":8080",
-					ServerDataDir:      "/var/lib/rascal",
-					ServerStatePath:    "/var/lib/rascal/state.db",
-					ServerCodexAuthDst: "/etc/rascal/codex_auth.json",
-					GOARCH:             resolvedGoarch,
-					UploadEnvFile:      true,
-					UploadCodexAuth:    true,
+					Domain:             domain,
+					SkipEnvUpload:      false,
+					SkipAuthUpload:     false,
+					SkipIfHealthy:      true,
+					RawErrors:          true,
 				}
-				healthyExisting := false
-				if provisionOut == nil {
-					if st, err := runRemoteDoctor(deployConfig{
-						Host:       deployCfg.Host,
-						SSHUser:    deployCfg.SSHUser,
-						SSHKeyPath: deployCfg.SSHKeyPath,
-						SSHPort:    deployCfg.SSHPort,
-					}); err == nil {
-						caddyOK := st.CaddyInstalled || strings.TrimSpace(domain) == ""
-						if caddyOK && strings.TrimSpace(domain) != "" {
-							configured, err := remoteCaddyDomainConfigured(deployConfig{
-								Host:       deployCfg.Host,
-								SSHUser:    deployCfg.SSHUser,
-								SSHKeyPath: deployCfg.SSHKeyPath,
-								SSHPort:    deployCfg.SSHPort,
-							}, domain)
-							if err != nil || !configured {
-								caddyOK = false
-							}
-						}
-						healthyExisting = st.RascalService && st.DockerInstalled && st.SQLiteInstalled && caddyOK && st.EnvFilePresent && st.AuthRuntimeSynced && st.CodexAuthPresent && st.RunnerImagePresent
-					}
+				if provisionOut != nil {
+					input.ProvisionedArch = provisionOut.Architecture
 				}
-				if !healthyExisting {
-					if err := deployToExistingHost(deployCfg); err != nil {
-						return err
-					}
-					deployPerformed = true
-				} else {
-					a.println("existing deployment detected on %s; skipping deploy", host)
+				result, err := a.runDeployExisting(input)
+				if err != nil {
+					return err
 				}
+				deployPerformed = result.DeployPerformed
 				if err := waitForServerHealthSSH(deployConfig{
-					Host:       deployCfg.Host,
-					SSHUser:    deployCfg.SSHUser,
-					SSHKeyPath: deployCfg.SSHKeyPath,
-					SSHPort:    deployCfg.SSHPort,
+					Host:       host,
+					SSHUser:    firstNonEmpty(sshUser, "root"),
+					SSHKeyPath: sshKey,
+					SSHPort:    sshPort,
 				}, 90*time.Second); err != nil {
 					return fmt.Errorf("server health check failed after bootstrap deploy stage: %w", err)
 				}
@@ -843,15 +771,15 @@ func (a *app) newBootstrapCmd() *cobra.Command {
 			serverURL = strings.TrimRight(serverURL, "/")
 
 			if !skipWebhook {
-				gh := ghapi.NewAPIClient(githubAdminToken)
-				ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
-				defer cancel()
-
-				if err := gh.EnsureLabel(ctx, repo, "rascal", "0e8a16", "Trigger Rascal automation"); err != nil {
-					return fmt.Errorf("ensure label: %w", err)
-				}
-				if err := gh.UpsertWebhook(ctx, repo, serverURL+"/v1/webhooks/github", webhookSecret, nil); err != nil {
-					return fmt.Errorf("upsert webhook: %w", err)
+				if _, err := a.runRepoEnable(repoEnableInput{
+					Repo:          repo,
+					GitHubToken:   githubAdminToken,
+					WebhookSecret: webhookSecret,
+					WebhookURL:    serverURL + "/v1/webhooks/github",
+					Timeout:       45 * time.Second,
+					RawErrors:     true,
+				}); err != nil {
+					return err
 				}
 			}
 

--- a/cmd/rascal/repo.go
+++ b/cmd/rascal/repo.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"slices"
 	"strings"
@@ -17,6 +18,68 @@ var requiredWebhookEvents = []string{
 	"pull_request_review",
 	"pull_request_review_comment",
 	"pull_request",
+}
+
+type repoEnableInput struct {
+	Repo          string
+	GitHubToken   string
+	WebhookSecret string
+	WebhookURL    string
+	Timeout       time.Duration
+	Client        repoGitHubClient
+	RawErrors     bool
+}
+
+type repoEnableResult struct {
+	Repo       string
+	WebhookURL string
+}
+
+type repoGitHubClient interface {
+	EnsureLabel(ctx context.Context, repo, name, color, description string) error
+	UpsertWebhook(ctx context.Context, repo, webhookURL, secret string, events []string) error
+}
+
+func (a *app) runRepoEnable(input repoEnableInput) (repoEnableResult, error) {
+	repo := strings.TrimSpace(input.Repo)
+	if repo == "" {
+		return repoEnableResult{}, &cliError{Code: exitInput, Message: "repo is required", Hint: "pass OWNER/REPO or set --default-repo"}
+	}
+	githubToken := firstNonEmpty(strings.TrimSpace(input.GitHubToken), strings.TrimSpace(os.Getenv("GITHUB_TOKEN")))
+	if githubToken == "" {
+		return repoEnableResult{}, &cliError{Code: exitInput, Message: "missing GitHub token", Hint: "set --github-token or GITHUB_TOKEN"}
+	}
+	webhookSecret := strings.TrimSpace(input.WebhookSecret)
+	if webhookSecret == "" {
+		return repoEnableResult{}, &cliError{Code: exitInput, Message: "missing webhook secret", Hint: "pass --webhook-secret (must match server secret)"}
+	}
+	webhookURL := firstNonEmpty(strings.TrimSpace(input.WebhookURL), strings.TrimSpace(a.cfg.ServerURL)+"/v1/webhooks/github")
+	webhookURL = strings.TrimRight(webhookURL, "/")
+	timeout := input.Timeout
+	if timeout <= 0 {
+		timeout = 45 * time.Second
+	}
+
+	client := input.Client
+	if client == nil {
+		client = ghapi.NewAPIClient(githubToken)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	if err := client.EnsureLabel(ctx, repo, "rascal", "0e8a16", "Trigger Rascal automation"); err != nil {
+		if input.RawErrors {
+			return repoEnableResult{}, fmt.Errorf("ensure label: %w", err)
+		}
+		return repoEnableResult{}, &cliError{Code: exitRuntime, Message: "failed to ensure label", Cause: err}
+	}
+	if err := client.UpsertWebhook(ctx, repo, webhookURL, webhookSecret, nil); err != nil {
+		if input.RawErrors {
+			return repoEnableResult{}, fmt.Errorf("upsert webhook: %w", err)
+		}
+		return repoEnableResult{}, &cliError{Code: exitRuntime, Message: "failed to upsert webhook", Cause: err}
+	}
+	return repoEnableResult{Repo: repo, WebhookURL: webhookURL}, nil
 }
 
 func (a *app) newRepoCmd() *cobra.Command {
@@ -51,41 +114,24 @@ func (a *app) newRepoEnableCmd() *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			repo := resolveRepoArg(args, a.cfg.DefaultRepo)
-			if repo == "" {
-				return &cliError{Code: exitInput, Message: "repo is required", Hint: "pass OWNER/REPO or set --default-repo"}
-			}
-			githubToken = firstNonEmpty(strings.TrimSpace(githubToken), strings.TrimSpace(os.Getenv("GITHUB_TOKEN")))
-			if githubToken == "" {
-				return &cliError{Code: exitInput, Message: "missing GitHub token", Hint: "set --github-token or GITHUB_TOKEN"}
-			}
-			webhookSecret = strings.TrimSpace(webhookSecret)
-			if webhookSecret == "" {
-				return &cliError{Code: exitInput, Message: "missing webhook secret", Hint: "pass --webhook-secret (must match server secret)"}
-			}
-			webhookURL = firstNonEmpty(strings.TrimSpace(webhookURL), strings.TrimSpace(a.cfg.ServerURL)+"/v1/webhooks/github")
-			webhookURL = strings.TrimRight(webhookURL, "/")
-			if timeout <= 0 {
-				timeout = 45 * time.Second
-			}
-
-			gh := ghapi.NewAPIClient(githubToken)
-			ctx, cancel := context.WithTimeout(context.Background(), timeout)
-			defer cancel()
-
-			if err := gh.EnsureLabel(ctx, repo, "rascal", "0e8a16", "Trigger Rascal automation"); err != nil {
-				return &cliError{Code: exitRuntime, Message: "failed to ensure label", Cause: err}
-			}
-			if err := gh.UpsertWebhook(ctx, repo, webhookURL, webhookSecret, nil); err != nil {
-				return &cliError{Code: exitRuntime, Message: "failed to upsert webhook", Cause: err}
+			result, err := a.runRepoEnable(repoEnableInput{
+				Repo:          repo,
+				GitHubToken:   githubToken,
+				WebhookSecret: webhookSecret,
+				WebhookURL:    webhookURL,
+				Timeout:       timeout,
+			})
+			if err != nil {
+				return err
 			}
 			return a.emit(map[string]any{
-				"repo":        repo,
+				"repo":        result.Repo,
 				"enabled":     true,
-				"webhook_url": webhookURL,
+				"webhook_url": result.WebhookURL,
 				"label":       "rascal",
 			}, func() error {
-				a.println("repo enabled: %s", repo)
-				a.println("webhook: %s", webhookURL)
+				a.println("repo enabled: %s", result.Repo)
+				a.println("webhook: %s", result.WebhookURL)
 				return nil
 			})
 		},

--- a/cmd/rascal/repo_test.go
+++ b/cmd/rascal/repo_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"context"
 	"reflect"
 	"testing"
+	"time"
+
+	"github.com/rtzll/rascal/internal/config"
 )
 
 func TestMissingRequiredWebhookEvents(t *testing.T) {
@@ -41,4 +45,72 @@ func TestMissingRequiredWebhookEvents(t *testing.T) {
 			t.Fatalf("missing = %v, want %v", got, want)
 		}
 	})
+}
+
+type fakeRepoClient struct {
+	ensureCalled  bool
+	ensureRepo    string
+	ensureName    string
+	ensureColor   string
+	ensureDesc    string
+	webhookCalled bool
+	webhookRepo   string
+	webhookURL    string
+	webhookSecret string
+	webhookEvents []string
+}
+
+func (f *fakeRepoClient) EnsureLabel(_ context.Context, repo, name, color, description string) error {
+	f.ensureCalled = true
+	f.ensureRepo = repo
+	f.ensureName = name
+	f.ensureColor = color
+	f.ensureDesc = description
+	return nil
+}
+
+func (f *fakeRepoClient) UpsertWebhook(_ context.Context, repo, webhookURL, secret string, events []string) error {
+	f.webhookCalled = true
+	f.webhookRepo = repo
+	f.webhookURL = webhookURL
+	f.webhookSecret = secret
+	f.webhookEvents = events
+	return nil
+}
+
+func TestRunRepoEnableUsesProvidedClient(t *testing.T) {
+	client := &fakeRepoClient{}
+	a := &app{
+		cfg: config.ClientConfig{
+			ServerURL: "http://example.com",
+		},
+	}
+	result, err := a.runRepoEnable(repoEnableInput{
+		Repo:          "owner/repo",
+		GitHubToken:   "token",
+		WebhookSecret: "secret",
+		Client:        client,
+		Timeout:       5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("runRepoEnable failed: %v", err)
+	}
+	if !client.ensureCalled || !client.webhookCalled {
+		t.Fatalf("expected ensure label and webhook calls, got ensure=%t webhook=%t", client.ensureCalled, client.webhookCalled)
+	}
+	if client.ensureRepo != "owner/repo" || client.ensureName != "rascal" || client.ensureColor != "0e8a16" {
+		t.Fatalf("unexpected ensure label args: repo=%s name=%s color=%s", client.ensureRepo, client.ensureName, client.ensureColor)
+	}
+	if client.ensureDesc != "Trigger Rascal automation" {
+		t.Fatalf("unexpected ensure label description: %s", client.ensureDesc)
+	}
+	if client.webhookURL != "http://example.com/v1/webhooks/github" {
+		t.Fatalf("unexpected webhook url: %s", client.webhookURL)
+	}
+	if client.webhookSecret != "secret" {
+		t.Fatalf("unexpected webhook secret: %s", client.webhookSecret)
+	}
+	if result.WebhookURL != "http://example.com/v1/webhooks/github" {
+		t.Fatalf("unexpected result webhook url: %s", result.WebhookURL)
+	}
 }


### PR DESCRIPTION
- route bootstrap deploy path through shared deploy helper with health-skip logic
- reuse shared Hetzner provisioning and repo enable helpers
- add tests for deploy skip and repo enable helper behavior

Automated changes from Rascal run run_24b6d2e6cec2c918.

<details><summary>Run Details</summary>

```

    __( O)>  ● new session · codex gpt-5.2-codex
   \____)    20260303_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: "/usr/bin/codex"
Model: gpt-5.2-codex
Reasoning effort: high
Skip git check: false
Prompt length: 1841 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Response Guidelines

Use Markdown formatting for all responses.

Human: <info-msg>
It is currently 2026-03-03 10:50:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

</info-msg>
# Rascal Run Instructions

Run ID: run_24b6d2e6cec2c918
Task ID: rtzll/rascal#55
Repository: rtzll/rascal
Issue: #55

## Task

refactor(cli): make bootstrap a thin wrapper over shared setup helpers

## Problem
`rascal bootstrap` still contains duplicated orchestration logic instead of delegating to focused shared helpers (`infra`/`github` setup paths).

## Goal
Make `bootstrap` a thin orchestration wrapper over shared setup components.

## Scope
- Refactor bootstrap internals to call shared helper functions used by focused commands.
- Remove duplicated deploy/provision/webhook setup logic where possible.
- Preserve current bootstrap UX and output contract.

## Acceptance Criteria
- Bootstrap behavior remains functionally equivalent for existing inputs.
- Internal duplication between bootstrap and focused commands is reduced.
- Unit tests cover the refactored orchestration path.
- `go test ./...` passes.

## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run tests or explain why tests could not run.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label 'rascal' on issue #55


Assistant: 
Image files: 0
============================
{"type":"message","message":{"id":null,"role":"assistant","created":1772536256,"content":[{"type":"text","text":"**Summary**\n- Refactored bootstrap to use shared Hetzner provisioning, deploy, and repo enable helpers while keeping the same UX/error behavior, with bootstrap still performing its post-deploy health check. (`cmd/rascal/main.go`)\n- Added shared Hetzner provisioning helpers and extended deploy helper to support provisioned architecture, skip-when-healthy, and raw error modes for bootstrap. (`cmd/rascal/infra.go`)\n- Centralized GitHub repo setup logic into a reusable helper and updated the repo enable command to use it. (`cmd/rascal/repo.go`)\n- Added unit coverage for the deploy skip path and repo enable helper. (`cmd/rascal/infra_test.go`, `cmd/rascal/repo_test.go`)\n\n**Tests**\n1. `go test ./...`"}],"metadata":{"userVisible":true,"agentVisible":true}}}
{"type":"complete","total_tokens":6921683}
```

</details>

Closes #55

---

Rascal run took 20m 19s