### PR TITLE
chore(deploy): drop legacy single-unit rascal service compatibility

### DIFF
--- a/cmd/rascal/doctor_remote.go
+++ b/cmd/rascal/doctor_remote.go
@@ -36,13 +36,13 @@ func runRemoteDoctor(cfg deployConfig) (remoteDoctorStatus, error) {
 		return strings.TrimSpace(out) == "ok"
 	}
 
-	status.RascalService = check("if systemctl is-active --quiet 'rascal@blue' || systemctl is-active --quiet 'rascal@green' || systemctl is-active --quiet rascal; then echo ok; fi")
+	status.RascalService = check("if systemctl is-active --quiet 'rascal@blue' || systemctl is-active --quiet 'rascal@green'; then echo ok; fi")
 	activeSlot, _ := runLocalCapture("ssh", sshArgs(cfg, strings.Join([]string{
 		"set -eu",
 		"slot=''",
 		"if [ -f /etc/rascal/active_slot ]; then slot=$(tr -d '[:space:]' </etc/rascal/active_slot); fi",
 		"case \"$slot\" in blue|green) echo \"$slot\" ;;",
-		"*) if systemctl is-active --quiet 'rascal@blue'; then echo blue; elif systemctl is-active --quiet 'rascal@green'; then echo green; elif systemctl is-active --quiet rascal; then echo legacy; fi ;; esac",
+		"*) if systemctl is-active --quiet 'rascal@blue'; then echo blue; elif systemctl is-active --quiet 'rascal@green'; then echo green; fi ;; esac",
 	}, "\n"))...)
 	status.ActiveSlot = strings.TrimSpace(activeSlot)
 	status.DockerInstalled = check("command -v docker >/dev/null 2>&1 && echo ok")
@@ -55,9 +55,9 @@ func runRemoteDoctor(cfg deployConfig) (remoteDoctorStatus, error) {
 		"slot=''",
 		"if [ -f /etc/rascal/active_slot ]; then slot=$(tr -d '[:space:]' </etc/rascal/active_slot); fi",
 		"case \"$slot\" in blue|green) ;;",
-		"*) if systemctl is-active --quiet 'rascal@blue'; then slot=blue; elif systemctl is-active --quiet 'rascal@green'; then slot=green; elif systemctl is-active --quiet rascal; then slot=legacy; else slot=''; fi ;; esac",
+		"*) if systemctl is-active --quiet 'rascal@blue'; then slot=blue; elif systemctl is-active --quiet 'rascal@green'; then slot=green; else slot=''; fi ;; esac",
 		`[ -n "$slot" ]`,
-		`if [ "$slot" = "legacy" ]; then svc_ts=$(systemctl show rascal -p ExecMainStartTimestamp --value 2>/dev/null || true); else svc_ts=$(systemctl show "rascal@$slot" -p ExecMainStartTimestamp --value 2>/dev/null || true); fi`,
+		`svc_ts=$(systemctl show "rascal@$slot" -p ExecMainStartTimestamp --value 2>/dev/null || true)`,
 		`[ -n "$svc_ts" ]`,
 		`svc_epoch=$(date -d "$svc_ts" +%s 2>/dev/null || echo 0)`,
 		`[ "$svc_epoch" -ge "$env_epoch" ]`,
@@ -145,7 +145,7 @@ func checkServerHealthSSH(cfg deployConfig) (bool, string) {
 		"      exit 0",
 		"    fi",
 		"  fi",
-		"if systemctl is-active --quiet 'rascal@blue' || systemctl is-active --quiet 'rascal@green' || systemctl is-active --quiet rascal; then",
+		"if systemctl is-active --quiet 'rascal@blue' || systemctl is-active --quiet 'rascal@green'; then",
 		"  echo ok",
 		"  exit 0",
 		"fi",

--- a/cmd/rascal/doctor_remote_test.go
+++ b/cmd/rascal/doctor_remote_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestRunRemoteDoctorUsesSlotUnitsOnly(t *testing.T) {
+	logDir := setupDoctorRemoteFakes(t)
+
+	status, err := runRemoteDoctor(deployConfig{
+		Host:    "example-host",
+		SSHUser: "root",
+		SSHPort: 22,
+	})
+	if err != nil {
+		t.Fatalf("runRemoteDoctor: %v", err)
+	}
+	if !status.RascalService {
+		t.Fatal("expected rascal service check to pass")
+	}
+	if status.ActiveSlot != "blue" {
+		t.Fatalf("active slot = %q, want blue", status.ActiveSlot)
+	}
+	if !status.AuthRuntimeSynced {
+		t.Fatal("expected auth runtime sync check to pass")
+	}
+
+	sshLog, err := os.ReadFile(filepath.Join(logDir, "ssh_calls.log"))
+	if err != nil {
+		t.Fatalf("read ssh log: %v", err)
+	}
+	sshCalls := string(sshLog)
+	if !strings.Contains(sshCalls, "systemctl is-active --quiet 'rascal@blue'") {
+		t.Fatalf("expected slot unit checks in doctor commands, got:\n%s", sshCalls)
+	}
+	if containsLegacySingleUnitRef(sshCalls) {
+		t.Fatalf("unexpected legacy single-unit command in doctor calls:\n%s", sshCalls)
+	}
+}
+
+func TestCheckServerHealthSSHUsesSlotUnitsOnly(t *testing.T) {
+	logDir := setupDoctorRemoteFakes(t)
+
+	ok, errText := checkServerHealthSSH(deployConfig{
+		Host:    "example-host",
+		SSHUser: "root",
+		SSHPort: 22,
+	})
+	if !ok {
+		t.Fatalf("expected remote ssh health check to pass, got err=%q", errText)
+	}
+
+	sshLog, err := os.ReadFile(filepath.Join(logDir, "ssh_calls.log"))
+	if err != nil {
+		t.Fatalf("read ssh log: %v", err)
+	}
+	sshCalls := string(sshLog)
+	if !strings.Contains(sshCalls, "systemctl is-active --quiet 'rascal@green'") {
+		t.Fatalf("expected slot unit fallback in ssh health check, got:\n%s", sshCalls)
+	}
+	if containsLegacySingleUnitRef(sshCalls) {
+		t.Fatalf("unexpected legacy single-unit command in ssh health check:\n%s", sshCalls)
+	}
+}
+
+func setupDoctorRemoteFakes(t *testing.T) string {
+	t.Helper()
+
+	binDir := t.TempDir()
+	logDir := t.TempDir()
+	t.Setenv("RASCAL_DOCTOR_LOG_DIR", logDir)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	writeFakeExe(t, filepath.Join(binDir, "ssh"), `#!/usr/bin/env bash
+set -euo pipefail
+log_dir="${RASCAL_DOCTOR_LOG_DIR:?}"
+printf '%s\n' "$*" >> "$log_dir/ssh_calls.log"
+cmd="${@: -1}"
+if [[ "$cmd" == *"case \"\$slot\" in blue|green) echo \"\$slot\" ;;"* ]]; then
+  printf 'blue'
+  exit 0
+fi
+if [[ "$cmd" == *"echo ok"* ]]; then
+  printf 'ok'
+  exit 0
+fi
+exit 0
+`)
+
+	return logDir
+}
+
+func containsLegacySingleUnitRef(s string) bool {
+	legacyPattern := regexp.MustCompile(`\bsystemctl\s+(?:is-active --quiet|show|restart|stop|disable)\s+rascal(?:\s|;|$)`)
+	return legacyPattern.MatchString(s)
+}

--- a/cmd/rascal/main.go
+++ b/cmd/rascal/main.go
@@ -1118,7 +1118,7 @@ rascal logs run run_abc123 --follow --interval 4s
 	rascaldCmd := &cobra.Command{
 		Use:   "rascald",
 		Short: "Fetch rascald system logs over SSH",
-		Long:  "Stream logs from the remote `rascal`/`rascal@slot` systemd service over SSH.",
+		Long:  "Stream logs from the remote active `rascal@<slot>` systemd service over SSH.",
 		Example: strings.TrimSpace(`
 rascal logs rascald
 rascal logs rascald --follow
@@ -1345,14 +1345,11 @@ func rascaldJournalctlRemoteCmd(lines int, follow bool) string {
 		`case "$slot" in`,
 		`  blue|green) unit="rascal@$slot" ;;`,
 		`  *)`,
-		`    if systemctl is-active --quiet rascal@green; then`,
+		`    if systemctl is-active --quiet 'rascal@green'; then`,
 		`      unit=rascal@green`,
-		`    elif systemctl is-active --quiet rascal@blue; then`,
+		`    elif systemctl is-active --quiet 'rascal@blue'; then`,
 		`      unit=rascal@blue`,
-		`    elif systemctl is-active --quiet rascal; then`,
-		`      unit=rascal`,
-		`    else`,
-		`      unit=rascal@green`,
+		`    else unit=rascal@blue`,
 		`    fi`,
 		`    ;;`,
 		`esac`,
@@ -1550,14 +1547,9 @@ func (a *app) newDoctorCmd() *cobra.Command {
 				}
 				if remote != nil {
 					if synced, ok := remote["auth_runtime_synced"].(bool); ok && !synced {
-						activeSlot := strings.TrimSpace(fmt.Sprintf("%v", remote["active_slot"]))
 						targetUser := firstNonEmpty(strings.TrimSpace(sshUser), strings.TrimSpace(a.cfg.SSHUser), "root")
 						targetHost := firstNonEmpty(strings.TrimSpace(host), strings.TrimSpace(a.cfg.SSHHost), strings.TrimSpace(a.cfg.Host))
-						if activeSlot == "legacy" {
-							a.println("hint: remote rascal.env changed after service start; restart service: `ssh %s@%s 'systemctl restart rascal'`", targetUser, targetHost)
-						} else {
-							a.println("hint: remote rascal.env changed after service start; restart active slot: `ssh %s@%s 'slot=$(cat /etc/rascal/active_slot 2>/dev/null || echo blue); systemctl restart rascal@$slot'`", targetUser, targetHost)
-						}
+						a.println("hint: remote rascal.env changed after service start; restart active slot: `ssh %s@%s 'slot=$(cat /etc/rascal/active_slot 2>/dev/null || echo blue); systemctl restart rascal@$slot'`", targetUser, targetHost)
 					}
 				}
 				return nil
@@ -2684,7 +2676,7 @@ func (c apiClient) doOverSSH(method, path string, body io.Reader) (*http.Respons
 		"case \"$slot\" in",
 		fmt.Sprintf("  %s) port=%d ;;", rascalSlotBlue, rascalSlotBluePort),
 		fmt.Sprintf("  %s) port=%d ;;", rascalSlotGreen, rascalSlotGreenPort),
-		fmt.Sprintf("  *) if systemctl is-active --quiet rascal; then port=%d; else port=%d; fi ;;", rascalProxyPort, rascalSlotBluePort),
+		fmt.Sprintf("  *) if systemctl is-active --quiet 'rascal@green'; then port=%d; elif systemctl is-active --quiet 'rascal@blue'; then port=%d; else port=%d; fi ;;", rascalSlotGreenPort, rascalSlotBluePort, rascalSlotBluePort),
 		"esac",
 		"url=$(printf 'http://127.0.0.1:%s%s' \"$port\" " + shellSingleQuote(path) + ")",
 		curlCmd + " \"$url\"",
@@ -2758,7 +2750,6 @@ const (
 	rascalSlotGreen     = deployengine.SlotGreen
 	rascalSlotBluePort  = deployengine.SlotBluePort
 	rascalSlotGreenPort = deployengine.SlotGreenPort
-	rascalProxyPort     = deployengine.ProxyPort
 )
 
 func deployToExistingHost(cfg deployConfig) error {

--- a/cmd/rascal/main_slot_only_test.go
+++ b/cmd/rascal/main_slot_only_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRascaldJournalctlRemoteCmdUsesSlotUnitsOnly(t *testing.T) {
+	cmd := rascaldJournalctlRemoteCmd(120, true)
+	if !strings.Contains(cmd, `blue|green) unit="rascal@$slot"`) {
+		t.Fatalf("expected slot-based unit selection, got:\n%s", cmd)
+	}
+	if !strings.Contains(cmd, `systemctl is-active --quiet 'rascal@green'`) {
+		t.Fatalf("expected slot service fallback for green unit, got:\n%s", cmd)
+	}
+	if !strings.Contains(cmd, `systemctl is-active --quiet 'rascal@blue'`) {
+		t.Fatalf("expected slot service fallback for blue unit, got:\n%s", cmd)
+	}
+	if strings.Contains(cmd, `unit=rascal`) && !strings.Contains(cmd, `unit=rascal@`) {
+		t.Fatalf("unexpected legacy unit selection in command:\n%s", cmd)
+	}
+	if containsLegacySingleUnitRef(cmd) {
+		t.Fatalf("unexpected legacy single-unit checks in command:\n%s", cmd)
+	}
+}
+
+func TestAPIDoOverSSHUsesSlotPortsWithoutLegacySingleUnitChecks(t *testing.T) {
+	logDir := setupAPISSHFakes(t)
+
+	client := apiClient{
+		transport: "ssh",
+		sshHost:   "example-host",
+		sshUser:   "root",
+		sshPort:   22,
+	}
+	resp, err := client.doOverSSH(http.MethodGet, "/v1/healthz", nil)
+	if err != nil {
+		t.Fatalf("doOverSSH: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status code = %d, want 200", resp.StatusCode)
+	}
+
+	sshLog, err := os.ReadFile(filepath.Join(logDir, "ssh_calls.log"))
+	if err != nil {
+		t.Fatalf("read ssh log: %v", err)
+	}
+	sshCalls := string(sshLog)
+	if !strings.Contains(sshCalls, `systemctl is-active --quiet 'rascal@green'`) {
+		t.Fatalf("expected slot health fallback for green in ssh command, got:\n%s", sshCalls)
+	}
+	if !strings.Contains(sshCalls, `systemctl is-active --quiet 'rascal@blue'`) {
+		t.Fatalf("expected slot health fallback for blue in ssh command, got:\n%s", sshCalls)
+	}
+	if strings.Contains(sshCalls, "127.0.0.1:8080") {
+		t.Fatalf("unexpected proxy-port fallback in ssh API command, got:\n%s", sshCalls)
+	}
+	if containsLegacySingleUnitRef(sshCalls) {
+		t.Fatalf("unexpected legacy single-unit checks in ssh API command, got:\n%s", sshCalls)
+	}
+}
+
+func setupAPISSHFakes(t *testing.T) string {
+	t.Helper()
+
+	binDir := t.TempDir()
+	logDir := t.TempDir()
+	t.Setenv("RASCAL_API_SSH_LOG_DIR", logDir)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	writeFakeExe(t, filepath.Join(binDir, "ssh"), `#!/usr/bin/env bash
+set -euo pipefail
+log_dir="${RASCAL_API_SSH_LOG_DIR:?}"
+printf '%s\n' "$*" >> "$log_dir/ssh_calls.log"
+cat <<'EOF'
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 2
+
+{}
+EOF
+`)
+
+	return logDir
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -25,6 +25,7 @@ It also writes:
 - `rascal@blue` listens on `127.0.0.1:18080`
 - `rascal@green` listens on `127.0.0.1:18081`
 - Caddy proxies external traffic to the currently selected slot
+- Legacy single-unit `rascal` service mode is not supported
 - Slot identity is set by env:
   - `rascal@blue` gets `RASCAL_SLOT=blue`
   - `rascal@green` gets `RASCAL_SLOT=green`

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -316,11 +316,6 @@ fi
 	if err := runRemoteScript(cfg, fmt.Sprintf("set -eu\ncat >/etc/caddy/rascal-upstream.caddy <<'EOF_UPSTREAM'\nreverse_proxy 127.0.0.1:%d\nEOF_UPSTREAM\n", inactivePort)); err != nil {
 		return err
 	}
-	if strings.TrimSpace(cfg.Domain) == "" {
-		if err := runRemoteScript(cfg, "set -eu\nif systemctl is-active --quiet rascal; then systemctl stop rascal || true; systemctl disable rascal >/dev/null 2>&1 || true; fi\n"); err != nil {
-			return err
-		}
-	}
 
 	if err := runRemoteScript(cfg, "set -eu\nsystemctl enable caddy --now\nsystemctl reload caddy || systemctl restart caddy\n"); err != nil {
 		_ = rollback(cfg, activeSlot, inactiveSlot, activePort)
@@ -336,10 +331,6 @@ set -eu
 echo %s >/etc/rascal/active_slot
 sync
 sleep 3
-if systemctl is-active --quiet rascal; then
-  systemctl stop rascal || true
-  systemctl disable rascal >/dev/null 2>&1 || true
-fi
 if [ %s != %s ]; then
   systemctl stop --no-block "rascal@%s" || true
   systemctl disable "rascal@%s" >/dev/null 2>&1 || true

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -3,6 +3,7 @@ package deploy
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -176,6 +177,21 @@ func TestExecuteRollsOutRunnerBinaryBeforeImageBuild(t *testing.T) {
 	}
 	if !foundBuildScript {
 		t.Fatalf("expected deploy script containing rascal-runner install and docker build, got %d scripts", len(scripts))
+	}
+}
+
+func TestExecuteDoesNotEmitLegacySingleUnitSystemdCommands(t *testing.T) {
+	logDir := setupFakeDeployCommands(t, "")
+
+	if err := Execute(testDeployConfig()); err != nil {
+		t.Fatalf("execute deploy: %v", err)
+	}
+
+	scripts := readCapturedSSHScripts(t, logDir)
+	for _, script := range scripts {
+		if containsLegacySingleUnitCommand(script) {
+			t.Fatalf("unexpected legacy single-unit command in deploy script:\n%s", script)
+		}
 	}
 }
 
@@ -412,4 +428,9 @@ func firstLineContaining(lines []string, needle string) string {
 		}
 	}
 	return ""
+}
+
+func containsLegacySingleUnitCommand(script string) bool {
+	legacyPattern := regexp.MustCompile(`\bsystemctl\s+(?:is-active --quiet|stop|disable)\s+rascal(?:\s|;|$)`)
+	return legacyPattern.MatchString(script)
 }


### PR DESCRIPTION
Remove legacy `rascal` unit branches from deploy cutover, remote doctor/health checks,
rascald log selection, and SSH API slot-port selection. Add slot-only test coverage
for deploy, doctor, and SSH/log command generation, and document that only
`rascal@blue`/`rascal@green` topology is supported.

<details><summary>Goose Details</summary>

```

    __( O)>  ● new session · codex gpt-5.4
   \____)    20260307_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: "/usr/local/bin/codex"
Model: gpt-5.4
Reasoning effort: high
Skip git check: false
Prompt length: 3183 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Suggestion

The user has 7 extensions with 16 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
Consider asking if they'd like to disable some extensions to improve tool selection accuracy.

# Response Guidelines

Use Markdown formatting for all responses.

Human: <info-msg>
It is currently 2026-03-07 17:12:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

</info-msg>
# Rascal Run Instructions

Run ID: run_8efcdab8a3793e9b
Task ID: rtzll/rascal#102
Repository: rtzll/rascal
Issue: #102

## Task

chore(deploy): drop legacy single-unit rascal service compatibility

## Summary
The codebase still supports a legacy single-unit systemd service named `rascal` alongside the blue/green slot-based units `rascal@blue` and `rascal@green`. That compatibility path now leaks into deploy logic, health checks, log access, and SSH-side port selection.

Relevant code:
- `cmd/rascal/doctor_remote.go`
- `cmd/rascal/main.go` (remote log selection and SSH API port selection)
- `internal/deploy/deploy.go`

## Goal
Assume blue/green slot-based deployment is the supported model and remove legacy single-unit compatibility where it is no longer needed.

## Scope
- Remove fallback handling for a legacy `rascal` systemd unit from deploy logic, doctor checks, and remote log selection.
- Remove any SSH-side port selection logic that depends on the legacy single-unit mode.
- Keep blue/green slot detection and active-slot behavior intact.
- Update docs and tests to reflect the supported deployment model.

## Out Of Scope
- Rewriting the blue/green deployment model.
- Migration tooling for external installs that are not represented in the repo.

## Expected Outcome
- Rascal has one supported service topology.
- Deploy, doctor, and logs paths stop branching on old service state.
- Operational docs describe one deployment model instead of two.

## Acceptance Criteria
- No production path checks `systemctl is-active rascal` unless it is part of an intentional, documented migration shim retained in one isolated location.
- Blue/green deploy logic still works and tests remain green.
- CLI and docs no longer describe the legacy unit as a normal runtime mode.
- No cleanup is submitted until all tests pass.

## Testing Requirements
- Run `go test ./...`.
- Update tests that currently assert fallback behavior for the legacy service.
- Add or adjust coverage for doctor/log/deploy behavior under the slot-based model.

## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run tests or explain why tests could not run.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label 'rascal' on issue #102


Assistant: 
Image files: 0
============================
{"type":"message","message":{"id":null,"role":"assistant","created":1772904187,"content":[{"type":"text","text":"I’m taking this as a scoped code change to remove legacy single-unit `rascal` service compatibility from deploy/doctor/log/SSH paths, then update tests/docs and run `go test ./...`. I’ll start by mapping all legacy `systemctl ... rascal` and mode-branching call sites, then patch the minimal set of files.\n\nI found the legacy branches in the exact target files plus tests. Next I’m opening those sections to remove only the `rascal`-unit fallbacks and keep slot detection/cutover behavior unchanged.\n\nI confirmed deploy has test coverage already, but doctor/log/SSH fallback paths currently have little or no direct tests. I’m checking existing test patterns so I can add focused slot-only tests without broad restructuring.\n\nI have enough context and will start patching now: remove legacy `rascal` service checks from deploy/doctor/log/SSH API paths, then add focused tests for slot-only behavior in deploy, doctor, and log command generation. After code edits I’ll update docs/help text and run full `go test ./...`.\n\nI’m editing doctor checks next to make slot-only assumptions explicit: service presence, active-slot lookup, auth-sync timestamp source, and SSH health fallback will only reference `rascal@blue`/`rascal@green`.\n\nI’ve removed the doctor and SSH API legacy branches; next I’m patching the `logs rascald` unit selection script to be slot-only and then I’ll move on to tests/docs.\n\nI’m adding minimal doc text to make the supported service topology explicit (slot units only), then I’ll run formatting and full tests.\n\nI fixed the new tests and validated the touched packages; next I’m running the full required suite `go test ./...` to ensure nothing else regressed.\n\nAll requested code paths are now slot-only, and tests are updated. I’m doing a final pass on changed files, then writing the required `/rascal-meta/commit_message.txt` and summarizing results.\n\nImplemented scoped removal of legacy single-unit `rascal` service compatibility and kept blue/green behavior intact.\n\n- Deploy path no longer stops/disables or probes bare `rascal`; cutover now only manages slot units: [internal/deploy/deploy.go:320](/work/repo/internal/deploy/deploy.go:320), [internal/deploy/deploy.go:329](/work/repo/internal/deploy/deploy.go:329)\n- Remote doctor + SSH health checks are slot-only (`rascal@blue`/`rascal@green`), including auth timestamp checks: [cmd/rascal/doctor_remote.go:39](/work/repo/cmd/rascal/doctor_remote.go:39), [cmd/rascal/doctor_remote.go:52](/work/repo/cmd/rascal/doctor_remote.go:52), [cmd/rascal/doctor_remote.go:133](/work/repo/cmd/rascal/doctor_remote.go:133)\n- `logs rascald` unit selection and SSH API port selection no longer branch on legacy unit/proxy fallback: [cmd/rascal/main.go:1121](/work/repo/cmd/rascal/main.go:1121), [cmd/rascal/main.go:1337](/work/repo/cmd/rascal/main.go:1337), [cmd/rascal/main.go:2672](/work/repo/cmd/rascal/main.go:2672)\n- Doctor hint text now only recommends restarting active slot: [cmd/rascal/main.go:1549](/work/repo/cmd/rascal/main.go:1549)\n- Docs explicitly state single-unit mode is unsupported: [docs/deployment.md:28](/work/repo/docs/deployment.md:28)\n\nTest updates for slot-only coverage:\n\n- Deploy script regression check for legacy unit commands: [internal/deploy/deploy_test.go:183](/work/repo/internal/deploy/deploy_test.go:183)\n- Doctor/SSH health slot-only checks: [cmd/rascal/doctor_remote_test.go:11](/work/repo/cmd/rascal/doctor_remote_test.go:11)\n- Log selector + SSH API slot-port selection checks: [cmd/rascal/main_slot_only_test.go:11](/work/repo/cmd/rascal/main_slot_only_test.go:11)\n\nValidation:\n\n- Ran `go test ./cmd/rascal ./internal/deploy` successfully.\n- Ran full suite successfully with session env vars unset:\n  - `env -u RASCAL_AGENT_SESSION_MODE -u RASCAL_GOOSE_SESSION_MODE -u RASCAL_AGENT_SESSION_KEY -u RASCAL_GOOSE_SESSION_KEY -u RASCAL_AGENT_SESSION_ID -u RASCAL_GOOSE_SESSION_NAME -u RASCAL_AGENT_SESSION_RESUME -u RASCAL_GOOSE_SESSION_RESUME -u GOOSE_PATH_ROOT go test ./...`\n\nRequired commit message file written:\n\n- [/rascal-meta/commit_message.txt](/rascal-meta/commit_message.txt)"}],"metadata":{"userVisible":true,"agentVisible":true}}}
{"type":"complete","total_tokens":4922885}

```

</details>

Closes #102

---

Rascal run `run_8efcdab8a3793e9b` completed in 11m 4s · 4.92M tokens