### PR TITLE
fix(runner): run runtime as non-root and set no-new-privileges

### DIFF
--- a/internal/runner/docker.go
+++ b/internal/runner/docker.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -21,6 +22,12 @@ type DockerLauncher struct {
 	GitHubToken string
 }
 
+const (
+	// Keep in sync with runner/Dockerfile runtime user UID/GID.
+	runtimeUID = 10001
+	runtimeGID = 10001
+)
+
 func (l DockerLauncher) Start(ctx context.Context, spec Spec) (Result, error) {
 	if l.Image == "" {
 		return Result{}, fmt.Errorf("docker image is required")
@@ -31,6 +38,9 @@ func (l DockerLauncher) Start(ctx context.Context, spec Spec) (Result, error) {
 	workspaceDir := filepath.Join(spec.RunDir, "workspace")
 	if err := os.MkdirAll(workspaceDir, 0o755); err != nil {
 		return Result{}, fmt.Errorf("create workspace dir: %w", err)
+	}
+	if err := prepareMountAccess(spec.RunDir, workspaceDir); err != nil {
+		return Result{}, err
 	}
 
 	logPath := filepath.Join(spec.RunDir, "runner.log")
@@ -82,6 +92,8 @@ func (l DockerLauncher) Start(ctx context.Context, spec Spec) (Result, error) {
 		args = append(args, "-e", fmt.Sprintf("%s=%s", k, v))
 	}
 	args = append(args,
+		// Harden container execution against privilege escalation.
+		"--security-opt", "no-new-privileges:true",
 		"-v", fmt.Sprintf("%s:/rascal-meta", spec.RunDir),
 		"-v", fmt.Sprintf("%s:/work", workspaceDir),
 		l.Image,
@@ -158,6 +170,45 @@ func forceStopContainer(containerName string, logOut io.Writer) {
 	rmCmd.Stdout = logOut
 	rmCmd.Stderr = logOut
 	_ = rmCmd.Run()
+}
+
+func prepareMountAccess(runDir, workspaceDir string) error {
+	if os.Geteuid() == 0 {
+		if err := chownTree(runDir, runtimeUID, runtimeGID); err != nil {
+			return fmt.Errorf("prepare run dir ownership: %w", err)
+		}
+		return nil
+	}
+
+	// Non-root launcher fallback: make bind mounts writable by the runtime UID.
+	for _, target := range []string{runDir, workspaceDir, filepath.Join(runDir, "codex"), filepath.Join(runDir, "goose")} {
+		if err := chmodIfExists(target, 0o777); err != nil {
+			return fmt.Errorf("prepare writable mount %s: %w", target, err)
+		}
+	}
+	if err := chmodIfExists(filepath.Join(runDir, "codex", "auth.json"), 0o644); err != nil {
+		return fmt.Errorf("prepare codex auth readability: %w", err)
+	}
+	return nil
+}
+
+func chownTree(root string, uid, gid int) error {
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		return os.Lchown(path, uid, gid)
+	})
+}
+
+func chmodIfExists(path string, mode os.FileMode) error {
+	if err := os.Chmod(path, mode); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func sanitizeContainerName(s string) string {

--- a/internal/runner/docker_test.go
+++ b/internal/runner/docker_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -112,5 +113,56 @@ exit 0
 	}
 	if err := waitForFile(rmCalled); err != nil {
 		t.Fatalf("expected docker rm to be called: %v", err)
+	}
+}
+
+func TestDockerLauncherIncludesNoNewPrivilegesSecurityOpt(t *testing.T) {
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "docker_calls.log")
+	fakeDocker := filepath.Join(tmp, "docker")
+	script := `#!/bin/sh
+set -eu
+echo "$@" >> "` + logPath + `"
+exit 0
+`
+	if err := os.WriteFile(fakeDocker, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake docker: %v", err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	t.Setenv("PATH", tmp+string(os.PathListSeparator)+oldPath)
+
+	runDir := filepath.Join(tmp, "run")
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatalf("create run dir: %v", err)
+	}
+
+	launcher := DockerLauncher{Image: "rascal-runner:latest"}
+	_, err := launcher.Start(context.Background(), Spec{
+		RunID:      "run_security",
+		TaskID:     "task_security",
+		Repo:       "owner/repo",
+		Task:       "security",
+		BaseBranch: "main",
+		HeadBranch: "rascal/task-security",
+		Trigger:    "cli",
+		Debug:      true,
+		RunDir:     runDir,
+	})
+	if err != nil {
+		t.Fatalf("unexpected start error: %v", err)
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read fake docker log: %v", err)
+	}
+	fields := strings.Fields(string(logData))
+	securityOptIdx := slices.Index(fields, "--security-opt")
+	if securityOptIdx == -1 {
+		t.Fatalf("expected --security-opt in docker args, got: %s", string(logData))
+	}
+	if securityOptIdx+1 >= len(fields) || fields[securityOptIdx+1] != "no-new-privileges:true" {
+		t.Fatalf("expected no-new-privileges:true in docker args, got: %s", string(logData))
 	}
 }

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -29,6 +29,8 @@ RUN set -eux; \
 
 FROM ubuntu:24.04
 ARG DEBIAN_FRONTEND=noninteractive
+ARG RUNTIME_UID=10001
+ARG RUNTIME_GID=10001
 RUN apt-get -qq update && apt-get -y -qq install --no-install-recommends \
     ca-certificates curl gnupg bzip2 xz-utils zip unzip \
     git gh \
@@ -60,5 +62,9 @@ WORKDIR /work
 COPY rascal-runner /usr/local/bin/rascal-runner
 COPY entrypoint.sh /usr/local/bin/rascal-entrypoint
 RUN chmod +x /usr/local/bin/rascal-runner /usr/local/bin/rascal-entrypoint
+RUN groupadd --system --gid "${RUNTIME_GID}" rascal \
+    && useradd --system --uid "${RUNTIME_UID}" --gid "${RUNTIME_GID}" --create-home --home-dir /home/rascal --shell /usr/sbin/nologin rascal \
+    && install -d -m 0755 -o rascal -g rascal /work /rascal-meta
+USER rascal:rascal
 
 ENTRYPOINT ["/usr/local/bin/rascal-entrypoint"]


### PR DESCRIPTION
Add a dedicated runtime user in the runner image and switch container execution
to that user. Harden docker launch arguments with
--security-opt=no-new-privileges:true and add a regression test for the arg.

To preserve current workflows with bind mounts, prepare mounted run directories
for non-root access before container start.

<details><summary>Goose Details</summary>

```

    __( O)>  ● new session · codex gpt-5.4
   \____)    20260307_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: "/usr/local/bin/codex"
Model: gpt-5.4
Reasoning effort: high
Skip git check: false
Prompt length: 3562 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Suggestion

The user has 7 extensions with 16 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
Consider asking if they'd like to disable some extensions to improve tool selection accuracy.

# Response Guidelines

Use Markdown formatting for all responses.

Human: <info-msg>
It is currently 2026-03-07 07:20:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

</info-msg>
# Rascal Run Instructions

Run ID: run_ce78d2140f0e58d4
Task ID: rtzll/rascal#94
Repository: rtzll/rascal
Issue: #94

## Task

Harden runner container: run runtime as non-root and enable no-new-privileges

## Summary
Harden the Rascal runner container by running the runtime as a non-root user and launching containers with `no-new-privileges` enabled.

This should reduce the impact of a compromised or misbehaving agent without changing the intended workflow inside the container.

## Why
Right now the runtime image does not declare a `USER`, so the runner process and tools execute as root inside the container. The Docker launcher also does not set `--security-opt=no-new-privileges:true`.

For Rascal's use case, the agent should be able to clone repos, edit files in `/work`, write run artifacts to `/rascal-meta`, run tests, and use outbound network access. It should not need privilege escalation inside the container.

## Scope
Implement both of these together:

1. Update the runtime image to run as a dedicated non-root user.
2. Add `--security-opt=no-new-privileges:true` to the Docker launcher.

## Implementation Notes
- Update `runner/Dockerfile`.
- Create a dedicated runtime user and group.
- Ensure that user can read and execute the installed tooling and can write to `/work` and `/rascal-meta`.
- Keep the existing runtime behavior intact: `rascal-runner`, `goose`, `git`, `gh`, node/codex, Go, and normal test/build workflows should still work.
- Update `internal/runner/docker.go` to include `--security-opt=no-new-privileges:true` in `docker run`.
- If ownership or permissions need to change for copied binaries or working directories, do that explicitly in the image.

## Acceptance Criteria
- Runner containers start successfully with the runtime user set to non-root.
- The agent can still clone/fetch repos, edit files, write logs/artifacts, and execute normal repo commands in `/work`.
- `no-new-privileges` is enabled on container startup.
- Existing tests covering runner startup still pass, and add/update tests if needed to lock in the `docker run` arguments.
- Document any behavior changes if a workflow previously depended on root inside the container.

## Nice to Have
- Add a regression test that asserts the Docker launcher includes `--security-opt=no-new-privileges:true`.
- Add a short note in docs or comments explaining that this is a hardening change, not a functional feature.

## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run tests or explain why tests could not run.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label 'rascal' on issue #94


Assistant: 
Image files: 0
============================
{"type":"message","message":{"id":null,"role":"assistant","created":1772868425,"content":[{"type":"text","text":"I’m implementing issue #94 by updating the runtime image to a non-root user and adding `no-new-privileges` to Docker launch args, then I’ll run the relevant tests and write the requested commit message file. I’ll start by scanning `runner/Dockerfile` and `internal/runner/docker.go` plus existing runner tests to keep the change minimal and covered.\n\nI’ve located the exact files and there are no pre-existing local changes. Next I’m reading the Dockerfile and Docker runner tests to make focused edits and lock the new hardening flags in tests.\n\nI confirmed where the runtime and launch args are set. I’m now checking for any tests that assert the exact `docker run` command so we can update or extend them for the new security option.\n\nI found an important compatibility risk: `/rascal-meta/codex/auth.json` is currently created with mode `0600`, which a new non-root container user may not be able to read unless UIDs match. I’m checking how this auth file is expected to be consumed so we can keep behavior intact while hardening.\n\nI’m about to patch `internal/runner/docker.go` to do two things: add `--security-opt=no-new-privileges:true` and ensure mounted run directories are accessible to the non-root runtime user (chown as root, with a non-root fallback). After that I’ll add a targeted regression test for the new Docker arg.\n\nThe core code changes are in place. I’m adding a regression test that asserts `docker run` receives `--security-opt no-new-privileges:true`, then I’ll run the runner tests and adjust if anything fails.\n\nA quick test fix is needed: the new test used `t.Parallel()` with `t.Setenv`, which Go disallows. I’m removing parallelization from that test and then rerunning targeted tests.\n\nI’ve finished the code edits and verified `internal/runner` tests pass. I’m now reviewing the diff for scope and then I’ll write `/rascal-meta/commit_message.txt` with a conventional commit title.\n\nImplemented the hardening changes for issue #94.\n\n- Updated runtime image to use a dedicated non-root user (`uid/gid 10001`) and set `USER rascal:rascal` in [runner/Dockerfile](/work/repo/runner/Dockerfile#L32).\n- Added `--security-opt no-new-privileges:true` to `docker run` args in [internal/runner/docker.go](/work/repo/internal/runner/docker.go#L94).\n- Added mount-access preparation so `/rascal-meta` and `/work` remain usable by the non-root runtime:\n  - root launcher path: recursive `Lchown` to runtime uid/gid\n  - non-root fallback: best-effort chmod for writable mounts/auth readability\n  - see [internal/runner/docker.go](/work/repo/internal/runner/docker.go#L175)\n- Added regression test asserting `--security-opt` is present in launcher args: [internal/runner/docker_test.go](/work/repo/internal/runner/docker_test.go#L119).\n- Wrote commit message file at `/rascal-meta/commit_message.txt`.\n\nTests run:\n- `go test ./internal/runner` passed.\n- I also tried `go test ./cmd/rascal-runner`; it fails in this environment due pre-set `RASCAL_*` env defaults (existing baseline issue unrelated to this change)."}],"metadata":{"userVisible":true,"agentVisible":true}}}
{"type":"complete","total_tokens":935779}

```

</details>

Closes #94

---

Rascal run `run_ce78d2140f0e58d4` completed in 6m 28s · 935K tokens