### PR TITLE
feat(webhooks): handle edited rascal issues

### DIFF
--- a/cmd/rascald/main.go
+++ b/cmd/rascald/main.go
@@ -521,6 +521,27 @@ func (s *server) processWebhookEvent(ctx context.Context, eventType string, payl
 				return nil
 			}
 			return err
+		case "edited":
+			if !issueHasLabel(ev.Issue.Labels, "rascal") {
+				return nil
+			}
+			taskID := fmt.Sprintf("%s#%d", ev.Repository.FullName, ev.Issue.Number)
+			if err := s.store.CancelQueuedRuns(taskID, "issue edited"); err != nil {
+				return err
+			}
+			_, err := s.createAndQueueRun(runRequest{
+				TaskID:      taskID,
+				Repo:        ev.Repository.FullName,
+				Task:        issueTaskFromIssue(ev.Issue.Title, ev.Issue.Body),
+				Trigger:     "issue_edited",
+				IssueNumber: ev.Issue.Number,
+				Context:     fmt.Sprintf("Triggered by issue edit on issue #%d", ev.Issue.Number),
+				Debug:       boolPtr(true),
+			})
+			if errors.Is(err, errTaskCompleted) {
+				return nil
+			}
+			return err
 		case "closed":
 			if !issueHasLabel(ev.Issue.Labels, "rascal") {
 				return nil

--- a/cmd/rascald/main_test.go
+++ b/cmd/rascald/main_test.go
@@ -335,6 +335,60 @@ func TestHandleWebhookIssueReopenedReenablesTask(t *testing.T) {
 	waitFor(t, time.Second, func() bool { return len(s.store.ListRuns(10)) == 1 }, "run queued")
 }
 
+func TestHandleWebhookIssueEditedRequeuesRuns(t *testing.T) {
+	waitCh := make(chan struct{})
+	launcher := &fakeLauncher{waitCh: waitCh}
+	s := newTestServer(t, launcher)
+	defer waitForServerIdle(t, s)
+	defer close(waitCh)
+	taskID := "owner/repo#7"
+
+	runningRun, err := s.createAndQueueRun(runRequest{TaskID: taskID, Repo: "owner/repo", Task: "work", IssueNumber: 7})
+	if err != nil {
+		t.Fatalf("create running run: %v", err)
+	}
+	queuedRun, err := s.createAndQueueRun(runRequest{TaskID: taskID, Repo: "owner/repo", Task: "stale", IssueNumber: 7})
+	if err != nil {
+		t.Fatalf("create queued run: %v", err)
+	}
+	waitFor(t, time.Second, func() bool { return launcher.Calls() == 1 }, "first run to be active")
+
+	payload := []byte(`{"action":"edited","issue":{"number":7,"title":"New Title","body":"New Body","labels":[{"name":"rascal"}]},"repository":{"full_name":"owner/repo"},"sender":{"login":"dev"}}`)
+	req := webhookRequest(t, payload, "issues", "delivery-edited", "")
+	rec := httptest.NewRecorder()
+	s.handleWebhook(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202 for edited issue event, got %d", rec.Code)
+	}
+
+	waitFor(t, time.Second, func() bool {
+		r, ok := s.store.GetRun(queuedRun.ID)
+		return ok && r.Status == state.StatusCanceled
+	}, "queued run canceled")
+
+	var editedRun state.Run
+	waitFor(t, time.Second, func() bool {
+		for _, run := range s.store.ListRuns(20) {
+			if run.Trigger == "issue_edited" {
+				editedRun = run
+				return true
+			}
+		}
+		return false
+	}, "issue edited run queued")
+
+	if editedRun.Task != "New Title\n\nNew Body" {
+		t.Fatalf("expected updated task text, got %q", editedRun.Task)
+	}
+	if editedRun.TaskID != taskID {
+		t.Fatalf("expected edited run task id %q, got %q", taskID, editedRun.TaskID)
+	}
+	if editedRun.ID == runningRun.ID || editedRun.ID == queuedRun.ID {
+		t.Fatalf("expected new run for edit, got existing run id %q", editedRun.ID)
+	}
+
+}
+
 func TestHandleListRunsSupportsAllQuery(t *testing.T) {
 	s := newTestServer(t, &fakeLauncher{})
 	for i := 1; i <= 3; i++ {


### PR DESCRIPTION
- requeue runs when rascal-labeled issues are edited
- add webhook test coverage for edited payloads

<details><summary>Goose Details</summary>

```

    __( O)>  ● new session · codex gpt-5.2-codex
   \____)    20260304_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: "/usr/local/bin/codex"
Model: gpt-5.2-codex
Reasoning effort: high
Skip git check: false
Prompt length: 1462 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Response Guidelines

Use Markdown formatting for all responses.

Human: <info-msg>
It is currently 2026-03-04 21:25:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

</info-msg>
# Rascal Run Instructions

Run ID: run_0411382b3f0fcfc6
Task ID: rtzll/rascal#48
Repository: rtzll/rascal
Issue: #48

## Task

feat(webhooks): handle issues edited for labeled rascal issues

Why:
- Issue titles/bodies can change materially after labeling.

Benefit:
- Keeps issue-driven runs aligned with current scope/acceptance criteria.

Scope:
- Handle `issues` action `edited` when label/state indicates rascal-managed work.
- Decide update policy (requeue, append context, or comment-only).
- Add tests for edited payload behavior.

## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run tests or explain why tests could not run.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label 'rascal' on issue #48


Assistant: 
Image files: 0
============================
{"type":"message","message":{"id":null,"role":"assistant","created":1772660010,"content":[{"type":"text","text":"**Summary**\n- Handled `issues` `edited` events by canceling queued runs for rascal-labeled issues and queueing a fresh run with updated title/body and context in `cmd/rascald/main.go`.\n- Added webhook test coverage for edited issues requeue behavior and updated task text in `cmd/rascald/main_test.go`.\n- Wrote commit message to `/rascal-meta/commit_message.txt`.\n\n**Tests**\n- `go test ./cmd/rascald -run TestHandleWebhookIssueEditedRequeuesRuns`"}],"metadata":{"userVisible":true,"agentVisible":true}}}
{"type":"complete","total_tokens":3371796}

```

</details>

Closes #48

---

Rascal run `run_0411382b3f0fcfc6` took 8m 21s [consumed 3371796 tokens]