### PR TITLE
feat(webhooks): handle edited PR issue comments

### DIFF
--- a/cmd/rascald/main.go
+++ b/cmd/rascald/main.go
@@ -577,7 +577,16 @@ func (s *server) processWebhookEvent(ctx context.Context, eventType string, payl
 		if err := json.Unmarshal(payload, &ev); err != nil {
 			return fmt.Errorf("decode issue_comment event: %w", err)
 		}
-		if ev.Action != "created" || ev.Issue.PullRequest == nil {
+		if ev.Issue.PullRequest == nil {
+			return nil
+		}
+		switch ev.Action {
+		case "created":
+		case "edited":
+			if !issueCommentBodyChanged(ev) {
+				return nil
+			}
+		default:
 			return nil
 		}
 		if s.isBotActor(ev.Comment.User.Login) || s.isBotActor(ev.Sender.Login) {
@@ -1385,6 +1394,15 @@ func issueHasLabel(labels []ghapi.Label, name string) bool {
 		}
 	}
 	return false
+}
+
+func issueCommentBodyChanged(ev ghapi.IssueCommentEvent) bool {
+	if ev.Changes.Body == nil {
+		return false
+	}
+	newBody := strings.TrimSpace(ev.Comment.Body)
+	oldBody := strings.TrimSpace(ev.Changes.Body.From)
+	return newBody != oldBody
 }
 
 func (s *server) isBotActor(login string) bool {

--- a/cmd/rascald/main_test.go
+++ b/cmd/rascald/main_test.go
@@ -537,6 +537,94 @@ func TestHandleWebhookIssueCommentUsesExistingPRTaskAndLastBranches(t *testing.T
 	}
 }
 
+func TestHandleWebhookIssueCommentEditedUsesUpdatedContext(t *testing.T) {
+	s := newTestServer(t, &fakeLauncher{})
+	defer waitForServerIdle(t, s)
+
+	const (
+		repo    = "owner/repo"
+		taskID  = "owner/repo#17"
+		prNum   = 17
+		baseRef = "main"
+		headRef = "rascal/pr-17"
+	)
+	if _, err := s.store.UpsertTask(state.UpsertTaskInput{ID: taskID, Repo: repo, PRNumber: prNum}); err != nil {
+		t.Fatalf("upsert task: %v", err)
+	}
+	seedRun, err := s.store.AddRun(state.CreateRunInput{
+		ID:         "seed_run_edited",
+		TaskID:     taskID,
+		Repo:       repo,
+		Task:       "seed",
+		BaseBranch: baseRef,
+		HeadBranch: headRef,
+		Trigger:    "seed",
+		RunDir:     filepath.Join(t.TempDir(), "seed_run_edited"),
+		PRNumber:   prNum,
+	})
+	if err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := s.store.SetRunStatus(seedRun.ID, state.StatusSucceeded, ""); err != nil {
+		t.Fatalf("mark seed run succeeded: %v", err)
+	}
+
+	payload := []byte(`{"action":"edited","issue":{"number":17,"pull_request":{}},"comment":{"id":202,"body":"  updated feedback  ","user":{"login":"alice"}},"changes":{"body":{"from":"prior feedback"}},"repository":{"full_name":"owner/repo"},"sender":{"login":"alice"}}`)
+	req := webhookRequest(t, payload, "issue_comment", "delivery-comment-edited", "")
+	rec := httptest.NewRecorder()
+	s.handleWebhook(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", rec.Code)
+	}
+
+	var got state.Run
+	waitFor(t, time.Second, func() bool {
+		runs := s.store.ListRuns(20)
+		for _, run := range runs {
+			if run.Trigger == "pr_comment" {
+				got = run
+				return true
+			}
+		}
+		return false
+	}, "pr_comment run created")
+
+	if got.TaskID != taskID {
+		t.Fatalf("task id = %q, want %q", got.TaskID, taskID)
+	}
+	if got.PRNumber != prNum {
+		t.Fatalf("pr number = %d, want %d", got.PRNumber, prNum)
+	}
+	if got.BaseBranch != baseRef {
+		t.Fatalf("base branch = %q, want %q", got.BaseBranch, baseRef)
+	}
+	if got.HeadBranch != headRef {
+		t.Fatalf("head branch = %q, want %q", got.HeadBranch, headRef)
+	}
+	if got.Context != "updated feedback" {
+		t.Fatalf("context = %q, want trimmed updated comment body", got.Context)
+	}
+}
+
+func TestHandleWebhookIssueCommentEditedSkipsUnchangedBody(t *testing.T) {
+	s := newTestServer(t, &fakeLauncher{})
+	defer waitForServerIdle(t, s)
+
+	payload := []byte(`{"action":"edited","issue":{"number":9,"pull_request":{}},"comment":{"id":303,"body":"  same feedback  ","user":{"login":"alice"}},"changes":{"body":{"from":"same feedback"}},"repository":{"full_name":"owner/repo"},"sender":{"login":"alice"}}`)
+	req := webhookRequest(t, payload, "issue_comment", "delivery-comment-nochange", "")
+	rec := httptest.NewRecorder()
+	s.handleWebhook(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", rec.Code)
+	}
+
+	for _, run := range s.store.ListRuns(10) {
+		if run.Trigger == "pr_comment" {
+			t.Fatalf("expected no pr_comment run for unchanged edit")
+		}
+	}
+}
+
 func TestHandleWebhookPullRequestReviewUsesStateFallbackContext(t *testing.T) {
 	s := newTestServer(t, &fakeLauncher{})
 	defer waitForServerIdle(t, s)

--- a/internal/github/events.go
+++ b/internal/github/events.go
@@ -62,11 +62,20 @@ type IssuesEvent struct {
 }
 
 type IssueCommentEvent struct {
-	Action     string     `json:"action"`
-	Issue      Issue      `json:"issue"`
-	Comment    Comment    `json:"comment"`
-	Repository Repository `json:"repository"`
-	Sender     User       `json:"sender"`
+	Action     string              `json:"action"`
+	Issue      Issue               `json:"issue"`
+	Comment    Comment             `json:"comment"`
+	Changes    IssueCommentChanges `json:"changes"`
+	Repository Repository          `json:"repository"`
+	Sender     User                `json:"sender"`
+}
+
+type IssueCommentChanges struct {
+	Body *IssueCommentBodyChange `json:"body"`
+}
+
+type IssueCommentBodyChange struct {
+	From string `json:"from"`
 }
 
 type PullRequestReviewEvent struct {


### PR DESCRIPTION
- trigger PR comment runs on edited comments with body changes
- skip noisy edits when body is unchanged after trim
- add tests for edited comment handling

<details><summary>Goose Details</summary>

```

    __( O)>  ● new session · codex gpt-5.2-codex
   \____)    20260304_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: "/usr/local/bin/codex"
Model: gpt-5.2-codex
Reasoning effort: high
Skip git check: false
Prompt length: 1442 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Response Guidelines

Use Markdown formatting for all responses.

Human: <info-msg>
It is currently 2026-03-04 21:33:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

</info-msg>
# Rascal Run Instructions

Run ID: run_8b770b2d5f45c26a
Task ID: rtzll/rascal#46
Repository: rtzll/rascal
Issue: #46

## Task

feat(webhooks): support issue_comment edited on PRs

Why:
- Maintainers often edit comments for clarity instead of posting a new one.

Benefit:
- Agent picks up corrected instructions without manual re-trigger.

Scope:
- Handle `issue_comment` action `edited` when issue is a PR.
- Re-run or append feedback handling with updated context.
- Add dedupe logic/tests to avoid noisy retriggers.

## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run tests or explain why tests could not run.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label 'rascal' on issue #46


Assistant: 
Image files: 0
============================
{"type":"message","message":{"id":null,"role":"assistant","created":1772660417,"content":[{"type":"text","text":"**Summary**\n- Added support for `issue_comment` action `edited` on PRs, only triggering when the comment body actually changes (trim-aware) to avoid noisy retriggers in `cmd/rascald/main.go`.\n- Extended GitHub issue comment event parsing to include `changes.body.from` in `internal/github/events.go`.\n- Added tests for edited comment triggering and unchanged-body dedupe in `cmd/rascald/main_test.go`.\n\n**Tests**\n- `go test ./cmd/rascald -run TestHandleWebhookIssueComment`\n\nCommit message prepared in `/rascal-meta/commit_message.txt`."}],"metadata":{"userVisible":true,"agentVisible":true}}}
{"type":"complete","total_tokens":1516870}

```

</details>

Closes #46

---

Rascal run `run_8b770b2d5f45c26a` took 6m 41s [consumed 1516870 tokens]