### PR TITLE
refactor(cli): extract shared issue-ref parser utility

### DIFF
--- a/cmd/rascal/main.go
+++ b/cmd/rascal/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pelletier/go-toml/v2"
 	"github.com/rtzll/rascal/internal/config"
 	deployengine "github.com/rtzll/rascal/internal/deploy"
+	"github.com/rtzll/rascal/internal/issueref"
 	"github.com/rtzll/rascal/internal/state"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -896,13 +897,13 @@ rascal run --issue OWNER/REPO#123
 				if cmd.Flags().Changed("repo") || cmd.Flags().Changed("task") || cmd.Flags().Changed("base-branch") {
 					return &cliError{Code: exitInput, Message: "--issue cannot be combined with --repo, --task, or --base-branch"}
 				}
-				repo, issueNumber, err := parseIssueRef(issueRef)
+				parsedIssue, err := issueref.Parse(issueRef)
 				if err != nil {
 					return &cliError{Code: exitInput, Message: err.Error()}
 				}
 				payload := map[string]any{
-					"repo":         repo,
-					"issue_number": issueNumber,
+					"repo":         parsedIssue.Repo,
+					"issue_number": parsedIssue.Number,
 				}
 				if cmd.Flags().Changed("debug") {
 					payload["debug"] = debug
@@ -2594,22 +2595,6 @@ func filterLogsSince(input string, since time.Time) string {
 		out = append(out, line)
 	}
 	return strings.Join(out, "\n")
-}
-
-func parseIssueRef(input string) (string, int, error) {
-	parts := strings.Split(input, "#")
-	if len(parts) != 2 {
-		return "", 0, fmt.Errorf("invalid issue ref %q, expected OWNER/REPO#123", input)
-	}
-	repo := strings.TrimSpace(parts[0])
-	var issue int
-	if _, err := fmt.Sscanf(parts[1], "%d", &issue); err != nil || issue <= 0 {
-		return "", 0, fmt.Errorf("invalid issue number in %q", input)
-	}
-	if repo == "" {
-		return "", 0, fmt.Errorf("invalid repo in %q", input)
-	}
-	return repo, issue, nil
 }
 
 func (c apiClient) doJSON(method, path string, payload any) (*http.Response, error) {

--- a/cmd/rascald/main.go
+++ b/cmd/rascald/main.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/rtzll/rascal/internal/config"
 	ghapi "github.com/rtzll/rascal/internal/github"
+	"github.com/rtzll/rascal/internal/issueref"
 	"github.com/rtzll/rascal/internal/logs"
 	"github.com/rtzll/rascal/internal/runner"
 	"github.com/rtzll/rascal/internal/runsummary"
@@ -366,17 +367,17 @@ func (s *server) handleCreateIssueTask(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid JSON body", http.StatusBadRequest)
 		return
 	}
-	req.Repo = strings.TrimSpace(req.Repo)
-	if req.Repo == "" || req.IssueNumber <= 0 {
-		http.Error(w, "repo and issue_number are required", http.StatusBadRequest)
+	issueRef, err := issueref.Normalize(req.Repo, req.IssueNumber)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	taskID := fmt.Sprintf("%s#%d", req.Repo, req.IssueNumber)
-	taskText := fmt.Sprintf("Work on issue #%d in %s", req.IssueNumber, req.Repo)
+	taskID := issueRef.String()
+	taskText := fmt.Sprintf("Work on issue #%d in %s", issueRef.Number, issueRef.Repo)
 	ctxText := ""
 	if strings.TrimSpace(s.cfg.GitHubToken) != "" {
-		issue, err := s.gh.GetIssue(r.Context(), req.Repo, req.IssueNumber)
+		issue, err := s.gh.GetIssue(r.Context(), issueRef.Repo, issueRef.Number)
 		if err != nil {
 			http.Error(w, "failed to fetch issue: "+err.Error(), http.StatusBadGateway)
 			return
@@ -387,10 +388,10 @@ func (s *server) handleCreateIssueTask(w http.ResponseWriter, r *http.Request) {
 
 	run, err := s.createAndQueueRun(runRequest{
 		TaskID:      taskID,
-		Repo:        req.Repo,
+		Repo:        issueRef.Repo,
 		Task:        taskText,
 		Trigger:     "issue_api",
-		IssueNumber: req.IssueNumber,
+		IssueNumber: issueRef.Number,
 		Context:     ctxText,
 		Debug:       req.Debug,
 	})
@@ -512,14 +513,17 @@ func (s *server) processWebhookEvent(ctx context.Context, eventType string, payl
 			if !strings.EqualFold(ev.Label.Name, "rascal") {
 				return nil
 			}
-			taskID := fmt.Sprintf("%s#%d", ev.Repository.FullName, ev.Issue.Number)
-			_, err := s.createAndQueueRun(runRequest{
-				TaskID:      taskID,
-				Repo:        ev.Repository.FullName,
+			issueRef, err := issueref.Normalize(ev.Repository.FullName, ev.Issue.Number)
+			if err != nil {
+				return err
+			}
+			_, err = s.createAndQueueRun(runRequest{
+				TaskID:      issueRef.String(),
+				Repo:        issueRef.Repo,
 				Task:        issueTaskFromIssue(ev.Issue.Title, ev.Issue.Body),
 				Trigger:     "issue_label",
-				IssueNumber: ev.Issue.Number,
-				Context:     fmt.Sprintf("Triggered by label 'rascal' on issue #%d", ev.Issue.Number),
+				IssueNumber: issueRef.Number,
+				Context:     fmt.Sprintf("Triggered by label 'rascal' on issue #%d", issueRef.Number),
 				Debug:       boolPtr(true),
 			})
 			if errors.Is(err, errTaskCompleted) {
@@ -530,23 +534,31 @@ func (s *server) processWebhookEvent(ctx context.Context, eventType string, payl
 			if !strings.EqualFold(ev.Label.Name, "rascal") {
 				return nil
 			}
-			s.removeIssueReactionsBestEffort(ev.Repository.FullName, ev.Issue.Number)
+			issueRef, err := issueref.Normalize(ev.Repository.FullName, ev.Issue.Number)
+			if err != nil {
+				return err
+			}
+			s.removeIssueReactionsBestEffort(issueRef.Repo, issueRef.Number)
 			return nil
 		case "edited":
 			if !issueHasLabel(ev.Issue.Labels, "rascal") {
 				return nil
 			}
-			taskID := fmt.Sprintf("%s#%d", ev.Repository.FullName, ev.Issue.Number)
+			issueRef, err := issueref.Normalize(ev.Repository.FullName, ev.Issue.Number)
+			if err != nil {
+				return err
+			}
+			taskID := issueRef.String()
 			if err := s.store.CancelQueuedRuns(taskID, "issue edited"); err != nil {
 				return err
 			}
-			_, err := s.createAndQueueRun(runRequest{
+			_, err = s.createAndQueueRun(runRequest{
 				TaskID:      taskID,
-				Repo:        ev.Repository.FullName,
+				Repo:        issueRef.Repo,
 				Task:        issueTaskFromIssue(ev.Issue.Title, ev.Issue.Body),
 				Trigger:     "issue_edited",
-				IssueNumber: ev.Issue.Number,
-				Context:     fmt.Sprintf("Triggered by issue edit on issue #%d", ev.Issue.Number),
+				IssueNumber: issueRef.Number,
+				Context:     fmt.Sprintf("Triggered by issue edit on issue #%d", issueRef.Number),
 				Debug:       boolPtr(true),
 			})
 			if errors.Is(err, errTaskCompleted) {
@@ -557,11 +569,15 @@ func (s *server) processWebhookEvent(ctx context.Context, eventType string, payl
 			if !issueHasLabel(ev.Issue.Labels, "rascal") {
 				return nil
 			}
-			taskID := fmt.Sprintf("%s#%d", ev.Repository.FullName, ev.Issue.Number)
+			issueRef, err := issueref.Normalize(ev.Repository.FullName, ev.Issue.Number)
+			if err != nil {
+				return err
+			}
+			taskID := issueRef.String()
 			if _, err := s.store.UpsertTask(state.UpsertTaskInput{
 				ID:          taskID,
-				Repo:        ev.Repository.FullName,
-				IssueNumber: ev.Issue.Number,
+				Repo:        issueRef.Repo,
+				IssueNumber: issueRef.Number,
 			}); err != nil {
 				return err
 			}
@@ -577,25 +593,29 @@ func (s *server) processWebhookEvent(ctx context.Context, eventType string, payl
 			if !issueHasLabel(ev.Issue.Labels, "rascal") {
 				return nil
 			}
-			taskID := fmt.Sprintf("%s#%d", ev.Repository.FullName, ev.Issue.Number)
+			issueRef, err := issueref.Normalize(ev.Repository.FullName, ev.Issue.Number)
+			if err != nil {
+				return err
+			}
+			taskID := issueRef.String()
 			if _, err := s.store.UpsertTask(state.UpsertTaskInput{
 				ID:          taskID,
-				Repo:        ev.Repository.FullName,
-				IssueNumber: ev.Issue.Number,
+				Repo:        issueRef.Repo,
+				IssueNumber: issueRef.Number,
 			}); err != nil {
 				return err
 			}
 			if err := s.store.MarkTaskOpen(taskID); err != nil {
 				return err
 			}
-			_, err := s.createAndQueueRun(runRequest{
+			_, err = s.createAndQueueRun(runRequest{
 				TaskID:      taskID,
-				Repo:        ev.Repository.FullName,
+				Repo:        issueRef.Repo,
 				Task:        issueTaskFromIssue(ev.Issue.Title, ev.Issue.Body),
 				Trigger:     "issue_reopened",
-				IssueNumber: ev.Issue.Number,
+				IssueNumber: issueRef.Number,
 				PRStatus:    state.PRStatusNone,
-				Context:     fmt.Sprintf("Triggered by issue reopen on issue #%d", ev.Issue.Number),
+				Context:     fmt.Sprintf("Triggered by issue reopen on issue #%d", issueRef.Number),
 				Debug:       boolPtr(true),
 			})
 			if errors.Is(err, errTaskCompleted) {

--- a/internal/issueref/issueref.go
+++ b/internal/issueref/issueref.go
@@ -1,0 +1,68 @@
+package issueref
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type Ref struct {
+	Repo   string
+	Number int
+}
+
+func (r Ref) String() string {
+	return fmt.Sprintf("%s#%d", r.Repo, r.Number)
+}
+
+func Parse(input string) (Ref, error) {
+	raw := strings.TrimSpace(input)
+	if strings.Count(raw, "#") != 1 {
+		return Ref{}, invalidIssueRef(raw, "expected OWNER/REPO#123")
+	}
+	parts := strings.SplitN(raw, "#", 2)
+	repo := normalizeRepo(parts[0])
+	if !isValidRepo(repo) {
+		return Ref{}, invalidIssueRef(raw, "repo must be OWNER/REPO")
+	}
+	number, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err != nil || number <= 0 {
+		return Ref{}, invalidIssueRef(raw, "issue number must be a positive integer")
+	}
+	return Ref{Repo: repo, Number: number}, nil
+}
+
+func Normalize(repo string, number int) (Ref, error) {
+	repo = normalizeRepo(repo)
+	if !isValidRepo(repo) {
+		return Ref{}, invalidIssueRef(fmt.Sprintf("%s#%d", strings.TrimSpace(repo), number), "repo must be OWNER/REPO")
+	}
+	if number <= 0 {
+		return Ref{}, invalidIssueRef(fmt.Sprintf("%s#%d", repo, number), "issue number must be a positive integer")
+	}
+	return Ref{Repo: repo, Number: number}, nil
+}
+
+func normalizeRepo(repo string) string {
+	return strings.ToLower(strings.TrimSpace(repo))
+}
+
+func isValidRepo(repo string) bool {
+	if strings.Count(repo, "/") != 1 {
+		return false
+	}
+	parts := strings.SplitN(repo, "/", 2)
+	for _, part := range parts {
+		if strings.TrimSpace(part) == "" {
+			return false
+		}
+		if strings.ContainsAny(part, " \t\r\n") {
+			return false
+		}
+	}
+	return true
+}
+
+func invalidIssueRef(input, reason string) error {
+	return fmt.Errorf("invalid issue ref %q: %s", input, reason)
+}

--- a/internal/issueref/issueref_test.go
+++ b/internal/issueref/issueref_test.go
@@ -1,0 +1,132 @@
+package issueref
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		wantRepo string
+		wantNum  int
+		wantErr  string
+	}{
+		{
+			name:     "valid",
+			input:    "owner/repo#123",
+			wantRepo: "owner/repo",
+			wantNum:  123,
+		},
+		{
+			name:     "valid trims and normalizes case",
+			input:    " Owner/Repo # 42 ",
+			wantRepo: "owner/repo",
+			wantNum:  42,
+		},
+		{
+			name:    "missing hash",
+			input:   "owner/repo",
+			wantErr: "expected OWNER/REPO#123",
+		},
+		{
+			name:    "extra hash",
+			input:   "owner/repo#1#2",
+			wantErr: "expected OWNER/REPO#123",
+		},
+		{
+			name:    "invalid repo",
+			input:   "owner/repo/extra#1",
+			wantErr: "repo must be OWNER/REPO",
+		},
+		{
+			name:    "empty repo",
+			input:   "#1",
+			wantErr: "repo must be OWNER/REPO",
+		},
+		{
+			name:    "non numeric issue",
+			input:   "owner/repo#abc",
+			wantErr: "issue number must be a positive integer",
+		},
+		{
+			name:    "trailing chars in issue",
+			input:   "owner/repo#12abc",
+			wantErr: "issue number must be a positive integer",
+		},
+		{
+			name:    "zero issue",
+			input:   "owner/repo#0",
+			wantErr: "issue number must be a positive integer",
+		},
+		{
+			name:    "negative issue",
+			input:   "owner/repo#-1",
+			wantErr: "issue number must be a positive integer",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := Parse(tt.input)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("Parse(%q) expected error containing %q", tt.input, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("Parse(%q) error %q, want substring %q", tt.input, err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Parse(%q) returned error: %v", tt.input, err)
+			}
+			if got.Repo != tt.wantRepo || got.Number != tt.wantNum {
+				t.Fatalf("Parse(%q) = %#v, want repo=%q number=%d", tt.input, got, tt.wantRepo, tt.wantNum)
+			}
+		})
+	}
+}
+
+func TestNormalize(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := Normalize(" Owner/Repo ", 7)
+		if err != nil {
+			t.Fatalf("Normalize returned error: %v", err)
+		}
+		if got.Repo != "owner/repo" || got.Number != 7 {
+			t.Fatalf("Normalize = %#v, want repo owner/repo and number 7", got)
+		}
+		if got.String() != "owner/repo#7" {
+			t.Fatalf("String() = %q, want owner/repo#7", got.String())
+		}
+	})
+
+	t.Run("invalid repo", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := Normalize("owner/repo/extra", 7)
+		if err == nil || !strings.Contains(err.Error(), "repo must be OWNER/REPO") {
+			t.Fatalf("expected repo validation error, got: %v", err)
+		}
+	})
+
+	t.Run("invalid issue number", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := Normalize("owner/repo", 0)
+		if err == nil || !strings.Contains(err.Error(), "issue number must be a positive integer") {
+			t.Fatalf("expected issue number validation error, got: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
- add internal issueref parser/normalizer for OWNER/REPO#N refs with standardized validation errors
- reuse shared issue-ref utility in rascal run --issue parsing and rascald issue-related handlers
- remove ad-hoc parser logic and add unit tests for valid/invalid edge cases

<details><summary>Goose Details</summary>

```

    __( O)>  ● new session · codex gpt-5.4
   \____)    20260307_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: "/usr/local/bin/codex"
Model: gpt-5.4
Reasoning effort: high
Skip git check: false
Prompt length: 1767 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Suggestion

The user has 7 extensions with 16 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
Consider asking if they'd like to disable some extensions to improve tool selection accuracy.

# Response Guidelines

Use Markdown formatting for all responses.

Human: <info-msg>
It is currently 2026-03-07 09:53:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

</info-msg>
# Rascal Run Instructions

Run ID: run_ada13d04a70c9ced
Task ID: rtzll/rascal#22
Repository: rtzll/rascal
Issue: #22

## Task

refactor(cli): extract shared issue-ref parser utility

## Goal
Have one canonical implementation for parsing/normalizing issue refs (`OWNER/REPO#N`).

## Scope
- Extract issue-ref parser utility used by relevant CLI commands.
- Standardize validation errors and normalization.
- Reuse across command handlers.

## Acceptance Criteria
- Parsing behavior is consistent across commands.
- Duplicate parser logic removed.
- Unit tests cover valid/invalid inputs and edge cases.
- `go test ./...` passes.

## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run tests or explain why tests could not run.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label 'rascal' on issue #22


Assistant: 
Image files: 0
============================
{"type":"message","message":{"id":null,"role":"assistant","created":1772877791,"content":[{"type":"text","text":"I’m going to inspect the CLI codepaths that parse issue references, identify duplicated logic, and then extract a shared parser with consistent normalization/errors. I’ll update the task plan now with all requirements and then start locating the current implementations.\n\nI found one parser in `cmd/rascal/main.go` and at least one other ad-hoc parse path in `cmd/rascal-runner/main.go`. Next I’m reading those exact functions and tests to design a single shared utility with matching error messages.\n\nI confirmed only one explicit `parseIssueRef` function in `cmd/rascal`, but there’s also separate parsing of issue identifiers from `task_id` in the runner path. I’m now checking those codepaths to decide what should be unified under one canonical parser without widening scope.\n\nI’m drilling into `cmd/rascald` too, because there are task-ID parsing helpers that may duplicate issue-ref behavior. If they parse `OWNER/REPO#N` separately, I’ll fold them into the same shared utility as part of this refactor.\n\nI have enough context to implement: I’ll add a new `internal/issueref` package with canonical parse/normalize logic and standardized error messages, then switch `cmd/rascal` and issue-related handlers in `cmd/rascald` to use it. After that I’ll add focused unit tests for valid/invalid edge cases and run `go test ./...`.\n\nI’ve added the shared parser package and I’m now wiring it into `rascal`/`rascald`, then I’ll add table-driven tests for edge cases (including malformed refs and non-numeric issue numbers).\n\nI’ve finished the refactor wiring and test additions; next I’m running the full Go test suite to verify behavior and catch any integration regressions.\n\nThe full test run is still in progress; I’m waiting for completion and will report any failures with targeted fixes if needed.\n\nI hit a compile error in `cmd/rascald` from short variable redeclarations in a few switch cases. I’m applying a small fix (`:=` to `=` where appropriate) and re-running the full test suite.\n\nI’ve verified all tests pass now. I’m doing a final diff check and then writing `/rascal-meta/commit_message.txt` with a conventional commit title matching this refactor.\n\nImplemented the refactor with a single canonical issue-ref utility and reused it across CLI handlers.\n\n- Added shared parser/normalizer: [internal/issueref/issueref.go](/work/repo/internal/issueref/issueref.go)\n- Added unit tests for valid/invalid/edge cases: [internal/issueref/issueref_test.go](/work/repo/internal/issueref/issueref_test.go)\n- Switched `rascal run --issue` to shared parser and removed local duplicate parser: [cmd/rascal/main.go](/work/repo/cmd/rascal/main.go)\n- Reused shared normalization in issue-related server handlers (`/v1/tasks/issue` + `issues` webhook actions) for consistent task ID construction and validation: [cmd/rascald/main.go](/work/repo/cmd/rascald/main.go)\n- Wrote commit message file: [/rascal-meta/commit_message.txt](/rascal-meta/commit_message.txt)\n\nValidation:\n- Ran `go test ./...` successfully."}],"metadata":{"userVisible":true,"agentVisible":true}}}
{"type":"complete","total_tokens":2634167}

```

</details>

Closes #22

---

Rascal run `run_ada13d04a70c9ced` completed in 9m 53s · 2.63M tokens