### PR TITLE
refactor(test): add reusable GitHub API mock helpers

### DIFF
--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -2,10 +2,8 @@ package github
 
 import (
 	"context"
-	"encoding/json"
 	"io"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -20,15 +18,11 @@ func newTestAPIClient(serverURL string) *APIClient {
 
 func TestLabelExists(t *testing.T) {
 	t.Run("label exists", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path != "/repos/owner/repo/labels/rascal" {
-				t.Fatalf("unexpected path: %s", r.URL.Path)
-			}
-			w.WriteHeader(http.StatusOK)
-		}))
-		defer srv.Close()
-
-		client := newTestAPIClient(srv.URL)
+		client := newGitHubMockClient(t,
+			githubRoute(http.MethodGet, "/repos/owner/repo/labels/rascal", func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}),
+		)
 		ok, err := client.LabelExists(context.Background(), "owner/repo", "rascal")
 		if err != nil {
 			t.Fatalf("LabelExists returned error: %v", err)
@@ -39,12 +33,11 @@ func TestLabelExists(t *testing.T) {
 	})
 
 	t.Run("label missing", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusNotFound)
-		}))
-		defer srv.Close()
-
-		client := newTestAPIClient(srv.URL)
+		client := newGitHubMockClient(t,
+			githubRoute(http.MethodGet, "/repos/owner/repo/labels/rascal", func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			}),
+		)
 		ok, err := client.LabelExists(context.Background(), "owner/repo", "rascal")
 		if err != nil {
 			t.Fatalf("LabelExists returned error: %v", err)
@@ -56,28 +49,24 @@ func TestLabelExists(t *testing.T) {
 }
 
 func TestFindWebhookByURL(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/repos/owner/repo/hooks" {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
-		}
-		_ = json.NewEncoder(w).Encode([]map[string]any{
-			{
-				"id":     1,
-				"active": true,
-				"events": []string{"issues"},
-				"config": map[string]any{"url": "https://example.com/a"},
-			},
-			{
-				"id":     2,
-				"active": true,
-				"events": []string{"issues", "issue_comment"},
-				"config": map[string]any{"url": "https://example.com/b"},
-			},
-		})
-	}))
-	defer srv.Close()
-
-	client := newTestAPIClient(srv.URL)
+	client := newGitHubMockClient(t,
+		githubRoute(http.MethodGet, "/repos/owner/repo/hooks", func(w http.ResponseWriter, _ *http.Request) {
+			writeJSONResponse(t, w, http.StatusOK, []map[string]any{
+				{
+					"id":     1,
+					"active": true,
+					"events": []string{"issues"},
+					"config": map[string]any{"url": "https://example.com/a"},
+				},
+				{
+					"id":     2,
+					"active": true,
+					"events": []string{"issues", "issue_comment"},
+					"config": map[string]any{"url": "https://example.com/b"},
+				},
+			})
+		}),
+	)
 	hook, err := client.FindWebhookByURL(context.Background(), "owner/repo", "https://example.com/b")
 	if err != nil {
 		t.Fatalf("FindWebhookByURL returned error: %v", err)
@@ -92,10 +81,9 @@ func TestFindWebhookByURL(t *testing.T) {
 
 func TestDeleteWebhookByURL(t *testing.T) {
 	deleted := false
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/hooks":
-			_ = json.NewEncoder(w).Encode([]map[string]any{
+	client := newGitHubMockClient(t,
+		githubRoute(http.MethodGet, "/repos/owner/repo/hooks", func(w http.ResponseWriter, _ *http.Request) {
+			writeJSONResponse(t, w, http.StatusOK, []map[string]any{
 				{
 					"id":     22,
 					"active": true,
@@ -103,16 +91,12 @@ func TestDeleteWebhookByURL(t *testing.T) {
 					"config": map[string]any{"url": "https://example.com/hook"},
 				},
 			})
-		case r.Method == http.MethodDelete && r.URL.Path == "/repos/owner/repo/hooks/22":
+		}),
+		githubRoute(http.MethodDelete, "/repos/owner/repo/hooks/22", func(w http.ResponseWriter, _ *http.Request) {
 			deleted = true
 			w.WriteHeader(http.StatusNoContent)
-		default:
-			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	defer srv.Close()
-
-	client := newTestAPIClient(srv.URL)
+		}),
+	)
 	removed, err := client.DeleteWebhookByURL(context.Background(), "owner/repo", "https://example.com/hook")
 	if err != nil {
 		t.Fatalf("DeleteWebhookByURL returned error: %v", err)
@@ -139,25 +123,15 @@ func TestDescribeWebhookAuthFailure(t *testing.T) {
 
 func TestAddIssueReaction(t *testing.T) {
 	t.Run("posts reaction", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Method != http.MethodPost {
-				t.Fatalf("unexpected method: %s", r.Method)
-			}
-			if r.URL.Path != "/repos/owner/repo/issues/42/reactions" {
-				t.Fatalf("unexpected path: %s", r.URL.Path)
-			}
-			var in map[string]string
-			if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
-				t.Fatalf("decode request body: %v", err)
-			}
-			if in["content"] != ReactionEyes {
-				t.Fatalf("unexpected reaction payload: %v", in)
-			}
-			w.WriteHeader(http.StatusCreated)
-		}))
-		defer srv.Close()
-
-		client := newTestAPIClient(srv.URL)
+		client := newGitHubMockClient(t,
+			githubRoute(http.MethodPost, "/repos/owner/repo/issues/42/reactions", func(w http.ResponseWriter, r *http.Request) {
+				in := decodeJSONRequest[map[string]string](t, r)
+				if in["content"] != ReactionEyes {
+					t.Fatalf("unexpected reaction payload: %v", in)
+				}
+				w.WriteHeader(http.StatusCreated)
+			}),
+		)
 		if err := client.AddIssueReaction(context.Background(), "owner/repo", 42, ReactionEyes); err != nil {
 			t.Fatalf("AddIssueReaction returned error: %v", err)
 		}
@@ -172,13 +146,12 @@ func TestAddIssueReaction(t *testing.T) {
 	})
 
 	t.Run("surfaces github error", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusForbidden)
-			_, _ = io.WriteString(w, `{"message":"forbidden"}`)
-		}))
-		defer srv.Close()
-
-		client := newTestAPIClient(srv.URL)
+		client := newGitHubMockClient(t,
+			githubRoute(http.MethodPost, "/repos/owner/repo/issues/42/reactions", func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = io.WriteString(w, `{"message":"forbidden"}`)
+			}),
+		)
 		err := client.AddIssueReaction(context.Background(), "owner/repo", 42, ReactionRocket)
 		if err == nil || !strings.Contains(err.Error(), "github add issue reaction failed") {
 			t.Fatalf("expected github error, got: %v", err)
@@ -188,25 +161,15 @@ func TestAddIssueReaction(t *testing.T) {
 
 func TestAddIssueCommentReaction(t *testing.T) {
 	t.Run("posts reaction", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Method != http.MethodPost {
-				t.Fatalf("unexpected method: %s", r.Method)
-			}
-			if r.URL.Path != "/repos/owner/repo/issues/comments/123/reactions" {
-				t.Fatalf("unexpected path: %s", r.URL.Path)
-			}
-			var in map[string]string
-			if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
-				t.Fatalf("decode request body: %v", err)
-			}
-			if in["content"] != ReactionEyes {
-				t.Fatalf("unexpected reaction payload: %v", in)
-			}
-			w.WriteHeader(http.StatusCreated)
-		}))
-		defer srv.Close()
-
-		client := newTestAPIClient(srv.URL)
+		client := newGitHubMockClient(t,
+			githubRoute(http.MethodPost, "/repos/owner/repo/issues/comments/123/reactions", func(w http.ResponseWriter, r *http.Request) {
+				in := decodeJSONRequest[map[string]string](t, r)
+				if in["content"] != ReactionEyes {
+					t.Fatalf("unexpected reaction payload: %v", in)
+				}
+				w.WriteHeader(http.StatusCreated)
+			}),
+		)
 		if err := client.AddIssueCommentReaction(context.Background(), "owner/repo", 123, ReactionEyes); err != nil {
 			t.Fatalf("AddIssueCommentReaction returned error: %v", err)
 		}
@@ -223,25 +186,15 @@ func TestAddIssueCommentReaction(t *testing.T) {
 
 func TestCreateIssueComment(t *testing.T) {
 	t.Run("posts issue comment", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Method != http.MethodPost {
-				t.Fatalf("unexpected method: %s", r.Method)
-			}
-			if r.URL.Path != "/repos/owner/repo/issues/42/comments" {
-				t.Fatalf("unexpected path: %s", r.URL.Path)
-			}
-			var in map[string]string
-			if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
-				t.Fatalf("decode request body: %v", err)
-			}
-			if in["body"] != "hello from rascal" {
-				t.Fatalf("unexpected comment payload: %v", in)
-			}
-			w.WriteHeader(http.StatusCreated)
-		}))
-		defer srv.Close()
-
-		client := newTestAPIClient(srv.URL)
+		client := newGitHubMockClient(t,
+			githubRoute(http.MethodPost, "/repos/owner/repo/issues/42/comments", func(w http.ResponseWriter, r *http.Request) {
+				in := decodeJSONRequest[map[string]string](t, r)
+				if in["body"] != "hello from rascal" {
+					t.Fatalf("unexpected comment payload: %v", in)
+				}
+				w.WriteHeader(http.StatusCreated)
+			}),
+		)
 		if err := client.CreateIssueComment(context.Background(), "owner/repo", 42, "hello from rascal"); err != nil {
 			t.Fatalf("CreateIssueComment returned error: %v", err)
 		}
@@ -266,25 +219,15 @@ func TestCreateIssueComment(t *testing.T) {
 
 func TestAddPullRequestReviewReaction(t *testing.T) {
 	t.Run("posts reaction", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Method != http.MethodPost {
-				t.Fatalf("unexpected method: %s", r.Method)
-			}
-			if r.URL.Path != "/repos/owner/repo/pulls/42/reviews/999/reactions" {
-				t.Fatalf("unexpected path: %s", r.URL.Path)
-			}
-			var in map[string]string
-			if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
-				t.Fatalf("decode request body: %v", err)
-			}
-			if in["content"] != ReactionEyes {
-				t.Fatalf("unexpected reaction payload: %v", in)
-			}
-			w.WriteHeader(http.StatusCreated)
-		}))
-		defer srv.Close()
-
-		client := newTestAPIClient(srv.URL)
+		client := newGitHubMockClient(t,
+			githubRoute(http.MethodPost, "/repos/owner/repo/pulls/42/reviews/999/reactions", func(w http.ResponseWriter, r *http.Request) {
+				in := decodeJSONRequest[map[string]string](t, r)
+				if in["content"] != ReactionEyes {
+					t.Fatalf("unexpected reaction payload: %v", in)
+				}
+				w.WriteHeader(http.StatusCreated)
+			}),
+		)
 		if err := client.AddPullRequestReviewReaction(context.Background(), "owner/repo", 42, 999, ReactionEyes); err != nil {
 			t.Fatalf("AddPullRequestReviewReaction returned error: %v", err)
 		}
@@ -305,25 +248,15 @@ func TestAddPullRequestReviewReaction(t *testing.T) {
 
 func TestAddPullRequestReviewCommentReaction(t *testing.T) {
 	t.Run("posts reaction", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Method != http.MethodPost {
-				t.Fatalf("unexpected method: %s", r.Method)
-			}
-			if r.URL.Path != "/repos/owner/repo/pulls/comments/777/reactions" {
-				t.Fatalf("unexpected path: %s", r.URL.Path)
-			}
-			var in map[string]string
-			if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
-				t.Fatalf("decode request body: %v", err)
-			}
-			if in["content"] != ReactionEyes {
-				t.Fatalf("unexpected reaction payload: %v", in)
-			}
-			w.WriteHeader(http.StatusCreated)
-		}))
-		defer srv.Close()
-
-		client := newTestAPIClient(srv.URL)
+		client := newGitHubMockClient(t,
+			githubRoute(http.MethodPost, "/repos/owner/repo/pulls/comments/777/reactions", func(w http.ResponseWriter, r *http.Request) {
+				in := decodeJSONRequest[map[string]string](t, r)
+				if in["content"] != ReactionEyes {
+					t.Fatalf("unexpected reaction payload: %v", in)
+				}
+				w.WriteHeader(http.StatusCreated)
+			}),
+		)
 		if err := client.AddPullRequestReviewCommentReaction(context.Background(), "owner/repo", 777, ReactionEyes); err != nil {
 			t.Fatalf("AddPullRequestReviewCommentReaction returned error: %v", err)
 		}
@@ -341,27 +274,20 @@ func TestAddPullRequestReviewCommentReaction(t *testing.T) {
 func TestUpsertWebhookDefaultEventsIncludeReviewComment(t *testing.T) {
 	var receivedEvents []string
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/hooks":
-			_ = json.NewEncoder(w).Encode([]map[string]any{})
-		case r.Method == http.MethodPost && r.URL.Path == "/repos/owner/repo/hooks":
-			var payload struct {
+	client := newGitHubMockClient(t,
+		githubRoute(http.MethodGet, "/repos/owner/repo/hooks", func(w http.ResponseWriter, _ *http.Request) {
+			writeJSONResponse(t, w, http.StatusOK, []map[string]any{})
+		}),
+		githubRoute(http.MethodPost, "/repos/owner/repo/hooks", func(w http.ResponseWriter, r *http.Request) {
+			payload := decodeJSONRequest[struct {
 				Events []string `json:"events"`
-			}
-			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-				t.Fatalf("decode request body: %v", err)
-			}
+			}](t, r)
 			receivedEvents = append(receivedEvents, payload.Events...)
 			w.WriteHeader(http.StatusCreated)
 			_, _ = io.WriteString(w, `{"id":1}`)
-		default:
-			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	defer srv.Close()
+		}),
+	)
 
-	client := newTestAPIClient(srv.URL)
 	if err := client.UpsertWebhook(context.Background(), "owner/repo", "https://example.com/hook", "secret", nil); err != nil {
 		t.Fatalf("UpsertWebhook returned error: %v", err)
 	}

--- a/internal/github/client_test_helpers_test.go
+++ b/internal/github/client_test_helpers_test.go
@@ -1,0 +1,72 @@
+package github
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type githubAPIRoute struct {
+	method  string
+	path    string
+	handler http.HandlerFunc
+}
+
+func githubRoute(method, path string, handler http.HandlerFunc) githubAPIRoute {
+	return githubAPIRoute{
+		method:  method,
+		path:    path,
+		handler: handler,
+	}
+}
+
+func newGitHubMockClient(t *testing.T, routes ...githubAPIRoute) *APIClient {
+	t.Helper()
+
+	handlers := make(map[string]http.HandlerFunc, len(routes))
+	for _, route := range routes {
+		if route.method == "" || route.path == "" {
+			t.Fatal("mock github route must include method and path")
+		}
+		if route.handler == nil {
+			t.Fatalf("mock github route handler is required for %s %s", route.method, route.path)
+		}
+		key := route.method + " " + route.path
+		if _, exists := handlers[key]; exists {
+			t.Fatalf("duplicate mock github route: %s", key)
+		}
+		handlers[key] = route.handler
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.Method + " " + r.URL.Path
+		handler, ok := handlers[key]
+		if !ok {
+			t.Fatalf("unexpected request: %s", key)
+		}
+		handler(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	return newTestAPIClient(srv.URL)
+}
+
+func decodeJSONRequest[T any](t *testing.T, r *http.Request) T {
+	t.Helper()
+
+	var in T
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		t.Fatalf("decode request body: %v", err)
+	}
+	return in
+}
+
+func writeJSONResponse(t *testing.T, w http.ResponseWriter, status int, payload any) {
+	t.Helper()
+
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		t.Fatalf("encode response body: %v", err)
+	}
+}


### PR DESCRIPTION
Reduce GitHub client HTTP test boilerplate by introducing route-based mock server helpers and shared JSON encode/decode helpers, then migrate client HTTP tests to the new patterns while preserving assertions and behavior.

<details><summary>Goose Details</summary>

```

    __( O)>  ● new session · codex gpt-5.4
   \____)    20260307_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: "/usr/local/bin/codex"
Model: gpt-5.4
Reasoning effort: high
Skip git check: false
Prompt length: 1751 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Suggestion

The user has 7 extensions with 16 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
Consider asking if they'd like to disable some extensions to improve tool selection accuracy.

# Response Guidelines

Use Markdown formatting for all responses.

Human: <info-msg>
It is currently 2026-03-07 08:22:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

</info-msg>
# Rascal Run Instructions

Run ID: run_ec41a32762d13400
Task ID: rtzll/rascal#21
Repository: rtzll/rascal
Issue: #21

## Task

refactor(test): add reusable GitHub API test helpers

## Goal
Reduce test boilerplate for GitHub client HTTP tests.

## Scope
- Add reusable test helpers for mock GitHub API handlers/servers.
- Migrate existing tests to helper patterns where it improves clarity.
- Keep test readability high.

## Acceptance Criteria
- Existing test cases remain covered.
- Net line count in tests ideally decreases without losing clarity.
- No behavior regressions in tests.
- `go test ./...` passes.

## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run tests or explain why tests could not run.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label 'rascal' on issue #21


Assistant: 
Image files: 0
============================
{"type":"message","message":{"id":null,"role":"assistant","created":1772872264,"content":[{"type":"text","text":"I’m implementing issue `#21` by introducing reusable GitHub API test helpers and then migrating current HTTP tests to use them with minimal scope. I’ll first scan the existing GitHub client tests to identify repeated mock server/handler patterns and capture all requirements in a concrete plan.\n\nI found the GitHub test files; next I’m reading `internal/github/client_test.go` in detail to extract repeated HTTP mock patterns and shape the helper API around current usage.\n\nI’ve confirmed the main boilerplate is in `internal/github/client_test.go` (server setup/teardown and method+path assertions). I’m going to add a small helper layer in the same package (`newMockGitHubClient` + route matcher helpers) and refactor selected tests that benefit most, keeping behavior unchanged.\n\nI have enough context and I’m starting edits now. I’ll add a dedicated test helper file under `internal/github` for route-based mock API servers, then convert `client_test.go` HTTP cases to use it so repeated `httptest.NewServer` scaffolding is removed.\n\nI’ve added the helper file and started migrating tests to route-based mock clients. Next I’m converting the remaining HTTP tests in `client_test.go` and then running `go test ./...` to confirm no behavior regressions.\n\nThe route helper conversion is working cleanly; I’m now replacing the repeated JSON decode/assert blocks with `decodeJSONRequest` in the reaction/comment tests to cut duplication without hiding assertions.\n\nI’ve finished the refactor pass in `internal/github/client_test.go` and introduced a new helper file for reusable mock GitHub API routing and JSON helpers. I’m running the full test suite now (`go test ./...`) to validate there are no regressions.\n\nDependencies are still building, and the full test run is in progress. I’m polling until completion and will report exact pass/fail status.\n\n`internal/github` tests are passing, but `go test ./...` failed in unrelated packages (`cmd/rascal-runner`, `cmd/rascald`) with pre-existing config/timing issues. I’ll verify the touched package explicitly and then finalize with a clear note about the broader suite failures.\n\nI’ve written the required commit message file at `/rascal-meta/commit_message.txt`. I’m doing a final diff/stat check now so I can summarize exactly what changed and what test scope passed versus failed.\n\nI’m at final validation: changes are complete, package-level tests for the touched area pass, and metadata is written. I’ll now provide a concise summary with file references and the exact reason `go test ./...` did not fully pass in this environment.\n\nBefore I wrap up, I’m quickly re-running the two failing tests directly to confirm the full-suite failures are outside the GitHub client test refactor.\n\nImplemented a scoped refactor for GitHub client HTTP tests with reusable mock helpers.\n\n**Changes**\n- Added reusable GitHub API test helpers in [client_test_helpers_test.go](/work/repo/internal/github/client_test_helpers_test.go#L1):\n  - `githubRoute(...)`\n  - `newGitHubMockClient(...)` (route-based mock server/client wiring)\n  - `decodeJSONRequest[...]`\n  - `writeJSONResponse(...)`\n- Migrated `internal/github` HTTP tests to use helpers in [client_test.go](/work/repo/internal/github/client_test.go#L19), including:\n  - `TestLabelExists`\n  - `TestFindWebhookByURL`\n  - `TestDeleteWebhookByURL`\n  - reaction/comment HTTP tests\n  - `TestUpsertWebhookDefaultEventsIncludeReviewComment`\n- Kept behavior/assertions intact while removing duplicated server setup/teardown and request decoding.\n- Test LOC impact in scope: `382 -> 380` total lines across moved helper + refactored test code (net `-2`).\n\n**Validation**\n- `go test ./internal/github -count=1` passed.\n- `go test ./...` failed due unrelated existing tests:\n  - `cmd/rascal-runner`: `TestLoadConfig` (default head branch expectation mismatch)\n  - `cmd/rascald`: `TestCanceledRunDoesNotTransitionToSuccess` (timeout waiting for server idle)\n- Re-ran both failing tests directly; both still fail independently.\n\n**Required metadata**\n- Wrote commit message file: [/rascal-meta/commit_message.txt](/rascal-meta/commit_message.txt)\n\nNo listed AGENTS skill was used; available skills were for skill creation/installation and not applicable to this refactor."}],"metadata":{"userVisible":true,"agentVisible":true}}}
{"type":"complete","total_tokens":1193347}

```

</details>

Closes #21

---

Rascal run `run_ec41a32762d13400` completed in 8m 20s · 1.19M tokens