### PR TITLE
feat(webhooks): handle issue reopen/close lifecycle

### DIFF
--- a/cmd/rascald/main.go
+++ b/cmd/rascald/main.go
@@ -482,30 +482,82 @@ func (s *server) processWebhookEvent(ctx context.Context, eventType string, payl
 		if err := json.Unmarshal(payload, &ev); err != nil {
 			return fmt.Errorf("decode issues event: %w", err)
 		}
-		if ev.Action != "labeled" || !strings.EqualFold(ev.Label.Name, "rascal") {
-			return nil
-		}
 		if ev.Issue.PullRequest != nil {
 			return nil
 		}
 		if s.isBotActor(ev.Sender.Login) {
 			return nil
 		}
-
-		taskID := fmt.Sprintf("%s#%d", ev.Repository.FullName, ev.Issue.Number)
-		_, err := s.createAndQueueRun(runRequest{
-			TaskID:      taskID,
-			Repo:        ev.Repository.FullName,
-			Task:        issueTaskFromIssue(ev.Issue.Title, ev.Issue.Body),
-			Trigger:     "issue_label",
-			IssueNumber: ev.Issue.Number,
-			Context:     fmt.Sprintf("Triggered by label 'rascal' on issue #%d", ev.Issue.Number),
-			Debug:       boolPtr(true),
-		})
-		if errors.Is(err, errTaskCompleted) {
+		switch ev.Action {
+		case "labeled":
+			if !strings.EqualFold(ev.Label.Name, "rascal") {
+				return nil
+			}
+			taskID := fmt.Sprintf("%s#%d", ev.Repository.FullName, ev.Issue.Number)
+			_, err := s.createAndQueueRun(runRequest{
+				TaskID:      taskID,
+				Repo:        ev.Repository.FullName,
+				Task:        issueTaskFromIssue(ev.Issue.Title, ev.Issue.Body),
+				Trigger:     "issue_label",
+				IssueNumber: ev.Issue.Number,
+				Context:     fmt.Sprintf("Triggered by label 'rascal' on issue #%d", ev.Issue.Number),
+				Debug:       boolPtr(true),
+			})
+			if errors.Is(err, errTaskCompleted) {
+				return nil
+			}
+			return err
+		case "closed":
+			if !issueHasLabel(ev.Issue.Labels, "rascal") {
+				return nil
+			}
+			taskID := fmt.Sprintf("%s#%d", ev.Repository.FullName, ev.Issue.Number)
+			if _, err := s.store.UpsertTask(state.UpsertTaskInput{
+				ID:          taskID,
+				Repo:        ev.Repository.FullName,
+				IssueNumber: ev.Issue.Number,
+			}); err != nil {
+				return err
+			}
+			if err := s.store.MarkTaskCompleted(taskID); err != nil {
+				return err
+			}
+			if err := s.store.CancelQueuedRuns(taskID, "issue closed"); err != nil {
+				return err
+			}
+			s.cancelRunningTaskRuns(taskID, "issue closed")
+			return nil
+		case "reopened":
+			if !issueHasLabel(ev.Issue.Labels, "rascal") {
+				return nil
+			}
+			taskID := fmt.Sprintf("%s#%d", ev.Repository.FullName, ev.Issue.Number)
+			if _, err := s.store.UpsertTask(state.UpsertTaskInput{
+				ID:          taskID,
+				Repo:        ev.Repository.FullName,
+				IssueNumber: ev.Issue.Number,
+			}); err != nil {
+				return err
+			}
+			if err := s.store.MarkTaskOpen(taskID); err != nil {
+				return err
+			}
+			_, err := s.createAndQueueRun(runRequest{
+				TaskID:      taskID,
+				Repo:        ev.Repository.FullName,
+				Task:        issueTaskFromIssue(ev.Issue.Title, ev.Issue.Body),
+				Trigger:     "issue_reopened",
+				IssueNumber: ev.Issue.Number,
+				Context:     fmt.Sprintf("Triggered by issue reopen on issue #%d", ev.Issue.Number),
+				Debug:       boolPtr(true),
+			})
+			if errors.Is(err, errTaskCompleted) {
+				return nil
+			}
+			return err
+		default:
 			return nil
 		}
-		return err
 	case "issue_comment":
 		var ev ghapi.IssueCommentEvent
 		if err := json.Unmarshal(payload, &ev); err != nil {
@@ -1305,6 +1357,19 @@ func (s *server) defaultHeadBranchForTask(taskID string) string {
 	return ""
 }
 
+func issueHasLabel(labels []ghapi.Label, name string) bool {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return false
+	}
+	for _, label := range labels {
+		if strings.EqualFold(strings.TrimSpace(label.Name), name) {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *server) isBotActor(login string) bool {
 	login = strings.TrimSpace(strings.ToLower(login))
 	if login == "" {
@@ -1524,6 +1589,32 @@ func (s *server) waitForNoActiveRuns(timeout time.Duration) error {
 
 func (s *server) activeRunCount() int {
 	return s.store.CountRunLeasesByOwner(s.instanceID)
+}
+
+func (s *server) cancelRunningTaskRuns(taskID, reason string) {
+	taskID = strings.TrimSpace(taskID)
+	if taskID == "" {
+		return
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "canceled"
+	}
+	for _, run := range s.store.ListRunningRuns() {
+		if run.TaskID != taskID {
+			continue
+		}
+		if err := s.store.RequestRunCancel(run.ID, reason, "issue"); err != nil {
+			log.Printf("failed to request run cancel for %s: %v", run.ID, err)
+			continue
+		}
+		s.mu.Lock()
+		if cancel, ok := s.runCancels[run.ID]; ok {
+			s.runCancelNote[run.ID] = reason
+			cancel()
+		}
+		s.mu.Unlock()
+	}
 }
 
 func (s *server) cancelActiveRuns(reason string) {

--- a/cmd/rascald/main_test.go
+++ b/cmd/rascald/main_test.go
@@ -273,6 +273,68 @@ func TestHandleWebhookIgnoresIssueLabeledOnPR(t *testing.T) {
 	}
 }
 
+func TestHandleWebhookIssueClosedCancelsRunsAndCompletesTask(t *testing.T) {
+	waitCh := make(chan struct{})
+	launcher := &fakeLauncher{waitCh: waitCh}
+	s := newTestServer(t, launcher)
+	defer waitForServerIdle(t, s)
+	taskID := "owner/repo#7"
+
+	runningRun, err := s.createAndQueueRun(runRequest{TaskID: taskID, Repo: "owner/repo", Task: "work", IssueNumber: 7})
+	if err != nil {
+		t.Fatalf("create running run: %v", err)
+	}
+	queuedRun, err := s.createAndQueueRun(runRequest{TaskID: taskID, Repo: "owner/repo", Task: "queued", IssueNumber: 7})
+	if err != nil {
+		t.Fatalf("create queued run: %v", err)
+	}
+	waitFor(t, time.Second, func() bool { return launcher.Calls() == 1 }, "first run to be active")
+
+	payload := []byte(`{"action":"closed","issue":{"number":7,"title":"Title","body":"Body","labels":[{"name":"rascal"}]},"repository":{"full_name":"owner/repo"},"sender":{"login":"dev"}}`)
+	req := webhookRequest(t, payload, "issues", "delivery-closed", "")
+	rec := httptest.NewRecorder()
+	s.handleWebhook(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202 for closed issue event, got %d", rec.Code)
+	}
+
+	waitFor(t, time.Second, func() bool { return s.store.IsTaskCompleted(taskID) }, "task marked completed")
+	waitFor(t, time.Second, func() bool {
+		r, ok := s.store.GetRun(queuedRun.ID)
+		return ok && r.Status == state.StatusCanceled
+	}, "queued run canceled")
+	waitFor(t, time.Second, func() bool {
+		r, ok := s.store.GetRun(runningRun.ID)
+		return ok && r.Status == state.StatusCanceled
+	}, "running run canceled")
+
+	close(waitCh)
+}
+
+func TestHandleWebhookIssueReopenedReenablesTask(t *testing.T) {
+	s := newTestServer(t, &fakeLauncher{})
+	defer waitForServerIdle(t, s)
+	taskID := "owner/repo#7"
+
+	if _, err := s.store.UpsertTask(state.UpsertTaskInput{ID: taskID, Repo: "owner/repo", IssueNumber: 7}); err != nil {
+		t.Fatalf("upsert task: %v", err)
+	}
+	if err := s.store.MarkTaskCompleted(taskID); err != nil {
+		t.Fatalf("mark task completed: %v", err)
+	}
+
+	payload := []byte(`{"action":"reopened","issue":{"number":7,"title":"Title","body":"Body","labels":[{"name":"rascal"}]},"repository":{"full_name":"owner/repo"},"sender":{"login":"dev"}}`)
+	req := webhookRequest(t, payload, "issues", "delivery-reopened", "")
+	rec := httptest.NewRecorder()
+	s.handleWebhook(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202 for reopened issue event, got %d", rec.Code)
+	}
+
+	waitFor(t, time.Second, func() bool { return !s.store.IsTaskCompleted(taskID) }, "task reopened")
+	waitFor(t, time.Second, func() bool { return len(s.store.ListRuns(10)) == 1 }, "run queued")
+}
+
 func TestHandleWebhookInactiveSlotIsSkipped(t *testing.T) {
 	s := newTestServer(t, &fakeLauncher{})
 	defer waitForServerIdle(t, s)

--- a/internal/github/events.go
+++ b/internal/github/events.go
@@ -16,6 +16,7 @@ type Issue struct {
 	Number      int         `json:"number"`
 	Title       string      `json:"title"`
 	Body        string      `json:"body"`
+	Labels      []Label     `json:"labels"`
 	PullRequest interface{} `json:"pull_request"`
 }
 

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -185,6 +185,25 @@ func (s *Store) MarkTaskCompleted(taskID string) error {
 	return nil
 }
 
+func (s *Store) MarkTaskOpen(taskID string) error {
+	taskID = strings.TrimSpace(taskID)
+	if taskID == "" {
+		return fmt.Errorf("task id is required")
+	}
+	res, err := s.db.ExecContext(context.Background(), "UPDATE tasks SET status = 'open', updated_at = ? WHERE id = ?", time.Now().UTC().UnixNano(), taskID)
+	if err != nil {
+		return err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return fmt.Errorf("task %q not found", taskID)
+	}
+	return nil
+}
+
 func (s *Store) IsTaskCompleted(taskID string) bool {
 	ok, err := s.q.IsTaskCompleted(context.Background(), strings.TrimSpace(taskID))
 	if err != nil {


### PR DESCRIPTION
<details><summary>Goose Details</summary>

```

    __( O)>  ● new session · codex gpt-5.2-codex
   \____)    20260304_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: "/usr/local/bin/codex"
Model: gpt-5.2-codex
Reasoning effort: high
Skip git check: false
Prompt length: 1474 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Response Guidelines

Use Markdown formatting for all responses.

Human: <info-msg>
It is currently 2026-03-04 20:51:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

</info-msg>
# Rascal Run Instructions

Run ID: run_6fba4a607eb1c1ec
Task ID: rtzll/rascal#49
Repository: rtzll/rascal
Issue: #49

## Task

feat(webhooks): react to issues reopened/closed for lifecycle-aware automation

Why:
- Reopen/close should map to resume/stop behavior for issue-based tasks.

Benefit:
- Avoids agent work on closed issues and resumes automatically on reopen.

Scope:
- Handle `issues` actions `reopened`, `closed` for rascal-labeled issues.
- Cancel queued/running work on close; re-enable on reopen.
- Add tests for lifecycle transitions.

## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run tests or explain why tests could not run.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label 'rascal' on issue #49


Assistant: 
Image files: 0
============================
{"type":"message","message":{"id":null,"role":"assistant","created":1772658214,"content":[{"type":"text","text":"**Summary**\n- Add issue `closed`/`reopened` handling for rascal-labeled issues, canceling queued/running work on close and re-queuing on reopen, with label detection and task-run cancel helper. `cmd/rascald/main.go:478` `cmd/rascald/main.go:1360` `cmd/rascald/main.go:1594`\n- Capture issue labels in webhook events and add task reopening support in the store. `internal/github/events.go:15` `internal/state/store.go:170`\n- Add lifecycle transition tests for closed/reopened issues. `cmd/rascald/main_test.go:276`\n\n**Tests**\n- `go test ./cmd/rascald -run TestHandleWebhookIssue`\n\n**Notes**\n- Commit message prepared in `/rascal-meta/commit_message.txt:1`.\n\n**Next Steps**\n1. Run `go test ./...`"}],"metadata":{"userVisible":true,"agentVisible":true}}}
{"type":"complete","total_tokens":5470139}

```

</details>

Closes #49

---

Rascal run `run_6fba4a607eb1c1ec` took 12m 29s [consumed 5470139 tokens]