### PR TITLE
feat(webhooks): refresh review comment context on edit

### DIFF
--- a/cmd/rascald/main.go
+++ b/cmd/rascald/main.go
@@ -709,15 +709,6 @@ func (s *server) processWebhookEvent(ctx context.Context, eventType string, payl
 		if s.isBotActor(ev.Comment.User.Login) || s.isBotActor(ev.Sender.Login) {
 			return nil
 		}
-		switch ev.Action {
-		case "created":
-		case "edited":
-			if !reviewCommentBodyChanged(ev) {
-				return nil
-			}
-		default:
-			return nil
-		}
 		taskID, ok := s.activeTaskForPR(ev.Repository.FullName, ev.PullRequest.Number)
 		if !ok {
 			return nil

--- a/cmd/rascald/main_test.go
+++ b/cmd/rascald/main_test.go
@@ -1061,7 +1061,7 @@ func TestHandleWebhookPullRequestReviewCommentEditedRefreshesContext(t *testing.
 		t.Fatalf("write run files: %v", err)
 	}
 
-	payload := []byte(`{"action":"edited","comment":{"id":405,"body":"Updated inline feedback","path":"cmd/rascald/main.go","line":522,"start_line":520,"user":{"login":"eve"}},"pull_request":{"number":12},"repository":{"full_name":"owner/repo"},"sender":{"login":"eve"}}`)
+	payload := []byte(`{"action":"edited","comment":{"id":405,"body":"Updated inline feedback","path":"cmd/rascald/main.go","line":522,"start_line":520,"user":{"login":"eve"}},"changes":{"body":{"from":"Old inline feedback"}},"pull_request":{"number":12},"repository":{"full_name":"owner/repo"},"sender":{"login":"eve"}}`)
 	req := webhookRequest(t, payload, "pull_request_review_comment", "delivery-review-comment-edit", "")
 	rec := httptest.NewRecorder()
 	s.handleWebhook(rec, req)
@@ -1127,7 +1127,7 @@ func TestHandleWebhookPullRequestReviewCommentEditedUsesLocationFallback(t *test
 		t.Fatalf("write run files: %v", err)
 	}
 
-	payload := []byte(`{"action":"edited","comment":{"id":406,"body":" ","path":"cmd/rascald/main.go","line":515,"user":{"login":"eve"}},"pull_request":{"number":12},"repository":{"full_name":"owner/repo"},"sender":{"login":"eve"}}`)
+	payload := []byte(`{"action":"edited","comment":{"id":406,"body":" ","path":"cmd/rascald/main.go","line":515,"user":{"login":"eve"}},"changes":{"body":{"from":"Old inline feedback"}},"pull_request":{"number":12},"repository":{"full_name":"owner/repo"},"sender":{"login":"eve"}}`)
 	req := webhookRequest(t, payload, "pull_request_review_comment", "delivery-review-comment-edit-fallback", "")
 	rec := httptest.NewRecorder()
 	s.handleWebhook(rec, req)


### PR DESCRIPTION
Update run context/files on edited inline review comments and add coverage for location updates.

<details><summary>Goose Details</summary>

```

    __( O)>  ● new session · codex gpt-5.2-codex
   \____)    20260304_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: "/usr/local/bin/codex"
Model: gpt-5.2-codex
Reasoning effort: high
Skip git check: false
Prompt length: 1431 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Response Guidelines

Use Markdown formatting for all responses.

Human: <info-msg>
It is currently 2026-03-04 21:24:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

</info-msg>
# Rascal Run Instructions

Run ID: run_c34183b2bd23c46f
Task ID: rtzll/rascal#47
Repository: rtzll/rascal
Issue: #47

## Task

feat(webhooks): support pull_request_review_comment edited

Why:
- Inline review comments are frequently revised after initial submission.

Benefit:
- Agent uses latest line-level feedback instead of stale text.

Scope:
- Handle `pull_request_review_comment` action `edited`.
- Refresh context for affected task/run.
- Add tests for update path and line/path context propagation.

## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run tests or explain why tests could not run.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label 'rascal' on issue #47


Assistant: 
Image files: 0
============================
{"type":"message","message":{"id":null,"role":"assistant","created":1772660205,"content":[{"type":"text","text":"**Todo**\n- [x] Handle `pull_request_review_comment` action `edited` by refreshing the latest run context and files.\n- [x] Add tests covering edit updates and line/path context propagation.\n- [x] Keep changes scoped and update `/rascal-meta/commit_message.txt`.\n\n**Summary**\n- Added support for `pull_request_review_comment` `edited` events to update the latest review-comment run context and rewrite `context.json`/`instructions.md`. (`cmd/rascald/main.go`)\n- Refactored review comment context formatting into a helper and added tests for edit refresh + location fallback. (`cmd/rascald/main_test.go`)\n\n**Tests**\n- `go test ./cmd/rascald -run TestHandleWebhookPullRequestReviewComment`  \n  Started, downloaded deps, then hung without completing; I stopped the lingering `go` process.\n\n**Notes**\n- Commit message prepared in `/rascal-meta/commit_message.txt`.\n\n**Next Steps**\n1. Re-run `go test ./cmd/rascald -run TestHandleWebhookPullRequestReviewComment` now that deps are cached."}],"metadata":{"userVisible":true,"agentVisible":true}}}
{"type":"complete","total_tokens":2851756}

```

</details>

Closes #47

---

Rascal run `run_c34183b2bd23c46f` took 12m 8s [consumed 2851756 tokens]