### PR TITLE
feat(deploy): reclaim draining slot on repeated blue/green deploys

### DIFF
--- a/cmd/rascald/main.go
+++ b/cmd/rascald/main.go
@@ -38,6 +38,9 @@ const runSupervisorTick = 1 * time.Second
 const runResponseTargetFile = "response_target.json"
 const runCompletionCommentMarkerFile = "completion_comment_posted.json"
 const runCompletionCommentBodyMarker = "<!-- rascal:completion-comment -->"
+const shutdownDrainTimeoutCancelReason = "orchestrator shutdown drain timeout"
+const deployReclaimCancelReason = "superseded by newer deploy while draining"
+const deployReclaimCleanupWindow = 20 * time.Second
 
 type githubClient interface {
 	GetIssue(ctx context.Context, repo string, issueNumber int) (ghapi.IssueData, error)
@@ -137,6 +140,8 @@ func main() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", s.handleHealth)
 	mux.HandleFunc("/readyz", s.handleReady)
+	mux.HandleFunc("/v1/admin/drain", s.withAuth(s.handleAdminDrain))
+	mux.HandleFunc("/v1/admin/reclaim", s.withAuth(s.handleAdminReclaim))
 	mux.HandleFunc("/v1/runs", s.withAuth(s.handleListRuns))
 	mux.HandleFunc("/v1/runs/", s.withAuth(s.handleRunSubresources))
 	mux.HandleFunc("/v1/tasks", s.withAuth(s.handleCreateTask))
@@ -179,7 +184,7 @@ func main() {
 
 	if err := s.waitForNoActiveRuns(5 * time.Minute); err != nil {
 		log.Printf("active runs did not finish within drain timeout; canceling remaining runs")
-		s.cancelActiveRuns("orchestrator shutdown drain timeout")
+		s.cancelActiveRuns(shutdownDrainTimeoutCancelReason)
 		_ = s.waitForNoActiveRuns(30 * time.Second)
 	}
 }
@@ -270,6 +275,35 @@ func (s *server) handleReady(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "service": "rascald", "ready": true})
+}
+
+func (s *server) handleAdminDrain(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	s.beginDrain()
+	writeJSON(w, http.StatusAccepted, map[string]any{
+		"draining":    true,
+		"active_runs": s.activeRunCount(),
+	})
+}
+
+func (s *server) handleAdminReclaim(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	s.beginDrain()
+	s.cancelActiveRunsWithSource(deployReclaimCancelReason, "deploy_reclaim")
+	waitErr := s.waitForNoActiveRuns(deployReclaimCleanupWindow)
+	writeJSON(w, http.StatusAccepted, map[string]any{
+		"reclaimed":      true,
+		"cancel_reason":  deployReclaimCancelReason,
+		"active_runs":    s.activeRunCount(),
+		"cleanup_timed":  waitErr != nil,
+		"cleanup_window": deployReclaimCleanupWindow.String(),
+	})
 }
 
 func (s *server) handleListRuns(w http.ResponseWriter, r *http.Request) {
@@ -1794,15 +1828,23 @@ func (s *server) cancelRunningTaskRuns(taskID, reason string) {
 }
 
 func (s *server) cancelActiveRuns(reason string) {
+	s.cancelActiveRunsWithSource(reason, "shutdown")
+}
+
+func (s *server) cancelActiveRunsWithSource(reason, source string) {
 	reason = strings.TrimSpace(reason)
 	if reason == "" {
 		reason = "canceled"
+	}
+	source = strings.TrimSpace(source)
+	if source == "" {
+		source = "system"
 	}
 	s.mu.Lock()
 	cancels := make([]context.CancelFunc, 0, len(s.runCancels))
 	for runID, cancel := range s.runCancels {
 		s.runCancelNote[runID] = reason
-		_ = s.store.RequestRunCancel(runID, reason, "shutdown")
+		_ = s.store.RequestRunCancel(runID, reason, source)
 		cancels = append(cancels, cancel)
 	}
 	s.mu.Unlock()

--- a/cmd/rascald/main_test.go
+++ b/cmd/rascald/main_test.go
@@ -1720,6 +1720,149 @@ func TestCancelActiveRunsUsesDrainReason(t *testing.T) {
 	}, "run canceled with drain reason")
 }
 
+func TestBeginDrainTimeoutDoesNotCancelActiveRuns(t *testing.T) {
+	waitCh := make(chan struct{})
+	launcher := &fakeLauncher{waitCh: waitCh}
+	s := newTestServer(t, launcher)
+	defer func() {
+		close(waitCh)
+		waitForServerIdle(t, s)
+	}()
+
+	run, err := s.createAndQueueRun(runRequest{TaskID: "drain-timeout-no-cancel", Repo: "owner/repo", Task: "long running"})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	waitFor(t, time.Second, func() bool { return launcher.Calls() == 1 }, "run start")
+
+	s.beginDrain()
+	if err := s.waitForNoActiveRuns(50 * time.Millisecond); err == nil {
+		t.Fatalf("expected waitForNoActiveRuns timeout while run is active")
+	}
+
+	current, ok := s.store.GetRun(run.ID)
+	if !ok {
+		t.Fatalf("missing run %s", run.ID)
+	}
+	if current.Status != state.StatusRunning {
+		t.Fatalf("expected run to remain running, got %s", current.Status)
+	}
+	if _, ok := s.store.GetRunCancel(run.ID); ok {
+		t.Fatalf("did not expect persisted cancel request when only waiting for drain")
+	}
+}
+
+func TestHandleAdminDrainKeepsActiveRuns(t *testing.T) {
+	waitCh := make(chan struct{})
+	launcher := &fakeLauncher{waitCh: waitCh}
+	s := newTestServer(t, launcher)
+	defer func() {
+		close(waitCh)
+		waitForServerIdle(t, s)
+	}()
+
+	run, err := s.createAndQueueRun(runRequest{TaskID: "admin-drain", Repo: "owner/repo", Task: "keep running"})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	waitFor(t, time.Second, func() bool { return launcher.Calls() == 1 }, "run start")
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/admin/drain", nil)
+	rec := httptest.NewRecorder()
+	s.handleAdminDrain(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", rec.Code)
+	}
+
+	current, ok := s.store.GetRun(run.ID)
+	if !ok {
+		t.Fatalf("missing run %s", run.ID)
+	}
+	if current.Status != state.StatusRunning {
+		t.Fatalf("expected run to remain running after admin drain, got %s", current.Status)
+	}
+}
+
+func TestHandleAdminReclaimCancelsActiveRunsWithDeployReason(t *testing.T) {
+	waitCh := make(chan struct{})
+	launcher := &fakeLauncher{waitCh: waitCh}
+	s := newTestServer(t, launcher)
+	defer func() {
+		close(waitCh)
+		waitForServerIdle(t, s)
+	}()
+
+	run, err := s.createAndQueueRun(runRequest{TaskID: "admin-reclaim", Repo: "owner/repo", Task: "cancel on reclaim"})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	waitFor(t, time.Second, func() bool { return launcher.Calls() == 1 }, "run start")
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/admin/reclaim", nil)
+	rec := httptest.NewRecorder()
+	s.handleAdminReclaim(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", rec.Code)
+	}
+
+	waitFor(t, 2*time.Second, func() bool {
+		current, ok := s.store.GetRun(run.ID)
+		return ok && current.Status == state.StatusCanceled && strings.Contains(current.Error, deployReclaimCancelReason)
+	}, "run canceled by reclaim reason")
+}
+
+func TestCancelActiveRunsOnlyCancelsKnownLocalRuns(t *testing.T) {
+	waitCh := make(chan struct{})
+	launcher := &fakeLauncher{waitCh: waitCh}
+	s := newTestServer(t, launcher)
+	defer func() {
+		close(waitCh)
+		waitForServerIdle(t, s)
+	}()
+
+	localRun, err := s.createAndQueueRun(runRequest{TaskID: "local-slot", Repo: "owner/repo", Task: "local active"})
+	if err != nil {
+		t.Fatalf("create local run: %v", err)
+	}
+	waitFor(t, time.Second, func() bool { return launcher.Calls() == 1 }, "local run start")
+
+	otherRun, err := s.store.AddRun(state.CreateRunInput{
+		ID:         "run_other_slot_active",
+		TaskID:     "other-slot",
+		Repo:       "owner/repo",
+		Task:       "other slot active",
+		BaseBranch: "main",
+		RunDir:     t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("add other-slot run: %v", err)
+	}
+	if _, err := s.store.SetRunStatus(otherRun.ID, state.StatusRunning, ""); err != nil {
+		t.Fatalf("set other-slot run running: %v", err)
+	}
+	if err := s.store.UpsertRunLease(otherRun.ID, "other-slot-instance", 2*time.Minute); err != nil {
+		t.Fatalf("set other-slot run lease: %v", err)
+	}
+
+	s.cancelActiveRunsWithSource(deployReclaimCancelReason, "deploy_reclaim")
+
+	waitFor(t, 2*time.Second, func() bool {
+		current, ok := s.store.GetRun(localRun.ID)
+		return ok && current.Status == state.StatusCanceled
+	}, "local run canceled")
+
+	otherCurrent, ok := s.store.GetRun(otherRun.ID)
+	if !ok {
+		t.Fatalf("missing other-slot run %s", otherRun.ID)
+	}
+	if otherCurrent.Status != state.StatusRunning {
+		t.Fatalf("expected other-slot run to remain running, got %s", otherCurrent.Status)
+	}
+	if _, ok := s.store.GetRunCancel(otherRun.ID); ok {
+		t.Fatalf("did not expect cancel request for other-slot run")
+	}
+}
+
 func TestExecuteRunHonorsPersistedCancelBeforeStart(t *testing.T) {
 	launcher := &fakeLauncher{}
 	s := newTestServer(t, launcher)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -39,28 +39,45 @@ Given active slot `A` and inactive slot `B`, deploy does:
 4. Install uploaded `rascal-runner` into `/opt/rascal/runner/rascal-runner`.
 5. Build/update runner image on host.
 6. Install/update systemd unit and env files.
-7. Start/restart slot `B`.
-8. Wait for slot `B` readiness (`/readyz` on `B` port).
-9. Update Caddy upstream to slot `B` and reload Caddy.
-10. Verify proxy readiness via Caddy.
-11. Write `/etc/rascal/active_slot = B`.
-12. Stop old slot `A` with `systemctl stop --no-block` (non-blocking).
-13. Disable old slot unit; keep new slot unit enabled/active.
+7. If slot `B` is still running in draining mode from a previous deploy, reclaim it first:
+   - call slot-local reclaim API on `B`
+   - cancel active runs on `B` with reason `superseded by newer deploy while draining`
+   - wait a short bounded cleanup window
+   - stop `B`
+8. Start/restart slot `B`.
+9. Wait for slot `B` readiness (`/readyz` on `B` port).
+10. Update Caddy upstream to slot `B` and reload Caddy.
+11. Verify proxy readiness via Caddy.
+12. Write `/etc/rascal/active_slot = B`.
+13. Mark old slot `A` as draining via slot-local admin API (do not stop immediately).
+14. Disable old slot unit; keep new slot unit enabled/active.
 
 Important: deploy success is no longer coupled to waiting for old-slot drain.
 
-## Drain Behavior
+## Slot States And Policy
 
-When old slot gets `SIGTERM`:
+Slots are treated as:
 
-1. Enters draining mode.
-2. Stops accepting new work.
-3. Cancels queued runs immediately.
-4. Waits up to 5 minutes for active runs to finish.
-5. If timeout hits, cancels remaining active runs with drain-timeout reason.
-6. Waits a short final window, then exits.
+- `active`: receives traffic and schedules work.
+- `draining`: no new work accepted, active work may continue.
+- `inactive`: free to deploy.
 
-This allows fast cutover while old work winds down in the background.
+Policy:
+
+1. The immediately previous slot is allowed to drain active work with no fixed deploy timeout.
+2. If the next deploy needs that slot and it is still draining, deploy explicitly reclaims it and cancels its active work.
+3. The currently active slot is not canceled just because a new deploy starts.
+
+## Drain And Shutdown Behavior
+
+Deploy-driven drain is now explicit (`/v1/admin/drain`) and does not apply a fixed active-run timeout.
+
+Generic process shutdown (`SIGTERM`, host shutdown, operator stop) keeps bounded shutdown behavior:
+
+1. Enter draining mode.
+2. Stop accepting new work.
+3. Wait up to 5 minutes for active runs.
+4. Cancel remaining runs with `orchestrator shutdown drain timeout`.
 
 ## Runner Entrypoint
 
@@ -89,7 +106,7 @@ Additional safeguards:
 - Docker launcher explicitly stops and removes the run container on cancel.
 - Final success write is guarded so canceled runs cannot later become
   `succeeded` or `review`.
-- Cancel reason distinguishes user cancel vs shutdown/drain timeout.
+- Cancel reason distinguishes user cancel vs deploy reclaim vs shutdown timeout.
 
 ## Rollback Behavior
 
@@ -113,13 +130,14 @@ ssh root@HOST 'curl -fsS http://127.0.0.1:18081/readyz || true'
 
 ## End-to-End Example Flow
 
-Example: `blue` is active and running a job, deploy is triggered.
+Example timeline:
 
-1. Deploy prepares `green` and passes `green` readiness.
-2. Caddy upstream switches to `green`.
-3. `active_slot` flips to `green`.
-4. `blue` gets stop request with `--no-block`; deploy returns success quickly.
-5. `blue` drains in background; existing job can finish or be canceled on
-   timeout.
-6. If canceled, runner container is explicitly stopped/removed and run stays
-   terminally `canceled`.
+1. `blue` is active and running a job.
+2. Deploy N starts `green`, flips traffic to `green`, and marks `blue` draining.
+3. `blue` keeps running its active job with no deploy-time fixed timeout.
+4. Deploy N+1 starts while `blue` is still draining.
+5. Deploy N+1 explicitly reclaims `blue` before reusing it:
+   - cancel `blue` active runs with reason `superseded by newer deploy while draining`
+   - bounded cleanup wait
+   - stop `blue`
+6. New version deploys onto `blue`, traffic flips, and `green` becomes the next draining slot.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -84,6 +84,13 @@ curl -fsS "https://${DOMAIN}/readyz"
 
 See also: [deployment.md](deployment.md)
 
+Repeated deploy policy (interim two-slot behavior):
+
+- After one deploy, the previous slot may keep draining active runs indefinitely.
+- If you deploy again before it finishes, deploy reclaims that oldest draining slot and cancels its active runs with reason:
+  - `superseded by newer deploy while draining`
+- This keeps two-slot rotation moving without adding a third slot.
+
 ## 3) Run Appears Stuck
 
 Identify run and follow logs:
@@ -153,7 +160,12 @@ EOF
 systemctl reload caddy || systemctl restart caddy
 echo blue >/etc/rascal/active_slot
 systemctl restart rascal@blue
-systemctl stop --no-block rascal@green || true"
+if [ -f /etc/rascal/rascal.env ]; then set -a; . /etc/rascal/rascal.env; set +a; fi
+if [ -n \"\${RASCAL_API_TOKEN:-}\" ]; then
+  curl -fsS -X POST -H \"Authorization: Bearer \${RASCAL_API_TOKEN}\" http://127.0.0.1:18081/v1/admin/drain >/dev/null || true
+else
+  curl -fsS -X POST http://127.0.0.1:18081/v1/admin/drain >/dev/null || true
+fi"
 ```
 
 3. Verify recovery:

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -13,11 +13,12 @@ import (
 )
 
 const (
-	SlotBlue      = "blue"
-	SlotGreen     = "green"
-	SlotBluePort  = 18080
-	SlotGreenPort = 18081
-	ProxyPort     = 8080
+	SlotBlue                  = "blue"
+	SlotGreen                 = "green"
+	SlotBluePort              = 18080
+	SlotGreenPort             = 18081
+	ProxyPort                 = 8080
+	deployReclaimCancelReason = "superseded by newer deploy while draining"
 )
 
 type Config struct {
@@ -257,6 +258,15 @@ systemctl daemon-reload
 	if err := runRemoteScript(cfg, fmt.Sprintf("set -eu\nif ! systemctl is-active --quiet 'rascal@%s'; then systemctl enable 'rascal@%s' >/dev/null 2>&1 || true; systemctl restart 'rascal@%s'; fi\n", activeSlot, activeSlot, activeSlot)); err != nil {
 		return err
 	}
+	inactiveDraining, err := isRemoteSlotDraining(cfg, inactiveSlot, inactivePort)
+	if err != nil {
+		return err
+	}
+	if inactiveDraining {
+		if err := reclaimRemoteSlot(cfg, inactiveSlot, inactivePort); err != nil {
+			return err
+		}
+	}
 	if err := runRemoteScript(cfg, fmt.Sprintf("set -eu\nsystemctl enable 'rascal@%s' >/dev/null 2>&1 || true\nsystemctl restart 'rascal@%s'\n", inactiveSlot, inactiveSlot)); err != nil {
 		return err
 	}
@@ -328,13 +338,17 @@ if systemctl is-active --quiet rascal; then
   systemctl disable rascal >/dev/null 2>&1 || true
 fi
 if [ %s != %s ]; then
-  systemctl stop --no-block "rascal@%s" || true
   systemctl disable "rascal@%s" >/dev/null 2>&1 || true
 fi
 systemctl enable "rascal@%s" >/dev/null 2>&1 || true
 systemctl is-active --quiet "rascal@%s"
-`)+"\n", shellSingleQuote(inactiveSlot), shellSingleQuote(activeSlot), shellSingleQuote(inactiveSlot), activeSlot, activeSlot, inactiveSlot, inactiveSlot)); err != nil {
+`)+"\n", shellSingleQuote(inactiveSlot), shellSingleQuote(activeSlot), shellSingleQuote(inactiveSlot), activeSlot, inactiveSlot, inactiveSlot)); err != nil {
 		return err
+	}
+	if activeSlot != inactiveSlot {
+		if err := markRemoteSlotDraining(cfg, activeSlot, activePort); err != nil {
+			return err
+		}
 	}
 	if err := runRemoteScript(cfg, "set -eu\nrm -rf /tmp/rascal-bootstrap\n"); err != nil {
 		return err
@@ -593,6 +607,94 @@ fi
 `)+"\n", ProxyPort, ProxyPort, ProxyPort)
 	if err := runRemoteScript(cfg, checkScript); err != nil {
 		return fmt.Errorf("proxy readiness check failed on caddy: %w", err)
+	}
+	return nil
+}
+
+func isRemoteSlotDraining(cfg Config, slot string, port int) (bool, error) {
+	out, err := runRemoteScriptCapture(cfg, fmt.Sprintf(strings.TrimSpace(`
+set -eu
+# rascal:check-draining slot=%s
+if ! systemctl is-active --quiet "rascal@%s"; then
+  printf 'inactive'
+  exit 0
+fi
+status_code=''
+if command -v curl >/dev/null 2>&1; then
+  status_code="$(curl -sS -o /dev/null -w '%%{http_code}' --max-time 5 http://127.0.0.1:%d/readyz || true)"
+fi
+if [ "$status_code" = "503" ]; then
+  printf 'draining'
+  exit 0
+fi
+printf 'ready'
+`)+"\n", slot, slot, port))
+	if err != nil {
+		return false, fmt.Errorf("detect slot %s drain state: %w", slot, err)
+	}
+	state := strings.TrimSpace(out)
+	switch state {
+	case "", "inactive", "ready":
+		return false, nil
+	case "draining":
+		return true, nil
+	default:
+		return false, fmt.Errorf("detect slot %s drain state: unexpected response %q", slot, state)
+	}
+}
+
+func reclaimRemoteSlot(cfg Config, slot string, port int) error {
+	if err := runRemoteScript(cfg, fmt.Sprintf(strings.TrimSpace(`
+set -eu
+# rascal:reclaim-slot slot=%s
+if ! systemctl is-active --quiet "rascal@%s"; then
+  exit 0
+fi
+if [ -f /etc/rascal/rascal.env ]; then
+  set -a
+  . /etc/rascal/rascal.env
+  set +a
+fi
+post_reclaim() {
+  url="$1"
+  if [ -n "${RASCAL_API_TOKEN:-}" ]; then
+    curl -fsS --max-time 15 -X POST -H "Authorization: Bearer ${RASCAL_API_TOKEN}" "$url" >/dev/null
+    return
+  fi
+  curl -fsS --max-time 15 -X POST "$url" >/dev/null
+}
+post_reclaim "http://127.0.0.1:%d/v1/admin/reclaim"
+systemctl stop "rascal@%s"
+systemctl disable "rascal@%s" >/dev/null 2>&1 || true
+`)+"\n", slot, slot, port, slot, slot)); err != nil {
+		return fmt.Errorf("reclaim draining slot %s (%s): %w", slot, deployReclaimCancelReason, err)
+	}
+	return nil
+}
+
+func markRemoteSlotDraining(cfg Config, slot string, port int) error {
+	if err := runRemoteScript(cfg, fmt.Sprintf(strings.TrimSpace(`
+set -eu
+# rascal:mark-draining slot=%s
+if ! systemctl is-active --quiet "rascal@%s"; then
+  exit 0
+fi
+if [ -f /etc/rascal/rascal.env ]; then
+  set -a
+  . /etc/rascal/rascal.env
+  set +a
+fi
+post_drain() {
+  url="$1"
+  if [ -n "${RASCAL_API_TOKEN:-}" ]; then
+    curl -fsS --max-time 10 -X POST -H "Authorization: Bearer ${RASCAL_API_TOKEN}" "$url" >/dev/null
+    return
+  fi
+  curl -fsS --max-time 10 -X POST "$url" >/dev/null
+}
+post_drain "http://127.0.0.1:%d/v1/admin/drain"
+`)+"\n", slot, slot, port)); err != nil {
+		return fmt.Errorf("mark previous slot %s draining: %w", slot, err)
 	}
 	return nil
 }

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -176,6 +176,60 @@ func TestExecuteRollsOutRunnerBinaryBeforeImageBuild(t *testing.T) {
 	}
 }
 
+func TestExecuteDoesNotReclaimWhenInactiveSlotNotDraining(t *testing.T) {
+	logDir := setupFakeDeployCommands(t, "")
+
+	if err := Execute(testDeployConfig()); err != nil {
+		t.Fatalf("execute deploy: %v", err)
+	}
+
+	scripts := readCapturedSSHScripts(t, logDir)
+	if !containsScript(scripts, "rascal:check-draining slot=green") {
+		t.Fatalf("expected inactive-slot drain detection script, got %d scripts", len(scripts))
+	}
+	if containsScript(scripts, "rascal:reclaim-slot slot=green") {
+		t.Fatalf("did not expect reclaim script when inactive slot is not draining")
+	}
+	if containsScript(scripts, "systemctl stop --no-block \"rascal@blue\"") {
+		t.Fatalf("did not expect old slot stop --no-block during cutover")
+	}
+	if !containsScript(scripts, "rascal:mark-draining slot=blue") {
+		t.Fatalf("expected old active slot to be marked draining")
+	}
+}
+
+func TestExecuteReclaimsDrainingInactiveSlotBeforeRestart(t *testing.T) {
+	logDir := setupFakeDeployCommands(t, "inactive_draining")
+
+	if err := Execute(testDeployConfig()); err != nil {
+		t.Fatalf("execute deploy: %v", err)
+	}
+
+	scripts := readCapturedSSHScripts(t, logDir)
+	reclaimIdx := scriptIndexContaining(scripts, "rascal:reclaim-slot slot=green")
+	if reclaimIdx < 0 {
+		t.Fatalf("expected reclaim script for draining inactive slot")
+	}
+	restartIdx := scriptIndexContaining(scripts, "systemctl restart 'rascal@green'")
+	if restartIdx < 0 {
+		t.Fatalf("expected inactive slot restart script")
+	}
+	if reclaimIdx > restartIdx {
+		t.Fatalf("expected reclaim before inactive slot restart (reclaim=%d restart=%d)", reclaimIdx, restartIdx)
+	}
+	switchIdx := scriptIndexContaining(scripts, "echo 'green' >/etc/rascal/active_slot")
+	if switchIdx < 0 {
+		t.Fatalf("expected active slot switch script")
+	}
+	markDrainIdx := scriptIndexContaining(scripts, "rascal:mark-draining slot=blue")
+	if markDrainIdx < 0 {
+		t.Fatalf("expected old active slot drain marker script")
+	}
+	if markDrainIdx < switchIdx {
+		t.Fatalf("expected old slot drain marker after active_slot switch (mark=%d switch=%d)", markDrainIdx, switchIdx)
+	}
+}
+
 func TestResolveRunnerBuildInfoUsesEnv(t *testing.T) {
 	t.Setenv("RASCAL_BUILD_VERSION", "v1.2.3")
 	t.Setenv("RASCAL_BUILD_COMMIT", "abc1234")
@@ -314,6 +368,14 @@ if grep -Fq "slot=''" "$script_file" && grep -Fq "printf 'blue'" "$script_file";
   printf 'blue'
   exit 0
 fi
+if grep -Fq "rascal:check-draining slot=green" "$script_file"; then
+  if [ "${RASCAL_TEST_FAIL_MODE:-}" = "inactive_draining" ]; then
+    printf 'draining'
+  else
+    printf 'ready'
+  fi
+  exit 0
+fi
 
 case "${RASCAL_TEST_FAIL_MODE:-}" in
   caddy_reload)
@@ -399,4 +461,13 @@ func firstLineContaining(lines []string, needle string) string {
 		}
 	}
 	return ""
+}
+
+func scriptIndexContaining(scripts []string, needle string) int {
+	for i, script := range scripts {
+		if strings.Contains(script, needle) {
+			return i
+		}
+	}
+	return -1
 }


### PR DESCRIPTION
Add explicit slot-admin drain/reclaim APIs in rascald and update deploy rotation
policy so the previous slot drains without a fixed deploy timeout, while a later
deploy can reclaim the oldest draining slot before reuse.

- deploy now detects a draining inactive slot and reclaims it before restart
- reclaim cancels active runs with deploy-specific reason
- cutover marks old slot draining instead of stopping it immediately
- docs and tests updated for interim two-slot policy

<details><summary>Goose Details</summary>

```

    __( O)>  ● new session · codex gpt-5.4
   \____)    20260306_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: "/usr/local/bin/codex"
Model: gpt-5.4
Reasoning effort: high
Skip git check: false
Prompt length: 10343 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Suggestion

The user has 7 extensions with 16 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
Consider asking if they'd like to disable some extensions to improve tool selection accuracy.

# Response Guidelines

Use Markdown formatting for all responses.

Human: <info-msg>
It is currently 2026-03-06 22:20:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

</info-msg>
# Rascal Run Instructions

Run ID: run_ce6db184be2eb5fe
Task ID: rtzll/rascal#88
Repository: rtzll/rascal
Issue: #88

## Task

deploy: reclaim oldest draining slot on repeated blue/green deploys

## Summary

Implement an interim blue/green deploy policy that avoids fixed-timeout cancellation for the immediately previous slot, but still allows repeated deploys with only two slots.

This is a smaller, transitional step before the fuller detached-container adoption work in #87.

Target behavior:

- deploy N:
  - switch traffic to the inactive slot
  - old slot stops accepting new work
  - old slot is allowed to keep running active jobs with **no fixed drain timeout**

- deploy N+1 while the previous old slot is still draining:
  - reclaim that oldest draining slot
  - cancel its still-running jobs
  - deploy the new version onto that slot
  - switch traffic as usual

In other words:

- allow one previous generation of work to continue
- on the next deploy, cancel the oldest still-draining work so the two-slot system can continue rotating

This is not the final architecture. It is an operational compromise until #87 is implemented.

## Why

Current deploy-driven shutdown uses a fixed active-run drain timeout in `rascald`:

- stop accepting new work
- wait up to 5 minutes
- then cancel remaining active runs

That is too short for normal Rascal runs, which frequently take 10-20 minutes.

We want better behavior now, without waiting for the larger adoption/detached-execution refactor in #87.

This issue is the smaller stopgap:

- remove deploy-driven timeout cancellation for the immediately previous slot
- preserve active work through one cutover
- only cancel if a later deploy needs to reclaim that old slot

## Non-Goals

- do not implement detached execution or adoptable supervision here
- do not solve repeated deploys without any cancellations at all
- do not add a third slot
- do not block deploys waiting for long-running work to finish

That fuller solution is tracked separately in #87.

## Desired Semantics

### Baseline case

Assume `green` is active and has an active run.

1. Deploy starts `blue`.
2. Traffic flips to `blue`.
3. `green` enters draining mode:
   - accepts no new work
   - queued work is canceled immediately as today
   - active work is allowed to continue
   - **no fixed 5-minute timeout**

At this point:

- `blue` is active
- `green` is draining

### Next deploy while old slot still draining

Now deploy again.

1. Active slot is `blue`.
2. Inactive slot is `green`, but `green` is still draining old work.
3. Before deploying onto `green`, explicitly reclaim it:
   - mark/cancel active runs on `green`
   - wait a short bounded cleanup window
   - stop `green`
4. Deploy new version onto `green`
5. Flip traffic to `green`
6. `blue` becomes the new draining slot

This means:

- the most recent previous slot gets a full chance to finish
- the oldest draining slot is the one that loses work if repeated deploys happen quickly

## Required Policy

Treat slots in one of these states:

- `active`: receiving traffic and scheduling work
- `draining`: not receiving traffic, not scheduling new work, but still running existing work
- `inactive`: free to deploy

Deploy policy:

1. If the inactive slot is truly inactive, deploy onto it normally.
2. If the inactive slot is still draining from the previous deploy, cancel that slot’s active runs and reclaim it for the new deploy.
3. Never cancel the current active slot’s runs just because a deploy begins.
4. Never use a fixed drain timeout to cancel the immediately previous slot.

## Scope

This should be implemented as a smaller change on top of the current architecture.

Likely files:

- `internal/deploy/deploy.go`
- `cmd/rascald/main.go`
- `cmd/rascald/main_test.go`
- `internal/deploy/deploy_test.go`
- `docs/deployment.md`
- `docs/runbook.md`
- optionally `docs/architecture.md` if deploy/drain semantics are documented there

## Current Behavior to Change

Current shutdown path in `cmd/rascald/main.go`:

- `httpServer.Shutdown(...)`
- `waitForNoActiveRuns(5 * time.Minute)`
- if timeout: `cancelActiveRuns("orchestrator shutdown drain timeout")`
- short final wait

For this issue, deploy-driven slot rotation should no longer use that fixed timeout policy for the immediately previous slot.

Current deploy path in `internal/deploy/deploy.go`:

- determines active/inactive slot
- starts inactive slot
- flips traffic
- writes `/etc/rascal/active_slot`
- stops old slot with `systemctl stop --no-block`

This needs to become aware of a draining inactive slot and reclaim it explicitly before reusing it.

## Proposed Implementation Direction

### 1. Distinguish deploy-driven drain from generic shutdown

The server currently treats SIGTERM/shutdown as a single mode. This issue likely needs a distinction between:

- deploy rotation drain
- full shutdown / host shutdown / operator stop

Deploy rotation drain behavior:

- no fixed active-run timeout
- old slot may remain alive and draining until explicitly reclaimed by a later deploy

Generic shutdown behavior can keep an operator-safe bounded timeout if needed, but be explicit about the difference.

Acceptable ways to implement this include:

- environment flag or runtime mode indicating deploy-managed slot semantics
- stop-file / reclaim signal approach
- separate endpoint or signal flow used by deploy scripts

Do not leave the behavior ambiguous.

### 2. Add an explicit reclaim path

Before deploying to the inactive slot, detect whether it is still draining active work.

If yes:

- send a reclaim request to that slot
- cancel its active runs with a clear reason, for example:
  - `superseded by newer deploy while draining`
  - or similar wording
- allow a short bounded cleanup period
- then stop the slot and continue deploy

This reclaim behavior should be specific and intentional, not an accidental side effect of generic timeout logic.

### 3. Prefer slot-local cancellation during reclaim

When reclaiming the old draining slot, cancellation should happen from that slot while it is still alive so:

- run state is updated cleanly
- runner containers are stopped cleanly
- logs/reasons are preserved

Avoid simply killing the service first and hoping recovery cleans up the rest.

### 4. Keep active slot untouched

The currently active slot must not have its active runs canceled due to a new deploy starting.

Only the oldest draining slot should be reclaimed.

### 5. Update reason strings and observability

Use explicit cancel reasons so operators can distinguish:

- user cancel
- deploy reclaim cancel
- generic shutdown
- drain timeout from non-deploy scenarios, if that remains anywhere

Document and test the reason string.

## Acceptance Criteria

- Deploy-driven rotation no longer cancels the immediately previous slot after a fixed 5-minute timeout.
- The previous slot can continue running active work indefinitely after one deploy.
- A subsequent deploy can still proceed without blocking.
- If the inactive slot is still draining, that oldest draining slot is explicitly reclaimed for the new deploy.
- Reclaim cancels that slot’s active runs with a clear deploy-specific reason.
- The currently active slot’s active runs are not canceled just because a new deploy starts.
- Docs explain the interim policy clearly.
- Tests cover the new behavior.

## Test Plan

### Orchestrator tests

Add tests in `cmd/rascald/main_test.go` for at least:

- deploy-drain shutdown mode does not auto-cancel active runs after 5 minutes
- reclaim path cancels active runs with the deploy-specific reason
- reclaim path still stops runner containers cleanly
- active slot is not canceled when another slot is being reclaimed

If the implementation introduces a new server mode or endpoint, test that directly.

### Deploy tests

Add tests in `internal/deploy/deploy_test.go` for at least:

- normal deploy onto inactive slot still works
- deploy detects an inactive slot that is actually draining
- deploy performs reclaim before reusing that slot
- reclaim occurs before service restart/deploy on that slot
- traffic switch still occurs in the right order

### Documentation

Update docs to explain the precise two-slot policy:

- one prior slot may drain indefinitely
- if another deploy happens, the oldest draining slot is reclaimed and its jobs are canceled

## Suggested Documentation Changes

Update at least:

- `docs/deployment.md`
- `docs/runbook.md`

Document examples like:

1. `green` active, `blue` inactive
2. deploy -> `blue` active, `green` draining indefinitely
3. deploy again before `green` finishes
4. `green` is reclaimed, its jobs are canceled, new version is deployed onto `green`

Make the operator tradeoff explicit: this is a pragmatic interim policy until #87 makes repeated deploys non-disruptive for active work.

## Notes

This issue is intentionally narrower than #87.

It should be implementable without redesigning the runner lifecycle around detached adoptable execution.

The goal here is simply:

- remove the too-short fixed drain timeout
- preserve active work across one deploy
- keep deploys moving by reclaiming the oldest draining slot on the next deploy

## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run tests or explain why tests could not run.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label 'rascal' on issue #88


Assistant: 
Image files: 0
============================
{"type":"message","message":{"id":null,"role":"assistant","created":1772836490,"content":[{"type":"text","text":"I’m implementing issue #88 by changing deploy and shutdown semantics so one previous slot can drain indefinitely, and the next deploy explicitly reclaims that oldest draining slot. I’ll first map the current deploy/orchestrator flow and tests, then patch minimally and run targeted tests.\n\nI’ve captured the full requirement set in the task plan and I’m now tracing the current deploy script generation and `rascald` shutdown/reclaim paths to apply the smallest coherent change.\n\nI’ve confirmed the current behavior: shutdown always applies a 5-minute timeout cancel, and deploy always `stop --no-block`s the old slot with no explicit reclaim path. Next I’m inspecting test harnesses to add coverage with minimal disruption.\n\nI’ve finished tracing the flows and test scaffolding. Next edits are: add explicit admin `drain`/`reclaim` endpoints in `rascald`, wire deploy to mark old slot draining instead of stopping it, and reclaim a draining inactive slot before reuse; then I’ll add targeted tests and doc updates.\n\nI’m now editing deploy orchestration to add explicit `drain` and `reclaim` API calls around slot rotation, with reclaim happening before restart of a draining inactive slot. After this I’ll adjust tests to assert ordering and reason semantics.\n\nI’m adding `rascald` tests for the new admin drain/reclaim endpoints and for non-cancellation behavior when a drain wait times out. I’ll also add a guard test that only locally-owned active runs are canceled by reclaim.\n\nCore code and tests are patched and formatted. I’m now updating deployment/runbook docs to describe the interim two-slot policy: previous slot drains without fixed timeout, then gets explicitly reclaimed on the next deploy if still draining.\n\nDocs are updated. I’m running targeted Go tests for `cmd/rascald` and `internal/deploy` now to validate behavior and catch regressions from the new reclaim/drain flow.\n\n`internal/deploy` tests passed; I hit one flaky timeout once in `cmd/rascald`, so I’m re-running the full `cmd/rascald` test package to confirm it’s stable with the new tests.\n\nI resolved the flaky test cleanup path and now both targeted packages pass together. I’ll do a final diff review, then write the required commit message file.\n\nAll scoped changes are in place and targeted tests pass. I’m writing the required conventional commit message file now, then I’ll summarize what changed and the exact test commands/results.\n\nImplemented issue #88 with an explicit two-slot drain/reclaim policy.\n\n**Code Changes**\n- Added deploy-admin endpoints in `rascald`:\n  - `POST /v1/admin/drain` to enter draining mode without timeout-cancel.\n  - `POST /v1/admin/reclaim` to cancel active runs with reason `superseded by newer deploy while draining`, then bounded cleanup wait.\n  - See [cmd/rascald/main.go:143](/work/repo/cmd/rascald/main.go:143), [cmd/rascald/main.go:280](/work/repo/cmd/rascald/main.go:280), [cmd/rascald/main.go:292](/work/repo/cmd/rascald/main.go:292), [cmd/rascald/main.go:1834](/work/repo/cmd/rascald/main.go:1834).\n- Kept generic SIGTERM shutdown timeout behavior explicit (`orchestrator shutdown drain timeout`) while separating deploy reclaim semantics.\n  - See [cmd/rascald/main.go:41](/work/repo/cmd/rascald/main.go:41), [cmd/rascald/main.go:187](/work/repo/cmd/rascald/main.go:187).\n- Updated deploy flow to:\n  - detect if inactive slot is still draining,\n  - reclaim it before restart/reuse,\n  - stop immediate old-slot `--no-block` behavior,\n  - mark previous active slot draining after cutover.\n  - See [internal/deploy/deploy.go:261](/work/repo/internal/deploy/deploy.go:261), [internal/deploy/deploy.go:646](/work/repo/internal/deploy/deploy.go:646), [internal/deploy/deploy.go:675](/work/repo/internal/deploy/deploy.go:675), [internal/deploy/deploy.go:333](/work/repo/internal/deploy/deploy.go:333).\n\n**Tests Added/Updated**\n- `rascald` tests for:\n  - no auto-cancel on drain wait timeout,\n  - admin drain preserves active runs,\n  - admin reclaim cancels with deploy-specific reason,\n  - canceling only local active runs.\n  - See [cmd/rascald/main_test.go:1723](/work/repo/cmd/rascald/main_test.go:1723), [cmd/rascald/main_test.go:1755](/work/repo/cmd/rascald/main_test.go:1755), [cmd/rascald/main_test.go:1786](/work/repo/cmd/rascald/main_test.go:1786), [cmd/rascald/main_test.go:1814](/work/repo/cmd/rascald/main_test.go:1814).\n- Deploy tests for:\n  - normal non-draining inactive slot path,\n  - reclaim-before-restart ordering when inactive is draining.\n  - See [internal/deploy/deploy_test.go:179](/work/repo/internal/deploy/deploy_test.go:179), [internal/deploy/deploy_test.go:201](/work/repo/internal/deploy/deploy_test.go:201).\n\n**Docs Updated**\n- Interim policy and semantics in [docs/deployment.md:42](/work/repo/docs/deployment.md:42), [docs/deployment.md:57](/work/repo/docs/deployment.md:57), [docs/deployment.md:71](/work/repo/docs/deployment.md:71).\n- Runbook/operator notes in [docs/runbook.md:87](/work/repo/docs/runbook.md:87), [docs/runbook.md:165](/work/repo/docs/runbook.md:165).\n\n**Test Commands Run**\n- `go test ./cmd/rascald -run 'Test(BeginDrainTimeoutDoesNotCancelActiveRuns|HandleAdminDrainKeepsActiveRuns|HandleAdminReclaimCancelsActiveRunsWithDeployReason|CancelActiveRunsOnlyCancelsKnownLocalRuns|CancelActiveRunsUsesDrainReason|HandleReadyReflectsDrainingState|CreateAndQueueRunRejectedWhenDraining|BeginDrainLeavesQueuedRunsForNextSlot)$' -count=1`\n- `go test ./internal/deploy -count=1`\n- Both passed.\n\nWrote commit message file: [/rascal-meta/commit_message.txt](/rascal-meta/commit_message.txt)."}],"metadata":{"userVisible":true,"agentVisible":true}}}
{"type":"complete","total_tokens":4873742}

```

</details>

Closes #88

---

Rascal run `run_ce6db184be2eb5fe` completed in 14m 2s · 4.87M tokens