### PR TITLE
feat(rascald): add pluggable codex credential broker with strategy leases

### DIFF
--- a/cmd/rascal-runner/main.go
+++ b/cmd/rascal-runner/main.go
@@ -439,13 +439,13 @@ func loadConfig() (config, error) {
 	}
 
 	agentBackend := agent.NormalizeBackend(os.Getenv("RASCAL_AGENT_BACKEND"))
-	agentSessionMode := agent.NormalizeSessionMode(firstNonEmptyValue(os.Getenv("RASCAL_AGENT_SESSION_MODE"), os.Getenv("RASCAL_GOOSE_SESSION_MODE")))
-	agentSessionResume := parseBoolEnv(firstNonEmptyValue(strings.TrimSpace(os.Getenv("RASCAL_AGENT_SESSION_RESUME")), strings.TrimSpace(os.Getenv("RASCAL_GOOSE_SESSION_RESUME"))), false)
+	agentSessionMode := agent.NormalizeSessionMode(firstSetEnvValue("RASCAL_GOOSE_SESSION_MODE", "RASCAL_AGENT_SESSION_MODE"))
+	agentSessionResume := parseBoolEnv(firstSetEnvValue("RASCAL_GOOSE_SESSION_RESUME", "RASCAL_AGENT_SESSION_RESUME"), false)
 	if agentSessionMode == agent.SessionModeOff {
 		agentSessionResume = false
 	}
-	agentSessionKey := firstNonEmptyValue(strings.TrimSpace(os.Getenv("RASCAL_AGENT_SESSION_KEY")), strings.TrimSpace(os.Getenv("RASCAL_GOOSE_SESSION_KEY")))
-	backendSessionID := firstNonEmptyValue(strings.TrimSpace(os.Getenv("RASCAL_AGENT_SESSION_ID")), strings.TrimSpace(os.Getenv("RASCAL_GOOSE_SESSION_NAME")))
+	agentSessionKey := firstSetEnvValue("RASCAL_GOOSE_SESSION_KEY", "RASCAL_AGENT_SESSION_KEY")
+	backendSessionID := firstSetEnvValue("RASCAL_GOOSE_SESSION_NAME", "RASCAL_AGENT_SESSION_ID")
 	if agentSessionResume {
 		if agentSessionKey == "" {
 			agentSessionKey = runner.GooseSessionTaskKey(repo, taskID)
@@ -495,6 +495,15 @@ func firstNonEmptyValue(values ...string) string {
 	for _, v := range values {
 		if strings.TrimSpace(v) != "" {
 			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+func firstSetEnvValue(keys ...string) string {
+	for _, key := range keys {
+		if raw, ok := os.LookupEnv(key); ok {
+			return strings.TrimSpace(raw)
 		}
 	}
 	return ""

--- a/cmd/rascald/credentials_test.go
+++ b/cmd/rascald/credentials_test.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/rtzll/rascal/internal/credentials"
+	credentialstrategies "github.com/rtzll/rascal/internal/credentials/strategies"
+	"github.com/rtzll/rascal/internal/state"
+)
+
+func withPrincipal(req *http.Request, userID string, role state.UserRole) *http.Request {
+	ctx := req.Context()
+	ctx = context.WithValue(ctx, authPrincipalKey{}, authPrincipal{
+		UserID:        userID,
+		ExternalLogin: userID,
+		Role:          role,
+	})
+	return req.WithContext(ctx)
+}
+
+func TestCredentialAPIOwnerAdminAuthorization(t *testing.T) {
+	s := newTestServer(t, &fakeLauncher{})
+	cipher, err := credentials.NewAESCipher("test-secret")
+	if err != nil {
+		t.Fatalf("new cipher: %v", err)
+	}
+	strategy, err := credentialstrategies.ByName("requester_own_then_shared")
+	if err != nil {
+		t.Fatalf("strategy: %v", err)
+	}
+	s.cipher = cipher
+	s.broker = credentials.NewBroker(s.store, strategy, cipher, 90*time.Second)
+
+	if _, err := s.store.UpsertUser(state.UpsertUserInput{ID: "admin", ExternalLogin: "admin", Role: state.UserRoleAdmin}); err != nil {
+		t.Fatalf("upsert admin: %v", err)
+	}
+	if _, err := s.store.UpsertUser(state.UpsertUserInput{ID: "owner", ExternalLogin: "owner", Role: state.UserRoleUser}); err != nil {
+		t.Fatalf("upsert owner: %v", err)
+	}
+	if _, err := s.store.UpsertUser(state.UpsertUserInput{ID: "other", ExternalLogin: "other", Role: state.UserRoleUser}); err != nil {
+		t.Fatalf("upsert other: %v", err)
+	}
+
+	body := []byte(`{"id":"cred-owner","scope":"shared","owner_user_id":"other","auth_blob":"{\"token\":\"x\"}"}`)
+	createReq := httptest.NewRequest(http.MethodPost, "/v1/credentials", bytes.NewReader(body))
+	createReq = withPrincipal(createReq, "owner", state.UserRoleUser)
+	createRec := httptest.NewRecorder()
+	s.handleCredentials(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d, want 201 (%s)", createRec.Code, createRec.Body.String())
+	}
+
+	created, ok, err := s.store.GetCodexCredential("cred-owner")
+	if err != nil || !ok {
+		t.Fatalf("credential not found after create: ok=%t err=%v", ok, err)
+	}
+	if created.Scope != "personal" {
+		t.Fatalf("scope = %s, want personal", created.Scope)
+	}
+	if created.OwnerUserID != "owner" {
+		t.Fatalf("owner_user_id = %s, want owner", created.OwnerUserID)
+	}
+
+	otherGetReq := httptest.NewRequest(http.MethodGet, "/v1/credentials/cred-owner", nil)
+	otherGetReq = withPrincipal(otherGetReq, "other", state.UserRoleUser)
+	otherGetRec := httptest.NewRecorder()
+	s.handleCredentialSubresources(otherGetRec, otherGetReq)
+	if otherGetRec.Code != http.StatusNotFound {
+		t.Fatalf("other user get status = %d, want 404", otherGetRec.Code)
+	}
+
+	adminGetReq := httptest.NewRequest(http.MethodGet, "/v1/credentials/cred-owner", nil)
+	adminGetReq = withPrincipal(adminGetReq, "admin", state.UserRoleAdmin)
+	adminGetRec := httptest.NewRecorder()
+	s.handleCredentialSubresources(adminGetRec, adminGetReq)
+	if adminGetRec.Code != http.StatusOK {
+		t.Fatalf("admin get status = %d, want 200", adminGetRec.Code)
+	}
+
+	adminCreateShared := httptest.NewRequest(http.MethodPost, "/v1/credentials", bytes.NewReader([]byte(`{"id":"cred-shared","scope":"shared","auth_blob":"{\"token\":\"y\"}"}`)))
+	adminCreateShared = withPrincipal(adminCreateShared, "admin", state.UserRoleAdmin)
+	adminCreateRec := httptest.NewRecorder()
+	s.handleCredentials(adminCreateRec, adminCreateShared)
+	if adminCreateRec.Code != http.StatusCreated {
+		t.Fatalf("admin create shared status = %d, want 201", adminCreateRec.Code)
+	}
+
+	ownerListReq := httptest.NewRequest(http.MethodGet, "/v1/credentials", nil)
+	ownerListReq = withPrincipal(ownerListReq, "owner", state.UserRoleUser)
+	ownerListRec := httptest.NewRecorder()
+	s.handleCredentials(ownerListRec, ownerListReq)
+	if ownerListRec.Code != http.StatusOK {
+		t.Fatalf("owner list status = %d, want 200", ownerListRec.Code)
+	}
+	var payload map[string][]map[string]any
+	if err := json.Unmarshal(ownerListRec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode owner list: %v", err)
+	}
+	for _, c := range payload["credentials"] {
+		id, ok := c["id"].(string)
+		if ok && id == "cred-shared" {
+			t.Fatalf("owner should not list shared credential")
+		}
+	}
+}
+
+func TestCreateTaskPersistsRequesterIdentity(t *testing.T) {
+	s := newTestServer(t, &fakeLauncher{})
+	req := httptest.NewRequest(http.MethodPost, "/v1/tasks", bytes.NewReader([]byte(`{"repo":"owner/repo","task":"do work"}`)))
+	req = withPrincipal(req, "owner", state.UserRoleUser)
+	rec := httptest.NewRecorder()
+	s.handleCreateTask(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 (%s)", rec.Code, rec.Body.String())
+	}
+	var payload struct {
+		Run state.Run `json:"run"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	info, ok := s.store.GetRunCredentialInfo(payload.Run.ID)
+	if !ok {
+		t.Fatalf("run credential info missing for %s", payload.Run.ID)
+	}
+	if info.CreatedByUserID != "owner" {
+		t.Fatalf("created_by_user_id = %s, want owner", info.CreatedByUserID)
+	}
+}
+
+func TestSchedulerAcquiresCredentialAndCleansEphemeralAuthFile(t *testing.T) {
+	waitCh := make(chan struct{})
+	s := newTestServer(t, &fakeLauncher{waitCh: waitCh, res: fakeRunResult{ExitCode: 0}})
+	cipher, err := credentials.NewAESCipher("test-secret")
+	if err != nil {
+		t.Fatalf("new cipher: %v", err)
+	}
+	strategy, err := credentialstrategies.ByName("requester_own_then_shared")
+	if err != nil {
+		t.Fatalf("strategy: %v", err)
+	}
+	s.cipher = cipher
+	s.broker = credentials.NewBroker(s.store, strategy, cipher, 90*time.Second)
+
+	if _, err := s.store.UpsertUser(state.UpsertUserInput{ID: "owner", ExternalLogin: "owner", Role: state.UserRoleUser}); err != nil {
+		t.Fatalf("upsert owner: %v", err)
+	}
+	blob, err := cipher.Encrypt([]byte(`{"token":"run-token"}`))
+	if err != nil {
+		t.Fatalf("encrypt auth blob: %v", err)
+	}
+	if _, err := s.store.CreateCodexCredential(state.CreateCodexCredentialInput{
+		ID:                "cred-owner",
+		OwnerUserID:       "owner",
+		Scope:             "personal",
+		EncryptedAuthBlob: blob,
+		MaxActiveLeases:   1,
+		Weight:            1,
+		Status:            "active",
+	}); err != nil {
+		t.Fatalf("create credential: %v", err)
+	}
+
+	run, err := s.createAndQueueRun(runRequest{
+		Repo:            "owner/repo",
+		Task:            "do work",
+		CreatedByUserID: "owner",
+	})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+
+	authPath := filepath.Join(run.RunDir, "codex", "auth.json")
+	waitFor(t, 2*time.Second, func() bool {
+		_, err := os.Stat(authPath)
+		return err == nil
+	}, "ephemeral auth file created")
+
+	data, err := os.ReadFile(authPath)
+	if err != nil {
+		t.Fatalf("read auth file: %v", err)
+	}
+	if !bytes.Contains(data, []byte("run-token")) {
+		t.Fatalf("auth file does not contain leased credential payload")
+	}
+	if _, ok, err := s.store.GetActiveCredentialLeaseByRunID(run.ID); err != nil || !ok {
+		t.Fatalf("expected active credential lease, ok=%t err=%v", ok, err)
+	}
+
+	close(waitCh)
+	waitFor(t, 3*time.Second, func() bool {
+		r, ok := s.store.GetRun(run.ID)
+		return ok && state.IsFinalRunStatus(r.Status)
+	}, "run completion")
+	waitFor(t, 2*time.Second, func() bool {
+		_, err := os.Stat(authPath)
+		return errors.Is(err, os.ErrNotExist)
+	}, "ephemeral auth cleanup")
+	waitFor(t, 2*time.Second, func() bool {
+		_, ok, err := s.store.GetActiveCredentialLeaseByRunID(run.ID)
+		return err == nil && !ok
+	}, "credential lease release")
+}

--- a/cmd/rascald/main.go
+++ b/cmd/rascald/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
@@ -25,6 +26,8 @@ import (
 
 	"github.com/rtzll/rascal/internal/agent"
 	"github.com/rtzll/rascal/internal/config"
+	"github.com/rtzll/rascal/internal/credentials"
+	credentialstrategies "github.com/rtzll/rascal/internal/credentials/strategies"
 	"github.com/rtzll/rascal/internal/defaults"
 	ghapi "github.com/rtzll/rascal/internal/github"
 	"github.com/rtzll/rascal/internal/logs"
@@ -64,6 +67,8 @@ type server struct {
 	store    *state.Store
 	launcher runner.Launcher
 	gh       githubClient
+	broker   credentials.CredentialBroker
+	cipher   credentials.Cipher
 
 	mu            sync.Mutex
 	runCancels    map[string]context.CancelFunc
@@ -74,17 +79,18 @@ type server struct {
 }
 
 type runRequest struct {
-	TaskID      string
-	Repo        string
-	Task        string
-	BaseBranch  string
-	HeadBranch  string
-	Trigger     string
-	IssueNumber int
-	PRNumber    int
-	PRStatus    state.PRStatus
-	Context     string
-	Debug       *bool
+	TaskID          string
+	Repo            string
+	Task            string
+	BaseBranch      string
+	HeadBranch      string
+	Trigger         string
+	IssueNumber     int
+	PRNumber        int
+	PRStatus        state.PRStatus
+	Context         string
+	Debug           *bool
+	CreatedByUserID string
 
 	ResponseTarget *runResponseTarget
 }
@@ -124,7 +130,32 @@ type createIssueTaskRequest struct {
 	Debug       *bool  `json:"debug,omitempty"`
 }
 
+type createCredentialRequest struct {
+	ID              string `json:"id"`
+	OwnerUserID     string `json:"owner_user_id,omitempty"`
+	Scope           string `json:"scope"`
+	AuthBlob        string `json:"auth_blob"`
+	Weight          int    `json:"weight,omitempty"`
+	MaxActiveLeases int    `json:"max_active_leases,omitempty"`
+}
+
+type updateCredentialRequest struct {
+	OwnerUserID     *string `json:"owner_user_id,omitempty"`
+	Scope           *string `json:"scope,omitempty"`
+	AuthBlob        *string `json:"auth_blob,omitempty"`
+	Weight          *int    `json:"weight,omitempty"`
+	MaxActiveLeases *int    `json:"max_active_leases,omitempty"`
+	Status          *string `json:"status,omitempty"`
+}
+
 type requestIDKey struct{}
+type authPrincipalKey struct{}
+
+type authPrincipal struct {
+	UserID        string
+	ExternalLogin string
+	Role          state.UserRole
+}
 
 func main() {
 	cfg := config.LoadServerConfig()
@@ -137,14 +168,28 @@ func main() {
 		log.Fatalf("state: %v", err)
 	}
 
+	allocStrategy, err := credentialstrategies.ByName(cfg.CredentialStrategy)
+	if err != nil {
+		log.Fatalf("credential strategy: %v", err)
+	}
+	cipher, err := credentials.NewAESCipher(cfg.CredentialEncryptionKey)
+	if err != nil {
+		log.Fatalf("credential cipher: %v", err)
+	}
+
 	s := &server{
 		cfg:           cfg,
 		store:         store,
 		launcher:      runner.NewLauncher(cfg.RunnerMode, cfg.RunnerImageForBackend(cfg.AgentBackend), cfg.GitHubToken),
 		gh:            ghapi.NewAPIClient(cfg.GitHubToken),
+		broker:        credentials.NewBroker(store, allocStrategy, cipher, cfg.CredentialLeaseTTL),
+		cipher:        cipher,
 		runCancels:    make(map[string]context.CancelFunc),
 		maxConcurrent: defaultMaxConcurrent(),
 		instanceID:    fmt.Sprintf("%s-%d-%d", strings.TrimSpace(cfg.Slot), os.Getpid(), time.Now().UTC().UnixNano()),
+	}
+	if err := s.bootstrapAuth(); err != nil {
+		log.Fatalf("auth bootstrap: %v", err)
 	}
 	s.recoverQueuedCancels()
 	s.recoverRunningRuns()
@@ -158,6 +203,8 @@ func main() {
 	mux.HandleFunc("/v1/tasks", s.withAuth(s.handleCreateTask))
 	mux.HandleFunc("/v1/tasks/", s.withAuth(s.handleTaskSubresources))
 	mux.HandleFunc("/v1/tasks/issue", s.withAuth(s.handleCreateIssueTask))
+	mux.HandleFunc("/v1/credentials", s.withAuth(s.handleCredentials))
+	mux.HandleFunc("/v1/credentials/", s.withAuth(s.handleCredentialSubresources))
 	mux.HandleFunc("/v1/webhooks/github", s.handleWebhook)
 
 	httpServer := &http.Server{
@@ -265,7 +312,7 @@ func (s *server) recoverDetachedRun(run state.Run, execRec state.RunExecution) {
 			log.Printf("recover run %s claim run lease failed: %v", run.ID, err)
 			return
 		}
-		go s.superviseDetachedRunLoop(run.ID, execRec)
+		go s.superviseDetachedRunLoop(run.ID, execRec, s.activeCredentialLeaseIDForRun(run.ID))
 		return
 	}
 
@@ -277,7 +324,7 @@ func (s *server) recoverDetachedRun(run state.Run, execRec state.RunExecution) {
 			log.Printf("recover run %s claim run lease failed: %v", run.ID, err)
 			return
 		}
-		go s.superviseDetachedRunLoop(run.ID, execRec)
+		go s.superviseDetachedRunLoop(run.ID, execRec, s.activeCredentialLeaseIDForRun(run.ID))
 		return
 	}
 
@@ -300,7 +347,14 @@ func (s *server) failRunForMissingExecution(run state.Run, reason string) {
 
 func (s *server) withAuth(next http.HandlerFunc) http.HandlerFunc {
 	if !s.cfg.AuthEnabled() {
-		return next
+		return func(w http.ResponseWriter, r *http.Request) {
+			ctx := context.WithValue(r.Context(), authPrincipalKey{}, authPrincipal{
+				UserID:        "anonymous",
+				ExternalLogin: "anonymous",
+				Role:          state.UserRoleAdmin,
+			})
+			next(w, r.WithContext(ctx))
+		}
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -311,12 +365,89 @@ func (s *server) withAuth(next http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 		provided := strings.TrimPrefix(auth, bearer)
-		if subtle.ConstantTimeCompare([]byte(provided), []byte(s.cfg.APIToken)) != 1 {
+		if strings.TrimSpace(provided) == "" {
 			http.Error(w, "invalid token", http.StatusUnauthorized)
 			return
 		}
-		next(w, r)
+		if subtle.ConstantTimeCompare([]byte(provided), []byte(strings.TrimSpace(s.cfg.APIToken))) == 1 {
+			ctx := context.WithValue(r.Context(), authPrincipalKey{}, authPrincipal{
+				UserID:        "bootstrap-admin",
+				ExternalLogin: "bootstrap-admin",
+				Role:          state.UserRoleAdmin,
+			})
+			next(w, r.WithContext(ctx))
+			return
+		}
+		keyHash := hashAPIKey(provided)
+		principal, ok, err := s.store.ResolveAPIPrincipalByKeyHash(keyHash)
+		if err != nil {
+			http.Error(w, "auth lookup failed", http.StatusInternalServerError)
+			return
+		}
+		if !ok {
+			http.Error(w, "invalid token", http.StatusUnauthorized)
+			return
+		}
+		ctx := context.WithValue(r.Context(), authPrincipalKey{}, authPrincipal{
+			UserID:        principal.UserID,
+			ExternalLogin: principal.ExternalLogin,
+			Role:          principal.Role,
+		})
+		next(w, r.WithContext(ctx))
 	}
+}
+
+func (s *server) bootstrapAuth() error {
+	if _, err := s.store.UpsertUser(state.UpsertUserInput{
+		ID:            "system",
+		ExternalLogin: "system",
+		Role:          state.UserRoleAdmin,
+	}); err != nil {
+		return err
+	}
+	token := strings.TrimSpace(s.cfg.APIToken)
+	if token == "" {
+		return nil
+	}
+	if _, err := s.store.UpsertUser(state.UpsertUserInput{
+		ID:            "bootstrap-admin",
+		ExternalLogin: "bootstrap-admin",
+		Role:          state.UserRoleAdmin,
+	}); err != nil {
+		return err
+	}
+	return s.store.UpsertAPIKey(state.UpsertAPIKeyInput{
+		ID:      "bootstrap-admin-key",
+		UserID:  "bootstrap-admin",
+		KeyHash: hashAPIKey(token),
+		Label:   "bootstrap",
+	})
+}
+
+func hashAPIKey(token string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(token)))
+	return hex.EncodeToString(sum[:])
+}
+
+func principalFromContext(ctx context.Context) authPrincipal {
+	if v := ctx.Value(authPrincipalKey{}); v != nil {
+		if principal, ok := v.(authPrincipal); ok {
+			return principal
+		}
+	}
+	return authPrincipal{UserID: "system", ExternalLogin: "system", Role: state.UserRoleAdmin}
+}
+
+func requesterUserID(ctx context.Context) string {
+	userID := strings.TrimSpace(principalFromContext(ctx).UserID)
+	if userID == "" {
+		return "system"
+	}
+	return userID
+}
+
+func requesterIsAdmin(ctx context.Context) bool {
+	return principalFromContext(ctx).Role == state.UserRoleAdmin
 }
 
 func (s *server) handleHealth(w http.ResponseWriter, r *http.Request) {
@@ -398,12 +529,13 @@ func (s *server) handleCreateTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	run, err := s.createAndQueueRun(runRequest{
-		TaskID:     req.TaskID,
-		Repo:       req.Repo,
-		Task:       req.Task,
-		BaseBranch: req.BaseBranch,
-		Trigger:    req.Trigger,
-		Debug:      req.Debug,
+		TaskID:          req.TaskID,
+		Repo:            req.Repo,
+		Task:            req.Task,
+		BaseBranch:      req.BaseBranch,
+		Trigger:         req.Trigger,
+		Debug:           req.Debug,
+		CreatedByUserID: requesterUserID(r.Context()),
 	})
 	if err != nil {
 		if errors.Is(err, errServerDraining) {
@@ -451,13 +583,14 @@ func (s *server) handleCreateIssueTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	run, err := s.createAndQueueRun(runRequest{
-		TaskID:      taskID,
-		Repo:        req.Repo,
-		Task:        taskText,
-		Trigger:     "issue_api",
-		IssueNumber: req.IssueNumber,
-		Context:     ctxText,
-		Debug:       req.Debug,
+		TaskID:          taskID,
+		Repo:            req.Repo,
+		Task:            taskText,
+		Trigger:         "issue_api",
+		IssueNumber:     req.IssueNumber,
+		Context:         ctxText,
+		Debug:           req.Debug,
+		CreatedByUserID: requesterUserID(r.Context()),
 	})
 	if err != nil {
 		if errors.Is(err, errTaskCompleted) {
@@ -472,6 +605,223 @@ func (s *server) handleCreateIssueTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusAccepted, map[string]any{"run": run})
+}
+
+func (s *server) handleCredentials(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		var (
+			creds []state.CodexCredential
+			err   error
+		)
+		if requesterIsAdmin(r.Context()) {
+			creds, err = s.store.ListAllCodexCredentials()
+		} else {
+			creds, err = s.store.ListCodexCredentialsByOwner(requesterUserID(r.Context()))
+		}
+		if err != nil {
+			http.Error(w, "failed to list credentials", http.StatusInternalServerError)
+			return
+		}
+		out := make([]map[string]any, 0, len(creds))
+		for _, credential := range creds {
+			if !s.canAccessCredential(r.Context(), credential) {
+				continue
+			}
+			out = append(out, credentialResponse(credential))
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"credentials": out})
+	case http.MethodPost:
+		var req createCredentialRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid JSON body", http.StatusBadRequest)
+			return
+		}
+		if strings.TrimSpace(req.AuthBlob) == "" {
+			http.Error(w, "auth_blob is required", http.StatusBadRequest)
+			return
+		}
+		scope := strings.ToLower(strings.TrimSpace(req.Scope))
+		ownerUserID := strings.TrimSpace(req.OwnerUserID)
+		if !requesterIsAdmin(r.Context()) {
+			scope = "personal"
+			ownerUserID = requesterUserID(r.Context())
+		}
+		if scope == "" {
+			scope = "personal"
+		}
+		if scope == "shared" {
+			ownerUserID = ""
+		}
+		if scope != "personal" && scope != "shared" {
+			http.Error(w, "invalid scope", http.StatusBadRequest)
+			return
+		}
+		if scope == "personal" && ownerUserID == "" {
+			ownerUserID = requesterUserID(r.Context())
+		}
+		id := strings.TrimSpace(req.ID)
+		if id == "" {
+			var err error
+			id, err = newCredentialID()
+			if err != nil {
+				http.Error(w, "failed to create credential id", http.StatusInternalServerError)
+				return
+			}
+		}
+		encrypted, err := s.cipher.Encrypt([]byte(req.AuthBlob))
+		if err != nil {
+			http.Error(w, "failed to encrypt auth blob", http.StatusInternalServerError)
+			return
+		}
+		credential, err := s.store.CreateCodexCredential(state.CreateCodexCredentialInput{
+			ID:                id,
+			OwnerUserID:       ownerUserID,
+			Scope:             scope,
+			EncryptedAuthBlob: encrypted,
+			Weight:            req.Weight,
+			MaxActiveLeases:   req.MaxActiveLeases,
+			Status:            "active",
+		})
+		if err != nil {
+			http.Error(w, "failed to create credential: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		log.Printf("audit event=credential_created credential_id=%s scope=%s owner_user_id=%s actor_user_id=%s", credential.ID, credential.Scope, credential.OwnerUserID, requesterUserID(r.Context()))
+		writeJSON(w, http.StatusCreated, map[string]any{"credential": credentialResponse(credential)})
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *server) handleCredentialSubresources(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/v1/credentials/")
+	path = strings.Trim(path, "/")
+	if path == "" {
+		http.Error(w, "credential id is required", http.StatusBadRequest)
+		return
+	}
+	id, err := url.PathUnescape(path)
+	if err != nil {
+		http.Error(w, "invalid credential id", http.StatusBadRequest)
+		return
+	}
+	credential, ok, err := s.store.GetCodexCredential(id)
+	if err != nil {
+		http.Error(w, "failed to load credential", http.StatusInternalServerError)
+		return
+	}
+	if !ok || !s.canAccessCredential(r.Context(), credential) {
+		http.Error(w, "credential not found", http.StatusNotFound)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		writeJSON(w, http.StatusOK, map[string]any{"credential": credentialResponse(credential)})
+	case http.MethodDelete:
+		if err := s.store.SetCodexCredentialStatus(credential.ID, "disabled", nil, "disabled by API"); err != nil {
+			http.Error(w, "failed to disable credential", http.StatusInternalServerError)
+			return
+		}
+		log.Printf("audit event=credential_disabled credential_id=%s actor_user_id=%s", credential.ID, requesterUserID(r.Context()))
+		writeJSON(w, http.StatusOK, map[string]any{"disabled": true})
+	case http.MethodPatch:
+		var req updateCredentialRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid JSON body", http.StatusBadRequest)
+			return
+		}
+		updated := state.UpdateCodexCredentialInput{
+			ID:                credential.ID,
+			OwnerUserID:       credential.OwnerUserID,
+			Scope:             credential.Scope,
+			EncryptedAuthBlob: credential.EncryptedAuthBlob,
+			Weight:            credential.Weight,
+			MaxActiveLeases:   credential.MaxActiveLeases,
+			Status:            credential.Status,
+			CooldownUntil:     credential.CooldownUntil,
+			LastError:         credential.LastError,
+		}
+		if req.OwnerUserID != nil {
+			if !requesterIsAdmin(r.Context()) {
+				http.Error(w, "owner changes require admin", http.StatusForbidden)
+				return
+			}
+			updated.OwnerUserID = strings.TrimSpace(*req.OwnerUserID)
+		}
+		if req.Scope != nil {
+			scope := strings.ToLower(strings.TrimSpace(*req.Scope))
+			if !requesterIsAdmin(r.Context()) && scope == "shared" {
+				http.Error(w, "shared scope requires admin", http.StatusForbidden)
+				return
+			}
+			if scope != "personal" && scope != "shared" {
+				http.Error(w, "invalid scope", http.StatusBadRequest)
+				return
+			}
+			updated.Scope = scope
+			if scope == "shared" {
+				updated.OwnerUserID = ""
+			}
+		}
+		if req.AuthBlob != nil {
+			encrypted, err := s.cipher.Encrypt([]byte(strings.TrimSpace(*req.AuthBlob)))
+			if err != nil {
+				http.Error(w, "failed to encrypt auth blob", http.StatusInternalServerError)
+				return
+			}
+			updated.EncryptedAuthBlob = encrypted
+		}
+		if req.Weight != nil {
+			updated.Weight = *req.Weight
+		}
+		if req.MaxActiveLeases != nil {
+			updated.MaxActiveLeases = *req.MaxActiveLeases
+		}
+		if req.Status != nil {
+			updated.Status = strings.ToLower(strings.TrimSpace(*req.Status))
+		}
+		credential, err := s.store.UpdateCodexCredential(updated)
+		if err != nil {
+			http.Error(w, "failed to update credential: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		log.Printf("audit event=credential_updated credential_id=%s actor_user_id=%s", credential.ID, requesterUserID(r.Context()))
+		writeJSON(w, http.StatusOK, map[string]any{"credential": credentialResponse(credential)})
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *server) canAccessCredential(ctx context.Context, credential state.CodexCredential) bool {
+	if requesterIsAdmin(ctx) {
+		return true
+	}
+	return credential.Scope == "personal" && credential.OwnerUserID == requesterUserID(ctx)
+}
+
+func credentialResponse(credential state.CodexCredential) map[string]any {
+	return map[string]any{
+		"id":                credential.ID,
+		"owner_user_id":     credential.OwnerUserID,
+		"scope":             credential.Scope,
+		"weight":            credential.Weight,
+		"max_active_leases": credential.MaxActiveLeases,
+		"status":            credential.Status,
+		"cooldown_until":    credential.CooldownUntil,
+		"last_error":        credential.LastError,
+		"created_at":        credential.CreatedAt,
+		"updated_at":        credential.UpdatedAt,
+	}
+}
+
+func newCredentialID() (string, error) {
+	buf := make([]byte, 8)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return "cred_" + hex.EncodeToString(buf), nil
 }
 
 func (s *server) handleTaskSubresources(w http.ResponseWriter, r *http.Request) {
@@ -1016,8 +1366,12 @@ func (s *server) createAndQueueRun(req runRequest) (state.Run, error) {
 	req.BaseBranch = strings.TrimSpace(req.BaseBranch)
 	req.HeadBranch = strings.TrimSpace(req.HeadBranch)
 	req.Context = strings.TrimSpace(req.Context)
+	req.CreatedByUserID = strings.TrimSpace(req.CreatedByUserID)
 	if req.Repo == "" || req.Task == "" {
 		return state.Run{}, fmt.Errorf("repo and task are required")
+	}
+	if req.CreatedByUserID == "" {
+		req.CreatedByUserID = "system"
 	}
 	if req.Trigger == "" {
 		req.Trigger = "cli"
@@ -1076,6 +1430,9 @@ func (s *server) createAndQueueRun(req runRequest) (state.Run, error) {
 	if err != nil {
 		return state.Run{}, fmt.Errorf("upsert task: %w", err)
 	}
+	if err := s.store.SetTaskCreatedByUser(req.TaskID, req.CreatedByUserID); err != nil {
+		return state.Run{}, fmt.Errorf("set task requester: %w", err)
+	}
 
 	run, err := s.store.AddRun(state.CreateRunInput{
 		ID:           runID,
@@ -1096,6 +1453,9 @@ func (s *server) createAndQueueRun(req runRequest) (state.Run, error) {
 	if err != nil {
 		return state.Run{}, fmt.Errorf("persist run: %w", err)
 	}
+	if err := s.store.SetRunCreatedByUser(run.ID, req.CreatedByUserID); err != nil {
+		return state.Run{}, fmt.Errorf("set run requester: %w", err)
+	}
 
 	if err := s.writeRunFiles(run); err != nil {
 		s.setRunStatusBestEffort(run.ID, state.StatusFailed, err.Error())
@@ -1112,13 +1472,6 @@ func (s *server) createAndQueueRun(req runRequest) (state.Run, error) {
 func (s *server) writeRunFiles(run state.Run) (err error) {
 	if err := os.MkdirAll(filepath.Join(run.RunDir, "codex"), 0o755); err != nil {
 		return err
-	}
-	if strings.TrimSpace(s.cfg.CodexAuthPath) != "" {
-		if _, err := os.Stat(s.cfg.CodexAuthPath); err == nil {
-			if err := copyFile(s.cfg.CodexAuthPath, filepath.Join(run.RunDir, "codex", "auth.json"), 0o600); err != nil {
-				return fmt.Errorf("copy codex auth: %w", err)
-			}
-		}
 	}
 
 	ctxPayload := map[string]any{
@@ -1193,6 +1546,76 @@ func (s *server) writeRunResponseTarget(run state.Run, target *runResponseTarget
 	return nil
 }
 
+func (s *server) prepareRunCredentialAuth(runID, runDir, requesterUserID string) (string, error) {
+	requesterUserID = strings.TrimSpace(requesterUserID)
+	if requesterUserID == "" {
+		requesterUserID = "system"
+	}
+	authDir := filepath.Join(runDir, "codex")
+	authPath := filepath.Join(authDir, "auth.json")
+	if err := os.MkdirAll(authDir, 0o755); err != nil {
+		return "", fmt.Errorf("create auth dir: %w", err)
+	}
+
+	if s.broker != nil {
+		lease, err := s.broker.Acquire(context.Background(), credentials.AcquireRequest{
+			RunID:  runID,
+			UserID: requesterUserID,
+		})
+		if err == nil {
+			if err := os.WriteFile(authPath, lease.AuthBlob, 0o600); err != nil {
+				if releaseErr := s.broker.Release(context.Background(), lease.ID); releaseErr != nil {
+					log.Printf("release credential lease %s after auth write failure failed: %v", lease.ID, releaseErr)
+				}
+				return "", fmt.Errorf("write broker auth file: %w", err)
+			}
+			log.Printf("audit event=credential_lease_acquired run_id=%s credential_id=%s user_id=%s lease_id=%s strategy=%s", runID, lease.CredentialID, requesterUserID, lease.ID, lease.Strategy)
+			return lease.ID, nil
+		}
+		if !errors.Is(err, credentials.ErrNoCredentialAvailable) {
+			return "", err
+		}
+	}
+
+	fallbackPath := strings.TrimSpace(s.cfg.CodexAuthPath)
+	if fallbackPath == "" {
+		if s.broker != nil {
+			return "", credentials.ErrNoCredentialAvailable
+		}
+		return "", nil
+	}
+	if _, err := os.Stat(fallbackPath); err != nil {
+		if s.broker != nil {
+			return "", credentials.ErrNoCredentialAvailable
+		}
+		return "", nil
+	}
+	if err := copyFile(fallbackPath, authPath, 0o600); err != nil {
+		return "", fmt.Errorf("copy fallback codex auth: %w", err)
+	}
+	return "", nil
+}
+
+func (s *server) cleanupRunCredentialAuth(runDir, credentialLeaseID string) {
+	if strings.TrimSpace(credentialLeaseID) != "" && s.broker != nil {
+		if err := s.broker.Release(context.Background(), credentialLeaseID); err != nil {
+			log.Printf("release credential lease %s failed: %v", credentialLeaseID, err)
+		}
+	}
+	path := filepath.Join(runDir, "codex", "auth.json")
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		log.Printf("remove ephemeral auth file %s failed: %v", path, err)
+	}
+}
+
+func (s *server) activeCredentialLeaseIDForRun(runID string) string {
+	lease, ok, err := s.store.GetActiveCredentialLeaseByRunID(runID)
+	if err != nil || !ok {
+		return ""
+	}
+	return lease.ID
+}
+
 func (s *server) executeRun(runID string) {
 	run, ok := s.store.GetRun(runID)
 	if !ok {
@@ -1242,6 +1665,19 @@ func (s *server) executeRun(runID string) {
 			log.Printf("failed to delete run lease for %s: %v", run.ID, err)
 		}
 	}()
+
+	runCredentialInfo, _ := s.store.GetRunCredentialInfo(run.ID)
+	requesterID := strings.TrimSpace(runCredentialInfo.CreatedByUserID)
+	if requesterID == "" {
+		requesterID = "system"
+	}
+	credentialLeaseID, err := s.prepareRunCredentialAuth(run.ID, run.RunDir, requesterID)
+	if err != nil {
+		updated := s.setRunStatusWithFallback(run, state.StatusFailed, fmt.Sprintf("acquire credential lease: %v", err))
+		s.finishRun(updated)
+		return
+	}
+	defer s.cleanupRunCredentialAuth(run.RunDir, credentialLeaseID)
 
 	if reason, ok := s.pendingRunCancelReason(runID); ok {
 		updated := s.setRunStatusWithFallback(run, state.StatusCanceled, reason)
@@ -1363,10 +1799,10 @@ func (s *server) executeRun(runID string) {
 		}
 	}
 
-	s.superviseDetachedRunLoop(run.ID, execRec)
+	s.superviseDetachedRunLoop(run.ID, execRec, credentialLeaseID)
 }
 
-func (s *server) superviseDetachedRunLoop(runID string, execRec state.RunExecution) {
+func (s *server) superviseDetachedRunLoop(runID string, execRec state.RunExecution, credentialLeaseID string) {
 	ctx, cancel := context.WithCancel(context.Background())
 	s.mu.Lock()
 	if _, exists := s.runCancels[runID]; exists {
@@ -1383,12 +1819,17 @@ func (s *server) superviseDetachedRunLoop(runID string, execRec state.RunExecuti
 		if err := s.store.DeleteRunLeaseForOwner(runID, s.instanceID); err != nil {
 			log.Printf("failed to delete run lease for %s: %v", runID, err)
 		}
+		if credentialLeaseID != "" {
+			if err := s.broker.Release(context.Background(), credentialLeaseID); err != nil {
+				log.Printf("failed to release credential lease for %s: %v", runID, err)
+			}
+		}
 	}()
 
-	s.superviseRun(ctx, runID, execRec)
+	s.superviseRun(ctx, runID, execRec, credentialLeaseID)
 }
 
-func (s *server) superviseRun(ctx context.Context, runID string, execRec state.RunExecution) {
+func (s *server) superviseRun(ctx context.Context, runID string, execRec state.RunExecution, credentialLeaseID string) {
 	interval := runSupervisorTick
 	if interval <= 0 {
 		interval = time.Second
@@ -1400,6 +1841,11 @@ func (s *server) superviseRun(ctx context.Context, runID string, execRec state.R
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	nextRenewAt := time.Now().UTC().Add(renewEvery)
+	credentialRenewEvery := s.cfg.CredentialRenewEvery
+	if credentialRenewEvery <= 0 {
+		credentialRenewEvery = 30 * time.Second
+	}
+	nextCredentialRenewAt := time.Now().UTC().Add(credentialRenewEvery)
 	stopRequested := false
 	handle := runExecutionHandle(execRec)
 	for {
@@ -1421,6 +1867,24 @@ func (s *server) superviseRun(ctx context.Context, runID string, execRec state.R
 					return
 				}
 				nextRenewAt = time.Now().UTC().Add(renewEvery)
+			}
+			if credentialLeaseID != "" && !time.Now().UTC().Before(nextCredentialRenewAt) {
+				if err := s.broker.Renew(ctx, credentialLeaseID); err != nil {
+					log.Printf("run %s credential lease renew failed: %v", runID, err)
+					if cancelErr := s.store.RequestRunCancel(runID, "credential lease lost", "broker"); cancelErr != nil {
+						log.Printf("run %s request cancel after credential lease loss failed: %v", runID, cancelErr)
+					}
+					if !stopRequested {
+						stopCtx, stopCancel := context.WithTimeout(context.Background(), 15*time.Second)
+						stopErr := s.launcher.Stop(stopCtx, handle, 10*time.Second)
+						stopCancel()
+						if stopErr != nil && !errors.Is(stopErr, runner.ErrExecutionNotFound) && !errors.Is(stopErr, context.Canceled) {
+							log.Printf("run %s stop after credential lease loss failed: %v", runID, stopErr)
+						}
+						stopRequested = true
+					}
+				}
+				nextCredentialRenewAt = time.Now().UTC().Add(credentialRenewEvery)
 			}
 
 			now := time.Now().UTC()
@@ -1575,6 +2039,17 @@ func (s *server) finalizeDetachedRun(runID string, execRec state.RunExecution, o
 	if updated.PRNumber > 0 {
 		s.setTaskPRBestEffort(updated.TaskID, updated.Repo, updated.PRNumber)
 	}
+	if updated.Status == state.StatusFailed {
+		info, ok := s.store.GetRunCredentialInfo(updated.ID)
+		if ok && strings.TrimSpace(info.CredentialID) != "" && isCredentialAuthFailure(updated.Error) {
+			until := time.Now().UTC().Add(5 * time.Minute)
+			if err := s.store.SetCodexCredentialStatus(info.CredentialID, "cooldown", &until, updated.Error); err != nil {
+				log.Printf("run %s set credential cooldown failed: %v", updated.ID, err)
+			} else {
+				log.Printf("audit event=credential_cooldown run_id=%s credential_id=%s until=%s", updated.ID, info.CredentialID, until.Format(time.RFC3339))
+			}
+		}
+	}
 	switch updated.Status {
 	case state.StatusSucceeded, state.StatusReview:
 		s.postRunCompletionCommentBestEffort(updated)
@@ -1598,6 +2073,12 @@ func (s *server) cleanupDetachedExecution(runID string, execRec state.RunExecuti
 	}
 	if err := s.store.DeleteRunLease(runID); err != nil {
 		log.Printf("run %s clear run lease failed: %v", runID, err)
+	}
+	if run, ok := s.store.GetRun(runID); ok {
+		authPath := filepath.Join(run.RunDir, "codex", "auth.json")
+		if err := os.Remove(authPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			log.Printf("run %s remove auth file failed: %v", runID, err)
+		}
 	}
 }
 
@@ -2115,6 +2596,26 @@ func maxInt(a, b int) int {
 
 func boolPtr(v bool) *bool {
 	return &v
+}
+
+func isCredentialAuthFailure(errText string) bool {
+	text := strings.ToLower(strings.TrimSpace(errText))
+	if text == "" {
+		return false
+	}
+	for _, marker := range []string{
+		"unauthorized",
+		"invalid api key",
+		"invalid token",
+		"authentication failed",
+		"forbidden",
+		"permission denied",
+	} {
+		if strings.Contains(text, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func defaultMaxConcurrent() int {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,7 +53,7 @@ These are the main layers in the Go codebase.
 4. Persistence abstraction
 
 - `internal/state` owns SQLite-backed persistence and state transitions.
-- It stores runs, tasks, run leases, detached run executions, cancel requests, webhook deliveries, and task agent session records.
+- It stores runs, tasks, run leases, detached run executions, cancel requests, webhook deliveries, task agent session records, and encrypted stored credentials plus credential leases.
 - SQL schema lives in embedded migrations and typed queries are generated under `internal/state/sqlitegen`.
 
 5. Supporting integrations
@@ -96,6 +96,8 @@ Key persisted entities:
 - `run_executions`: detached execution handle metadata for adoption and cleanup.
 - `run_cancels`: persisted cancel intent.
 - `task_agent_sessions`: stable backend session identifiers and mounted session roots.
+- `codex_credentials`: encrypted stored credential payloads and allocation metadata.
+- `credential_leases`: per-run credential assignments and lease expiry state.
 - `deliveries`: webhook dedupe/claim bookkeeping.
 
 ## Run Artifacts
@@ -119,6 +121,24 @@ Each run directory stores metadata and artifacts such as:
 - Goose resumes by named Goose session plus mounted session storage.
 - Codex resumes by reusing a task-scoped `CODEX_HOME` and the discovered backend session id.
 - If a Goose resume attempt fails because the stored session is missing or invalid, the runner falls back to a fresh session.
+
+## Credential Handling
+
+Rascal supports stored Codex credentials in addition to the legacy static
+`/etc/rascal/codex_auth.json` file.
+
+- Stored credentials are encrypted before being persisted in SQLite.
+- Each credential is either `personal` (owned by a user) or `shared`.
+- When a run starts, `rascald` asks the credential broker to lease a credential
+  for that run and records the selected credential id in state.
+- The broker chooses from eligible credentials using the configured allocation
+  strategy and enforces `max_active_leases`.
+- The leased auth blob is written into the run-scoped `codex/auth.json` file
+  and removed during run cleanup.
+- While a run is active, `rascald` renews the credential lease. If renewal is
+  lost, the run is canceled.
+- If no stored credential can be leased, Rascal can fall back to the static
+  `RASCAL_CODEX_AUTH_PATH` auth file when present.
 
 ## Runner Environment Contract
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -58,3 +58,30 @@ Tip: use `doctor` to confirm both local and remote resolution.
 ```bash
 ./bin/rascal doctor --host YOUR_SERVER_IP
 ```
+
+## Server Credential Settings
+
+Rascal supports encrypted stored credentials for Codex runs in addition to the
+legacy static auth file on disk.
+
+- `RASCAL_CREDENTIAL_STRATEGY`
+  Allocation strategy for choosing among eligible credentials.
+  Default: `requester_own_then_shared`
+
+- `RASCAL_CREDENTIAL_LEASE_TTL`
+  How long a credential lease stays valid before it must be renewed.
+  Default: `90s`
+
+- `RASCAL_CREDENTIAL_RENEW_INTERVAL`
+  How often the orchestrator renews an active credential lease.
+  Default: `30s`
+
+- `RASCAL_CREDENTIAL_ENCRYPTION_KEY`
+  Key used to encrypt stored credential auth blobs in SQLite.
+  If unset, Rascal falls back to `RASCAL_API_TOKEN`.
+  Recommended: set a dedicated encryption key instead of reusing the API token.
+
+- `RASCAL_CODEX_AUTH_PATH`
+  Path to the static fallback auth file used when no stored credential can be
+  leased.
+  Default: `/etc/rascal/codex_auth.json`

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -77,6 +77,22 @@ Backend notes:
 - Goose resumes a named Goose session with a task-scoped mounted session directory.
 - Codex resumes by reusing a task-scoped `CODEX_HOME` and the last discovered backend session id.
 
+## Credential Leasing
+
+For Codex runs, Rascal can use a leased stored credential instead of relying
+only on the static server auth file.
+
+Operational notes:
+
+- Credential leases are granted per run and renewed while the run is active.
+- If lease renewal fails, Rascal requests cancellation of the run.
+- Shared credentials can be constrained with `max_active_leases`; personal
+  credentials are only available to their owner.
+- Stored credential payloads are encrypted at rest in SQLite using
+  `RASCAL_CREDENTIAL_ENCRYPTION_KEY`.
+- If no stored credential is available, Rascal can fall back to
+  `RASCAL_CODEX_AUTH_PATH` when that file exists.
+
 ## Troubleshooting Checklist
 
 1. Run `doctor` first.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/rtzll/rascal/internal/agent"
 	"github.com/rtzll/rascal/internal/defaults"
@@ -14,29 +15,33 @@ import (
 
 // ServerConfig controls rascald runtime behavior.
 type ServerConfig struct {
-	ListenAddr          string
-	DataDir             string
-	StatePath           string
-	Slot                string
-	ActiveSlotPath      string
-	APIToken            string
-	GitHubToken         string
-	GitHubWebhookSecret string
-	BotLogin            string
-	RunnerMode          string
-	AgentBackend        agent.Backend
-	RunnerImage         string
-	RunnerImageGoose    string
-	RunnerImageCodex    string
-	RunnerMaxAttempts   int
-	CodexAuthPath       string
-	GooseSessionMode    string
-	GooseSessionRoot    string
-	GooseSessionTTLDays int
-	AgentSessionMode    agent.SessionMode
-	AgentSessionRoot    string
-	AgentSessionTTLDays int
-	MaxRuns             int
+	ListenAddr              string
+	DataDir                 string
+	StatePath               string
+	Slot                    string
+	ActiveSlotPath          string
+	APIToken                string
+	GitHubToken             string
+	GitHubWebhookSecret     string
+	BotLogin                string
+	RunnerMode              string
+	AgentBackend            agent.Backend
+	RunnerImage             string
+	RunnerImageGoose        string
+	RunnerImageCodex        string
+	RunnerMaxAttempts       int
+	CodexAuthPath           string
+	CredentialStrategy      string
+	CredentialLeaseTTL      time.Duration
+	CredentialRenewEvery    time.Duration
+	CredentialEncryptionKey string
+	GooseSessionMode        string
+	GooseSessionRoot        string
+	GooseSessionTTLDays     int
+	AgentSessionMode        agent.SessionMode
+	AgentSessionRoot        string
+	AgentSessionTTLDays     int
+	MaxRuns                 int
 }
 
 // ClientConfig controls rascal CLI behavior.
@@ -58,25 +63,29 @@ func LoadServerConfig() ServerConfig {
 	statePath := envOrDefault("RASCAL_STATE_PATH", filepath.Join(dataDir, "state.db"))
 
 	cfg := ServerConfig{
-		ListenAddr:          envOrDefault("RASCAL_LISTEN_ADDR", ":8080"),
-		DataDir:             dataDir,
-		StatePath:           statePath,
-		Slot:                strings.TrimSpace(os.Getenv("RASCAL_SLOT")),
-		ActiveSlotPath:      envOrDefault("RASCAL_ACTIVE_SLOT_PATH", "/etc/rascal/active_slot"),
-		APIToken:            strings.TrimSpace(os.Getenv("RASCAL_API_TOKEN")),
-		GitHubToken:         strings.TrimSpace(os.Getenv("RASCAL_GITHUB_TOKEN")),
-		GitHubWebhookSecret: strings.TrimSpace(os.Getenv("RASCAL_GITHUB_WEBHOOK_SECRET")),
-		BotLogin:            strings.TrimSpace(os.Getenv("RASCAL_BOT_LOGIN")),
-		RunnerMode:          envOrDefault("RASCAL_RUNNER_MODE", "noop"),
-		AgentBackend:        loadAgentBackend(),
-		RunnerImageGoose:    envOrDefault("RASCAL_RUNNER_IMAGE_GOOSE", envOrDefault("RASCAL_RUNNER_IMAGE", defaults.GooseRunnerImageTag)),
-		RunnerImageCodex:    envOrDefault("RASCAL_RUNNER_IMAGE_CODEX", defaults.CodexRunnerImageTag),
-		RunnerMaxAttempts:   envIntOrDefault("RASCAL_RUNNER_MAX_ATTEMPTS", 1),
-		CodexAuthPath:       envOrDefault("RASCAL_CODEX_AUTH_PATH", "/etc/rascal/codex_auth.json"),
-		AgentSessionMode:    loadAgentSessionMode(),
-		AgentSessionRoot:    loadAgentSessionRoot(dataDir),
-		AgentSessionTTLDays: loadAgentSessionTTLDays(),
-		MaxRuns:             200,
+		ListenAddr:              envOrDefault("RASCAL_LISTEN_ADDR", ":8080"),
+		DataDir:                 dataDir,
+		StatePath:               statePath,
+		Slot:                    strings.TrimSpace(os.Getenv("RASCAL_SLOT")),
+		ActiveSlotPath:          envOrDefault("RASCAL_ACTIVE_SLOT_PATH", "/etc/rascal/active_slot"),
+		APIToken:                strings.TrimSpace(os.Getenv("RASCAL_API_TOKEN")),
+		GitHubToken:             strings.TrimSpace(os.Getenv("RASCAL_GITHUB_TOKEN")),
+		GitHubWebhookSecret:     strings.TrimSpace(os.Getenv("RASCAL_GITHUB_WEBHOOK_SECRET")),
+		BotLogin:                strings.TrimSpace(os.Getenv("RASCAL_BOT_LOGIN")),
+		RunnerMode:              envOrDefault("RASCAL_RUNNER_MODE", "noop"),
+		AgentBackend:            loadAgentBackend(),
+		RunnerImageGoose:        envOrDefault("RASCAL_RUNNER_IMAGE_GOOSE", envOrDefault("RASCAL_RUNNER_IMAGE", defaults.GooseRunnerImageTag)),
+		RunnerImageCodex:        envOrDefault("RASCAL_RUNNER_IMAGE_CODEX", defaults.CodexRunnerImageTag),
+		RunnerMaxAttempts:       envIntOrDefault("RASCAL_RUNNER_MAX_ATTEMPTS", 1),
+		CodexAuthPath:           envOrDefault("RASCAL_CODEX_AUTH_PATH", "/etc/rascal/codex_auth.json"),
+		CredentialStrategy:      envOrDefault("RASCAL_CREDENTIAL_STRATEGY", "requester_own_then_shared"),
+		CredentialLeaseTTL:      envDurationOrDefault("RASCAL_CREDENTIAL_LEASE_TTL", 90*time.Second),
+		CredentialRenewEvery:    envDurationOrDefault("RASCAL_CREDENTIAL_RENEW_INTERVAL", 30*time.Second),
+		CredentialEncryptionKey: firstNonEmptyEnv("RASCAL_CREDENTIAL_ENCRYPTION_KEY", "RASCAL_API_TOKEN"),
+		AgentSessionMode:        loadAgentSessionMode(),
+		AgentSessionRoot:        loadAgentSessionRoot(dataDir),
+		AgentSessionTTLDays:     loadAgentSessionTTLDays(),
+		MaxRuns:                 200,
 	}
 	cfg.RunnerImage = cfg.RunnerImageForBackend(cfg.AgentBackend)
 	cfg.GooseSessionMode = string(cfg.AgentSessionMode)
@@ -248,6 +257,15 @@ func envOrDefault(key, fallback string) string {
 	return v
 }
 
+func firstNonEmptyEnv(keys ...string) string {
+	for _, key := range keys {
+		if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
 func envIntOrDefault(key string, fallback int) int {
 	v := strings.TrimSpace(os.Getenv(key))
 	if v == "" {
@@ -272,21 +290,66 @@ func envNonNegativeIntOrDefault(key string, fallback int) int {
 	return out
 }
 
+func envDurationOrDefault(key string, fallback time.Duration) time.Duration {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return fallback
+	}
+	out, err := time.ParseDuration(v)
+	if err != nil || out <= 0 {
+		return fallback
+	}
+	return out
+}
+
 func loadAgentBackend() agent.Backend {
 	return agent.NormalizeBackend(envOrDefault("RASCAL_AGENT_BACKEND", "goose"))
 }
 
 func loadAgentSessionMode() agent.SessionMode {
-	return agent.NormalizeSessionMode(envOrDefault("RASCAL_AGENT_SESSION_MODE", envOrDefault("RASCAL_GOOSE_SESSION_MODE", "all")))
+	if raw, ok := os.LookupEnv("RASCAL_GOOSE_SESSION_MODE"); ok {
+		mode := agent.NormalizeSessionMode(raw)
+		if mode == "" || mode == agent.SessionModeOff {
+			if strings.TrimSpace(raw) == "" {
+				return agent.SessionModeAll
+			}
+		}
+		return mode
+	}
+	if raw, ok := os.LookupEnv("RASCAL_AGENT_SESSION_MODE"); ok {
+		mode := agent.NormalizeSessionMode(raw)
+		if mode == "" || mode == agent.SessionModeOff {
+			if strings.TrimSpace(raw) == "" {
+				return agent.SessionModeAll
+			}
+		}
+		return mode
+	}
+	return agent.SessionModeAll
 }
 
 func loadAgentSessionRoot(dataDir string) string {
-	return envOrDefault("RASCAL_AGENT_SESSION_ROOT", envOrDefault("RASCAL_GOOSE_SESSION_ROOT", filepath.Join(dataDir, defaults.AgentSessionDirName)))
+	if raw, ok := os.LookupEnv("RASCAL_GOOSE_SESSION_ROOT"); ok {
+		if strings.TrimSpace(raw) == "" {
+			return filepath.Join(dataDir, defaults.AgentSessionDirName)
+		}
+		return strings.TrimSpace(raw)
+	}
+	if raw, ok := os.LookupEnv("RASCAL_AGENT_SESSION_ROOT"); ok {
+		if strings.TrimSpace(raw) == "" {
+			return filepath.Join(dataDir, defaults.AgentSessionDirName)
+		}
+		return strings.TrimSpace(raw)
+	}
+	return filepath.Join(dataDir, defaults.AgentSessionDirName)
 }
 
 func loadAgentSessionTTLDays() int {
-	if v := strings.TrimSpace(os.Getenv("RASCAL_AGENT_SESSION_TTL_DAYS")); v != "" {
-		return envNonNegativeIntOrDefault("RASCAL_AGENT_SESSION_TTL_DAYS", 14)
+	if _, ok := os.LookupEnv("RASCAL_GOOSE_SESSION_TTL_DAYS"); ok {
+		return envNonNegativeIntOrDefault("RASCAL_GOOSE_SESSION_TTL_DAYS", 14)
 	}
-	return envNonNegativeIntOrDefault("RASCAL_GOOSE_SESSION_TTL_DAYS", 14)
+	if _, ok := os.LookupEnv("RASCAL_AGENT_SESSION_TTL_DAYS"); !ok {
+		return 14
+	}
+	return envNonNegativeIntOrDefault("RASCAL_AGENT_SESSION_TTL_DAYS", 14)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -151,3 +151,19 @@ func TestLoadServerConfigGooseSessionOverrides(t *testing.T) {
 		t.Fatalf("GooseSessionTTLDays = %d, want 0", cfg.GooseSessionTTLDays)
 	}
 }
+
+func TestLoadServerConfigCredentialEncryptionKeyFallback(t *testing.T) {
+	t.Setenv("RASCAL_CREDENTIAL_ENCRYPTION_KEY", "")
+	t.Setenv("RASCAL_API_TOKEN", "api-token-fallback")
+
+	cfg := LoadServerConfig()
+	if cfg.CredentialEncryptionKey != "api-token-fallback" {
+		t.Fatalf("CredentialEncryptionKey = %q, want api-token-fallback", cfg.CredentialEncryptionKey)
+	}
+
+	t.Setenv("RASCAL_CREDENTIAL_ENCRYPTION_KEY", "explicit-key")
+	cfg = LoadServerConfig()
+	if cfg.CredentialEncryptionKey != "explicit-key" {
+		t.Fatalf("CredentialEncryptionKey = %q, want explicit-key", cfg.CredentialEncryptionKey)
+	}
+}

--- a/internal/credentials/broker.go
+++ b/internal/credentials/broker.go
@@ -1,0 +1,213 @@
+package credentials
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/rtzll/rascal/internal/state"
+)
+
+var (
+	ErrNoCredentialAvailable = errors.New("no credentials available")
+	ErrLeaseLost             = errors.New("credential lease lost")
+)
+
+type CredentialBroker interface {
+	Acquire(ctx context.Context, req AcquireRequest) (Lease, error)
+	Renew(ctx context.Context, leaseID string) error
+	Release(ctx context.Context, leaseID string) error
+}
+
+type Broker struct {
+	store                 *state.Store
+	strategy              AllocationStrategy
+	cipher                Cipher
+	leaseTTL              time.Duration
+	usageWindow           time.Duration
+	cooldownOnCryptoError time.Duration
+}
+
+func NewBroker(store *state.Store, strategy AllocationStrategy, cipher Cipher, leaseTTL time.Duration) *Broker {
+	if leaseTTL <= 0 {
+		leaseTTL = 90 * time.Second
+	}
+	return &Broker{
+		store:                 store,
+		strategy:              strategy,
+		cipher:                cipher,
+		leaseTTL:              leaseTTL,
+		usageWindow:           time.Hour,
+		cooldownOnCryptoError: 5 * time.Minute,
+	}
+}
+
+func (b *Broker) Acquire(_ context.Context, req AcquireRequest) (Lease, error) {
+	req.RunID = strings.TrimSpace(req.RunID)
+	req.UserID = strings.TrimSpace(req.UserID)
+	if req.RunID == "" || req.UserID == "" {
+		return Lease{}, fmt.Errorf("run_id and user_id are required")
+	}
+	if b.store == nil || b.strategy == nil || b.cipher == nil {
+		return Lease{}, ErrNoCredentialAvailable
+	}
+	now := time.Now().UTC()
+	if _, err := b.store.ReclaimExpiredCredentialLeases(now); err != nil {
+		return Lease{}, err
+	}
+	for attempt := 0; attempt < 12; attempt++ {
+		candidates, err := b.store.ListCredentialCandidates(req.UserID, now, now.Add(-b.usageWindow))
+		if err != nil {
+			return Lease{}, err
+		}
+		if len(candidates) == 0 {
+			return Lease{}, ErrNoCredentialAvailable
+		}
+
+		states := make([]CredentialState, 0, len(candidates))
+		for _, c := range candidates {
+			states = append(states, CredentialState{
+				ID:              c.ID,
+				OwnerUserID:     c.OwnerUserID,
+				Scope:           c.Scope,
+				Weight:          c.Weight,
+				MaxActiveLeases: c.MaxActiveLeases,
+				Status:          c.Status,
+				CooldownUntil:   c.CooldownUntil,
+				ActiveLeases:    c.ActiveLeases,
+				UsageTokens:     c.UsageTokens,
+				UsageRuns:       c.UsageRuns,
+				LastError:       c.LastError,
+				CreatedAt:       c.CreatedAt,
+				UpdatedAt:       c.UpdatedAt,
+			})
+		}
+
+		credentialID, err := b.strategy.Select(req, states)
+		if err != nil {
+			if errors.Is(err, ErrNoCredentialMatch) {
+				return Lease{}, ErrNoCredentialAvailable
+			}
+			return Lease{}, err
+		}
+
+		leaseID, err := newLeaseID()
+		if err != nil {
+			return Lease{}, err
+		}
+		acquiredAt := time.Now().UTC()
+		expiresAt := acquiredAt.Add(b.leaseTTL)
+		ok, err := b.store.TryCreateCredentialLease(state.CreateCredentialLeaseInput{
+			ID:           leaseID,
+			CredentialID: credentialID,
+			RunID:        req.RunID,
+			UserID:       req.UserID,
+			Strategy:     b.strategy.Name(),
+			AcquiredAt:   acquiredAt,
+			ExpiresAt:    expiresAt,
+			Now:          acquiredAt,
+		})
+		if err != nil {
+			return Lease{}, err
+		}
+		if !ok {
+			continue
+		}
+
+		credential, exists, err := b.store.GetCodexCredential(credentialID)
+		if err != nil {
+			if _, _, releaseErr := b.store.ReleaseCredentialLease(leaseID); releaseErr != nil {
+				return Lease{}, fmt.Errorf("release credential lease %s after lookup failure: %v: %w", leaseID, releaseErr, err)
+			}
+			return Lease{}, err
+		}
+		if !exists {
+			if _, _, releaseErr := b.store.ReleaseCredentialLease(leaseID); releaseErr != nil {
+				return Lease{}, fmt.Errorf("release credential lease %s after credential %s disappeared: %w", leaseID, credentialID, releaseErr)
+			}
+			return Lease{}, ErrNoCredentialAvailable
+		}
+		authBlob, err := b.cipher.Decrypt(credential.EncryptedAuthBlob)
+		if err != nil {
+			if _, _, releaseErr := b.store.ReleaseCredentialLease(leaseID); releaseErr != nil {
+				return Lease{}, fmt.Errorf("release credential lease %s after decrypt failure: %v: %w", leaseID, releaseErr, err)
+			}
+			until := time.Now().UTC().Add(b.cooldownOnCryptoError)
+			if statusErr := b.store.SetCodexCredentialStatus(credentialID, "cooldown", &until, "credential decrypt failure"); statusErr != nil {
+				return Lease{}, fmt.Errorf("set credential %s cooldown after decrypt failure: %v: %w", credentialID, statusErr, err)
+			}
+			return Lease{}, err
+		}
+		if err := b.store.SetRunCredentialID(req.RunID, credentialID); err != nil {
+			if _, _, releaseErr := b.store.ReleaseCredentialLease(leaseID); releaseErr != nil {
+				return Lease{}, fmt.Errorf("release credential lease %s after run credential update failure: %v: %w", leaseID, releaseErr, err)
+			}
+			return Lease{}, err
+		}
+		return Lease{
+			ID:           leaseID,
+			CredentialID: credentialID,
+			RunID:        req.RunID,
+			UserID:       req.UserID,
+			Strategy:     b.strategy.Name(),
+			AcquiredAt:   acquiredAt,
+			ExpiresAt:    expiresAt,
+			AuthBlob:     authBlob,
+		}, nil
+	}
+	return Lease{}, ErrNoCredentialAvailable
+}
+
+func (b *Broker) Renew(_ context.Context, leaseID string) error {
+	leaseID = strings.TrimSpace(leaseID)
+	if leaseID == "" {
+		return fmt.Errorf("lease id is required")
+	}
+	now := time.Now().UTC()
+	ok, err := b.store.RenewCredentialLease(leaseID, now.Add(b.leaseTTL), now)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return ErrLeaseLost
+	}
+	return nil
+}
+
+func (b *Broker) Release(_ context.Context, leaseID string) error {
+	leaseID = strings.TrimSpace(leaseID)
+	if leaseID == "" {
+		return nil
+	}
+	lease, released, err := b.store.ReleaseCredentialLease(leaseID)
+	if err != nil {
+		return err
+	}
+	if !released {
+		return nil
+	}
+	if err := b.store.UpsertCredentialUsage(lease.CredentialID, time.Now().UTC().Truncate(time.Hour), 0, 1); err != nil {
+		return fmt.Errorf("record credential usage for %s: %w", lease.CredentialID, err)
+	}
+	return nil
+}
+
+func (b *Broker) MarkCredentialCooldown(credentialID, reason string, duration time.Duration) error {
+	if duration <= 0 {
+		duration = 5 * time.Minute
+	}
+	until := time.Now().UTC().Add(duration)
+	return b.store.SetCodexCredentialStatus(credentialID, "cooldown", &until, strings.TrimSpace(reason))
+}
+
+func newLeaseID() (string, error) {
+	buf := make([]byte, 8)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate lease id: %w", err)
+	}
+	return "lease_" + hex.EncodeToString(buf), nil
+}

--- a/internal/credentials/broker_test.go
+++ b/internal/credentials/broker_test.go
@@ -1,0 +1,195 @@
+package credentials_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rtzll/rascal/internal/credentials"
+	credentialstrategies "github.com/rtzll/rascal/internal/credentials/strategies"
+	"github.com/rtzll/rascal/internal/state"
+)
+
+func newBrokerTestStore(t *testing.T) *state.Store {
+	t.Helper()
+	store, err := state.New(filepath.Join(t.TempDir(), "state.db"), 200)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	return store
+}
+
+func createCredential(t *testing.T, store *state.Store, c credentials.Cipher, id, owner, scope string, maxActive int) {
+	t.Helper()
+	blob, err := c.Encrypt([]byte(`{"token":"` + id + `"}`))
+	if err != nil {
+		t.Fatalf("encrypt auth blob: %v", err)
+	}
+	if _, err := store.CreateCodexCredential(state.CreateCodexCredentialInput{
+		ID:                id,
+		OwnerUserID:       owner,
+		Scope:             scope,
+		EncryptedAuthBlob: blob,
+		MaxActiveLeases:   maxActive,
+		Weight:            1,
+		Status:            "active",
+	}); err != nil {
+		t.Fatalf("create credential %s: %v", id, err)
+	}
+}
+
+func TestBrokerAcquireOwnThenShared(t *testing.T) {
+	store := newBrokerTestStore(t)
+	c, err := credentials.NewAESCipher("test-secret")
+	if err != nil {
+		t.Fatalf("new cipher: %v", err)
+	}
+	if _, err := store.UpsertUser(state.UpsertUserInput{ID: "u1", ExternalLogin: "u1", Role: state.UserRoleUser}); err != nil {
+		t.Fatalf("upsert user: %v", err)
+	}
+
+	createCredential(t, store, c, "cred-personal", "u1", "personal", 1)
+	createCredential(t, store, c, "cred-shared", "", "shared", 5)
+
+	strategy, err := credentialstrategies.ByName("requester_own_then_shared")
+	if err != nil {
+		t.Fatalf("strategy: %v", err)
+	}
+	broker := credentials.NewBroker(store, strategy, c, 90*time.Second)
+
+	lease, err := broker.Acquire(t.Context(), credentials.AcquireRequest{RunID: "run-a", UserID: "u1"})
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	if lease.CredentialID != "cred-personal" {
+		t.Fatalf("credential_id = %s, want cred-personal", lease.CredentialID)
+	}
+	if string(lease.AuthBlob) == "" {
+		t.Fatal("expected decrypted auth blob")
+	}
+	if err := broker.Release(t.Context(), lease.ID); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+}
+
+func TestBrokerRenewReleaseAndExpiryReclaim(t *testing.T) {
+	store := newBrokerTestStore(t)
+	c, err := credentials.NewAESCipher("test-secret")
+	if err != nil {
+		t.Fatalf("new cipher: %v", err)
+	}
+	createCredential(t, store, c, "cred-shared", "", "shared", 1)
+	strategy, err := credentialstrategies.ByName("shared_least_active_leases")
+	if err != nil {
+		t.Fatalf("strategy: %v", err)
+	}
+	broker := credentials.NewBroker(store, strategy, c, 50*time.Millisecond)
+
+	lease, err := broker.Acquire(t.Context(), credentials.AcquireRequest{RunID: "run-1", UserID: "u1"})
+	if err != nil {
+		t.Fatalf("acquire run-1: %v", err)
+	}
+	if err := broker.Renew(t.Context(), lease.ID); err != nil {
+		t.Fatalf("renew run-1: %v", err)
+	}
+	if err := broker.Release(t.Context(), lease.ID); err != nil {
+		t.Fatalf("release run-1: %v", err)
+	}
+	if err := broker.Renew(t.Context(), lease.ID); err == nil {
+		t.Fatal("expected renew to fail after release")
+	}
+
+	lease2, err := broker.Acquire(t.Context(), credentials.AcquireRequest{RunID: "run-2", UserID: "u2"})
+	if err != nil {
+		t.Fatalf("acquire run-2: %v", err)
+	}
+	time.Sleep(75 * time.Millisecond)
+	lease3, err := broker.Acquire(t.Context(), credentials.AcquireRequest{RunID: "run-3", UserID: "u3"})
+	if err != nil {
+		t.Fatalf("acquire run-3 after expiry reclaim: %v", err)
+	}
+	if lease3.CredentialID != lease2.CredentialID {
+		t.Fatalf("credential mismatch after reclaim: %s vs %s", lease3.CredentialID, lease2.CredentialID)
+	}
+	if err := broker.Release(t.Context(), lease3.ID); err != nil {
+		t.Fatalf("release run-3: %v", err)
+	}
+}
+
+func TestBrokerConcurrentAcquireRespectsCapacity(t *testing.T) {
+	store := newBrokerTestStore(t)
+	c, err := credentials.NewAESCipher("test-secret")
+	if err != nil {
+		t.Fatalf("new cipher: %v", err)
+	}
+	createCredential(t, store, c, "cred-shared", "", "shared", 1)
+	strategy, err := credentialstrategies.ByName("priority_burst")
+	if err != nil {
+		t.Fatalf("strategy: %v", err)
+	}
+	broker := credentials.NewBroker(store, strategy, c, 90*time.Second)
+
+	var successes atomic.Int64
+	var leaseIDs []string
+	var leaseMu sync.Mutex
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			lease, err := broker.Acquire(t.Context(), credentials.AcquireRequest{
+				RunID:  fmt.Sprintf("run-c-%d", idx),
+				UserID: "u1",
+			})
+			if err == nil {
+				successes.Add(1)
+				leaseMu.Lock()
+				leaseIDs = append(leaseIDs, lease.ID)
+				leaseMu.Unlock()
+			}
+		}(i)
+	}
+	wg.Wait()
+	if successes.Load() != 1 {
+		t.Fatalf("expected exactly one successful acquire, got %d", successes.Load())
+	}
+	for _, leaseID := range leaseIDs {
+		if err := broker.Release(t.Context(), leaseID); err != nil {
+			t.Fatalf("release %s: %v", leaseID, err)
+		}
+	}
+}
+
+func TestBrokerSkipsCooldownCredentials(t *testing.T) {
+	store := newBrokerTestStore(t)
+	c, err := credentials.NewAESCipher("test-secret")
+	if err != nil {
+		t.Fatalf("new cipher: %v", err)
+	}
+	createCredential(t, store, c, "cred-cooldown", "", "shared", 1)
+	createCredential(t, store, c, "cred-active", "", "shared", 1)
+
+	until := time.Now().UTC().Add(10 * time.Minute)
+	if err := store.SetCodexCredentialStatus("cred-cooldown", "cooldown", &until, "auth failure"); err != nil {
+		t.Fatalf("set cooldown: %v", err)
+	}
+
+	strategy, err := credentialstrategies.ByName("shared_least_active_leases")
+	if err != nil {
+		t.Fatalf("strategy: %v", err)
+	}
+	broker := credentials.NewBroker(store, strategy, c, 90*time.Second)
+	lease, err := broker.Acquire(t.Context(), credentials.AcquireRequest{RunID: "run-cooldown", UserID: "u1"})
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	if lease.CredentialID != "cred-active" {
+		t.Fatalf("credential_id = %s, want cred-active", lease.CredentialID)
+	}
+	if err := broker.Release(t.Context(), lease.ID); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+}

--- a/internal/credentials/crypto.go
+++ b/internal/credentials/crypto.go
@@ -1,0 +1,53 @@
+package credentials
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+)
+
+type Cipher interface {
+	Encrypt(plaintext []byte) ([]byte, error)
+	Decrypt(ciphertext []byte) ([]byte, error)
+}
+
+type AESCipher struct {
+	aead cipher.AEAD
+}
+
+func NewAESCipher(secret string) (*AESCipher, error) {
+	sum := sha256.Sum256([]byte(secret))
+	block, err := aes.NewCipher(sum[:])
+	if err != nil {
+		return nil, fmt.Errorf("create cipher block: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("create gcm: %w", err)
+	}
+	return &AESCipher{aead: aead}, nil
+}
+
+func (c *AESCipher) Encrypt(plaintext []byte) ([]byte, error) {
+	nonce := make([]byte, c.aead.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("generate nonce: %w", err)
+	}
+	out := c.aead.Seal(nil, nonce, plaintext, nil)
+	return append(nonce, out...), nil
+}
+
+func (c *AESCipher) Decrypt(ciphertext []byte) ([]byte, error) {
+	if len(ciphertext) < c.aead.NonceSize() {
+		return nil, fmt.Errorf("ciphertext too short")
+	}
+	nonce := ciphertext[:c.aead.NonceSize()]
+	body := ciphertext[c.aead.NonceSize():]
+	out, err := c.aead.Open(nil, nonce, body, nil)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt credential blob: %w", err)
+	}
+	return out, nil
+}

--- a/internal/credentials/models.go
+++ b/internal/credentials/models.go
@@ -1,0 +1,35 @@
+package credentials
+
+import "time"
+
+type AcquireRequest struct {
+	RunID  string
+	UserID string
+}
+
+type Lease struct {
+	ID           string
+	CredentialID string
+	RunID        string
+	UserID       string
+	Strategy     string
+	AcquiredAt   time.Time
+	ExpiresAt    time.Time
+	AuthBlob     []byte
+}
+
+type CredentialState struct {
+	ID              string
+	OwnerUserID     string
+	Scope           string
+	Weight          int
+	MaxActiveLeases int
+	Status          string
+	CooldownUntil   *time.Time
+	ActiveLeases    int
+	UsageTokens     int64
+	UsageRuns       int64
+	LastError       string
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}

--- a/internal/credentials/strategies/helpers.go
+++ b/internal/credentials/strategies/helpers.go
@@ -1,0 +1,29 @@
+package strategies
+
+import (
+	"sort"
+
+	"github.com/rtzll/rascal/internal/credentials"
+)
+
+func cloneAndSortByID(candidates []credentials.CredentialState) []credentials.CredentialState {
+	out := append([]credentials.CredentialState(nil), candidates...)
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+func filter(candidates []credentials.CredentialState, pred func(credentials.CredentialState) bool) []credentials.CredentialState {
+	out := make([]credentials.CredentialState, 0, len(candidates))
+	for _, candidate := range candidates {
+		if pred(candidate) {
+			out = append(out, candidate)
+		}
+	}
+	return out
+}
+
+func hasCapacity(candidate credentials.CredentialState) bool {
+	return candidate.MaxActiveLeases > candidate.ActiveLeases
+}

--- a/internal/credentials/strategies/hybrid_reserve_plus_pool.go
+++ b/internal/credentials/strategies/hybrid_reserve_plus_pool.go
@@ -1,0 +1,39 @@
+package strategies
+
+import "github.com/rtzll/rascal/internal/credentials"
+
+type HybridReservePlusPool struct{}
+
+func (HybridReservePlusPool) Name() string { return "hybrid_reserve_plus_pool" }
+
+func (HybridReservePlusPool) Select(req credentials.AcquireRequest, candidates []credentials.CredentialState) (string, error) {
+	sorted := cloneAndSortByID(candidates)
+	personal := filter(sorted, func(candidate credentials.CredentialState) bool {
+		return candidate.Scope == "personal" && candidate.OwnerUserID == req.UserID && hasCapacity(candidate)
+	})
+	for _, candidate := range personal {
+		reserve := candidate.MaxActiveLeases / 2
+		if reserve < 1 {
+			reserve = 1
+		}
+		if candidate.ActiveLeases < reserve {
+			return candidate.ID, nil
+		}
+	}
+	shared := filter(sorted, func(candidate credentials.CredentialState) bool {
+		return candidate.Scope == "shared" && hasCapacity(candidate)
+	})
+	if len(shared) == 0 {
+		if len(personal) > 0 {
+			return personal[0].ID, nil
+		}
+		return "", credentials.ErrNoCredentialMatch
+	}
+	best := shared[0]
+	for _, candidate := range shared[1:] {
+		if candidate.ActiveLeases < best.ActiveLeases {
+			best = candidate
+		}
+	}
+	return best.ID, nil
+}

--- a/internal/credentials/strategies/priority_burst.go
+++ b/internal/credentials/strategies/priority_burst.go
@@ -1,0 +1,30 @@
+package strategies
+
+import "github.com/rtzll/rascal/internal/credentials"
+
+type PriorityBurst struct{}
+
+func (PriorityBurst) Name() string { return "priority_burst" }
+
+func (PriorityBurst) Select(_ credentials.AcquireRequest, candidates []credentials.CredentialState) (string, error) {
+	sorted := cloneAndSortByID(candidates)
+	bestID := ""
+	bestSpare := -1
+	bestShared := false
+	for _, candidate := range sorted {
+		if !hasCapacity(candidate) {
+			continue
+		}
+		spare := candidate.MaxActiveLeases - candidate.ActiveLeases
+		isShared := candidate.Scope == "shared"
+		if spare > bestSpare || (spare == bestSpare && isShared && !bestShared) {
+			bestID = candidate.ID
+			bestSpare = spare
+			bestShared = isShared
+		}
+	}
+	if bestID == "" {
+		return "", credentials.ErrNoCredentialMatch
+	}
+	return bestID, nil
+}

--- a/internal/credentials/strategies/registry.go
+++ b/internal/credentials/strategies/registry.go
@@ -1,0 +1,25 @@
+package strategies
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rtzll/rascal/internal/credentials"
+)
+
+func ByName(name string) (credentials.AllocationStrategy, error) {
+	switch strings.TrimSpace(strings.ToLower(name)) {
+	case "", "requester_own_then_shared":
+		return RequesterOwnThenShared{}, nil
+	case "shared_least_active_leases":
+		return SharedLeastActiveLeases{}, nil
+	case "shared_weighted_usage":
+		return SharedWeightedUsage{}, nil
+	case "priority_burst":
+		return PriorityBurst{}, nil
+	case "hybrid_reserve_plus_pool":
+		return HybridReservePlusPool{}, nil
+	default:
+		return nil, fmt.Errorf("unknown credential strategy %q", name)
+	}
+}

--- a/internal/credentials/strategies/requester_own_then_shared.go
+++ b/internal/credentials/strategies/requester_own_then_shared.go
@@ -1,0 +1,38 @@
+package strategies
+
+import (
+	"github.com/rtzll/rascal/internal/credentials"
+)
+
+type RequesterOwnThenShared struct{}
+
+func (RequesterOwnThenShared) Name() string { return "requester_own_then_shared" }
+
+func (RequesterOwnThenShared) Select(req credentials.AcquireRequest, candidates []credentials.CredentialState) (string, error) {
+	sorted := cloneAndSortByID(candidates)
+	own := filter(sorted, func(candidate credentials.CredentialState) bool {
+		return candidate.Scope == "personal" && candidate.OwnerUserID == req.UserID && hasCapacity(candidate)
+	})
+	if len(own) > 0 {
+		best := own[0]
+		for _, candidate := range own[1:] {
+			if candidate.ActiveLeases < best.ActiveLeases {
+				best = candidate
+			}
+		}
+		return best.ID, nil
+	}
+	shared := filter(sorted, func(candidate credentials.CredentialState) bool {
+		return candidate.Scope == "shared" && hasCapacity(candidate)
+	})
+	if len(shared) == 0 {
+		return "", credentials.ErrNoCredentialMatch
+	}
+	best := shared[0]
+	for _, candidate := range shared[1:] {
+		if candidate.ActiveLeases < best.ActiveLeases {
+			best = candidate
+		}
+	}
+	return best.ID, nil
+}

--- a/internal/credentials/strategies/shared_least_active_leases.go
+++ b/internal/credentials/strategies/shared_least_active_leases.go
@@ -1,0 +1,23 @@
+package strategies
+
+import "github.com/rtzll/rascal/internal/credentials"
+
+type SharedLeastActiveLeases struct{}
+
+func (SharedLeastActiveLeases) Name() string { return "shared_least_active_leases" }
+
+func (SharedLeastActiveLeases) Select(_ credentials.AcquireRequest, candidates []credentials.CredentialState) (string, error) {
+	shared := filter(cloneAndSortByID(candidates), func(candidate credentials.CredentialState) bool {
+		return candidate.Scope == "shared" && hasCapacity(candidate)
+	})
+	if len(shared) == 0 {
+		return "", credentials.ErrNoCredentialMatch
+	}
+	best := shared[0]
+	for _, candidate := range shared[1:] {
+		if candidate.ActiveLeases < best.ActiveLeases {
+			best = candidate
+		}
+	}
+	return best.ID, nil
+}

--- a/internal/credentials/strategies/shared_weighted_usage.go
+++ b/internal/credentials/strategies/shared_weighted_usage.go
@@ -1,0 +1,43 @@
+package strategies
+
+import (
+	"math"
+
+	"github.com/rtzll/rascal/internal/credentials"
+)
+
+type SharedWeightedUsage struct{}
+
+func (SharedWeightedUsage) Name() string { return "shared_weighted_usage" }
+
+func (SharedWeightedUsage) Select(_ credentials.AcquireRequest, candidates []credentials.CredentialState) (string, error) {
+	shared := filter(cloneAndSortByID(candidates), func(candidate credentials.CredentialState) bool {
+		return candidate.Scope == "shared" && hasCapacity(candidate)
+	})
+	if len(shared) == 0 {
+		return "", credentials.ErrNoCredentialMatch
+	}
+	bestID := ""
+	bestScore := math.MaxFloat64
+	for _, candidate := range shared {
+		weight := float64(candidate.Weight)
+		if weight < 1 {
+			weight = 1
+		}
+		capacity := float64(candidate.MaxActiveLeases)
+		if capacity < 1 {
+			capacity = 1
+		}
+		load := float64(candidate.ActiveLeases) / capacity
+		usagePenalty := float64(candidate.UsageTokens)/weight/1_000_000 + float64(candidate.UsageRuns)/weight
+		score := load + usagePenalty
+		if score < bestScore {
+			bestID = candidate.ID
+			bestScore = score
+		}
+	}
+	if bestID == "" {
+		return "", credentials.ErrNoCredentialMatch
+	}
+	return bestID, nil
+}

--- a/internal/credentials/strategies/strategies_test.go
+++ b/internal/credentials/strategies/strategies_test.go
@@ -1,0 +1,78 @@
+package strategies
+
+import (
+	"testing"
+
+	"github.com/rtzll/rascal/internal/credentials"
+)
+
+func TestRequesterOwnThenSharedSelectsPersonalFirst(t *testing.T) {
+	strategy := RequesterOwnThenShared{}
+	got, err := strategy.Select(credentials.AcquireRequest{UserID: "u1"}, []credentials.CredentialState{
+		{ID: "shared-a", Scope: "shared", MaxActiveLeases: 2, ActiveLeases: 0},
+		{ID: "personal-a", Scope: "personal", OwnerUserID: "u1", MaxActiveLeases: 1, ActiveLeases: 0},
+	})
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if got != "personal-a" {
+		t.Fatalf("credential_id = %s, want personal-a", got)
+	}
+}
+
+func TestSharedLeastActiveLeases(t *testing.T) {
+	strategy := SharedLeastActiveLeases{}
+	got, err := strategy.Select(credentials.AcquireRequest{}, []credentials.CredentialState{
+		{ID: "shared-a", Scope: "shared", MaxActiveLeases: 2, ActiveLeases: 1},
+		{ID: "shared-b", Scope: "shared", MaxActiveLeases: 2, ActiveLeases: 0},
+	})
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if got != "shared-b" {
+		t.Fatalf("credential_id = %s, want shared-b", got)
+	}
+}
+
+func TestSharedWeightedUsagePrefersLowerUsageScore(t *testing.T) {
+	strategy := SharedWeightedUsage{}
+	got, err := strategy.Select(credentials.AcquireRequest{}, []credentials.CredentialState{
+		{ID: "shared-a", Scope: "shared", Weight: 1, MaxActiveLeases: 2, ActiveLeases: 0, UsageRuns: 9, UsageTokens: 9_000_000},
+		{ID: "shared-b", Scope: "shared", Weight: 3, MaxActiveLeases: 2, ActiveLeases: 0, UsageRuns: 1, UsageTokens: 500_000},
+	})
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if got != "shared-b" {
+		t.Fatalf("credential_id = %s, want shared-b", got)
+	}
+}
+
+func TestPriorityBurstPrefersLargestSpareSharedCapacity(t *testing.T) {
+	strategy := PriorityBurst{}
+	got, err := strategy.Select(credentials.AcquireRequest{}, []credentials.CredentialState{
+		{ID: "personal-a", Scope: "personal", MaxActiveLeases: 5, ActiveLeases: 2},
+		{ID: "shared-a", Scope: "shared", MaxActiveLeases: 4, ActiveLeases: 0},
+		{ID: "shared-b", Scope: "shared", MaxActiveLeases: 3, ActiveLeases: 0},
+	})
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if got != "shared-a" {
+		t.Fatalf("credential_id = %s, want shared-a (highest spare capacity with shared priority)", got)
+	}
+}
+
+func TestHybridReservePlusPoolUsesSharedAfterReserve(t *testing.T) {
+	strategy := HybridReservePlusPool{}
+	got, err := strategy.Select(credentials.AcquireRequest{UserID: "u1"}, []credentials.CredentialState{
+		{ID: "personal-a", Scope: "personal", OwnerUserID: "u1", MaxActiveLeases: 4, ActiveLeases: 3},
+		{ID: "shared-a", Scope: "shared", MaxActiveLeases: 3, ActiveLeases: 0},
+	})
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if got != "shared-a" {
+		t.Fatalf("credential_id = %s, want shared-a", got)
+	}
+}

--- a/internal/credentials/strategy.go
+++ b/internal/credentials/strategy.go
@@ -1,0 +1,10 @@
+package credentials
+
+import "fmt"
+
+type AllocationStrategy interface {
+	Name() string
+	Select(req AcquireRequest, candidates []CredentialState) (credentialID string, err error)
+}
+
+var ErrNoCredentialMatch = fmt.Errorf("no credential matched allocation strategy")

--- a/internal/state/credentials.go
+++ b/internal/state/credentials.go
@@ -1,0 +1,681 @@
+package state
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/rtzll/rascal/internal/state/sqlitegen"
+)
+
+type UserRole string
+
+const (
+	UserRoleUser  UserRole = "user"
+	UserRoleAdmin UserRole = "admin"
+)
+
+type User struct {
+	ID            string    `json:"id"`
+	ExternalLogin string    `json:"external_login"`
+	Role          UserRole  `json:"role"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+type APIPrincipal struct {
+	APIKeyID      string
+	UserID        string
+	ExternalLogin string
+	Role          UserRole
+}
+
+type RunCredentialInfo struct {
+	RunID           string
+	CreatedByUserID string
+	CredentialID    string
+}
+
+type CodexCredential struct {
+	ID                string
+	OwnerUserID       string
+	Scope             string
+	EncryptedAuthBlob []byte
+	Weight            int
+	MaxActiveLeases   int
+	Status            string
+	CooldownUntil     *time.Time
+	LastError         string
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+}
+
+type CredentialCandidate struct {
+	ID              string
+	OwnerUserID     string
+	Scope           string
+	Weight          int
+	MaxActiveLeases int
+	Status          string
+	CooldownUntil   *time.Time
+	ActiveLeases    int
+	UsageTokens     int64
+	UsageRuns       int64
+	LastError       string
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
+type CredentialLease struct {
+	ID           string
+	CredentialID string
+	RunID        string
+	UserID       string
+	Strategy     string
+	AcquiredAt   time.Time
+	ExpiresAt    time.Time
+	ReleasedAt   *time.Time
+}
+
+type UpsertUserInput struct {
+	ID            string
+	ExternalLogin string
+	Role          UserRole
+}
+
+type UpsertAPIKeyInput struct {
+	ID      string
+	UserID  string
+	KeyHash string
+	Label   string
+}
+
+type CreateCodexCredentialInput struct {
+	ID                string
+	OwnerUserID       string
+	Scope             string
+	EncryptedAuthBlob []byte
+	Weight            int
+	MaxActiveLeases   int
+	Status            string
+	CooldownUntil     *time.Time
+	LastError         string
+}
+
+type UpdateCodexCredentialInput struct {
+	ID                string
+	OwnerUserID       string
+	Scope             string
+	EncryptedAuthBlob []byte
+	Weight            int
+	MaxActiveLeases   int
+	Status            string
+	CooldownUntil     *time.Time
+	LastError         string
+}
+
+type CreateCredentialLeaseInput struct {
+	ID           string
+	CredentialID string
+	RunID        string
+	UserID       string
+	Strategy     string
+	AcquiredAt   time.Time
+	ExpiresAt    time.Time
+	Now          time.Time
+}
+
+func normalizeUserRole(role UserRole) UserRole {
+	switch strings.ToLower(strings.TrimSpace(string(role))) {
+	case string(UserRoleAdmin):
+		return UserRoleAdmin
+	default:
+		return UserRoleUser
+	}
+}
+
+func (s *Store) UpsertUser(in UpsertUserInput) (User, error) {
+	in.ID = strings.TrimSpace(in.ID)
+	in.ExternalLogin = strings.TrimSpace(in.ExternalLogin)
+	in.Role = normalizeUserRole(in.Role)
+	if in.ID == "" || in.ExternalLogin == "" {
+		return User{}, fmt.Errorf("id and external_login are required")
+	}
+	now := time.Now().UTC().UnixNano()
+	if err := s.q.UpsertUser(context.Background(), sqlitegen.UpsertUserParams{
+		ID:            in.ID,
+		ExternalLogin: in.ExternalLogin,
+		Role:          string(in.Role),
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}); err != nil {
+		return User{}, err
+	}
+	row, err := s.q.GetUserByID(context.Background(), in.ID)
+	if err != nil {
+		return User{}, err
+	}
+	return fromDBUser(row), nil
+}
+
+func (s *Store) GetUserByID(userID string) (User, bool) {
+	row, err := s.q.GetUserByID(context.Background(), strings.TrimSpace(userID))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return User{}, false
+		}
+		return User{}, false
+	}
+	return fromDBUser(row), true
+}
+
+func (s *Store) GetUserByExternalLogin(externalLogin string) (User, bool) {
+	row, err := s.q.GetUserByExternalLogin(context.Background(), strings.TrimSpace(externalLogin))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return User{}, false
+		}
+		return User{}, false
+	}
+	return fromDBUser(row), true
+}
+
+func (s *Store) UpsertAPIKey(in UpsertAPIKeyInput) error {
+	in.ID = strings.TrimSpace(in.ID)
+	in.UserID = strings.TrimSpace(in.UserID)
+	in.KeyHash = strings.TrimSpace(in.KeyHash)
+	in.Label = strings.TrimSpace(in.Label)
+	if in.ID == "" || in.UserID == "" || in.KeyHash == "" {
+		return fmt.Errorf("id, user_id and key_hash are required")
+	}
+	now := time.Now().UTC().UnixNano()
+	return s.q.UpsertAPIKey(context.Background(), sqlitegen.UpsertAPIKeyParams{
+		ID:         in.ID,
+		UserID:     in.UserID,
+		KeyHash:    in.KeyHash,
+		Label:      in.Label,
+		CreatedAt:  now,
+		LastUsedAt: now,
+		DisabledAt: sql.NullInt64{},
+	})
+}
+
+func (s *Store) ResolveAPIPrincipalByKeyHash(keyHash string) (APIPrincipal, bool, error) {
+	keyHash = strings.TrimSpace(keyHash)
+	if keyHash == "" {
+		return APIPrincipal{}, false, nil
+	}
+	row, err := s.q.GetAPIKeyPrincipal(context.Background(), keyHash)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return APIPrincipal{}, false, nil
+		}
+		return APIPrincipal{}, false, err
+	}
+	if _, err := s.q.TouchAPIKeyLastUsed(context.Background(), sqlitegen.TouchAPIKeyLastUsedParams{
+		LastUsedAt: time.Now().UTC().UnixNano(),
+		ID:         row.ApiKeyID,
+	}); err != nil {
+		log.Printf("touch api key last used for %s failed: %v", row.ApiKeyID, err)
+	}
+	return APIPrincipal{
+		APIKeyID:      row.ApiKeyID,
+		UserID:        row.UserID,
+		ExternalLogin: row.ExternalLogin,
+		Role:          normalizeUserRole(UserRole(row.Role)),
+	}, true, nil
+}
+
+func (s *Store) SetTaskCreatedByUser(taskID, userID string) error {
+	taskID = strings.TrimSpace(taskID)
+	userID = strings.TrimSpace(userID)
+	if taskID == "" || userID == "" {
+		return nil
+	}
+	_, err := s.q.SetTaskCreatedByUser(context.Background(), sqlitegen.SetTaskCreatedByUserParams{
+		CreatedByUserID: userID,
+		UpdatedAt:       time.Now().UTC().UnixNano(),
+		ID:              taskID,
+	})
+	return err
+}
+
+func (s *Store) SetRunCreatedByUser(runID, userID string) error {
+	runID = strings.TrimSpace(runID)
+	userID = strings.TrimSpace(userID)
+	if runID == "" || userID == "" {
+		return nil
+	}
+	_, err := s.q.SetRunCreatedByUser(context.Background(), sqlitegen.SetRunCreatedByUserParams{
+		CreatedByUserID: userID,
+		UpdatedAt:       time.Now().UTC().UnixNano(),
+		ID:              runID,
+	})
+	return err
+}
+
+func (s *Store) SetRunCredentialID(runID, credentialID string) error {
+	runID = strings.TrimSpace(runID)
+	credentialID = strings.TrimSpace(credentialID)
+	if runID == "" {
+		return nil
+	}
+	_, err := s.q.SetRunCredentialID(context.Background(), sqlitegen.SetRunCredentialIDParams{
+		CredentialID: credentialID,
+		UpdatedAt:    time.Now().UTC().UnixNano(),
+		ID:           runID,
+	})
+	return err
+}
+
+func (s *Store) GetRunCredentialInfo(runID string) (RunCredentialInfo, bool) {
+	row, err := s.q.GetRunCredentialInfo(context.Background(), strings.TrimSpace(runID))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return RunCredentialInfo{}, false
+		}
+		return RunCredentialInfo{}, false
+	}
+	return RunCredentialInfo{
+		RunID:           row.ID,
+		CreatedByUserID: row.CreatedByUserID,
+		CredentialID:    row.CredentialID,
+	}, true
+}
+
+func (s *Store) CreateCodexCredential(in CreateCodexCredentialInput) (CodexCredential, error) {
+	in.ID = strings.TrimSpace(in.ID)
+	in.OwnerUserID = strings.TrimSpace(in.OwnerUserID)
+	in.Scope = strings.TrimSpace(strings.ToLower(in.Scope))
+	in.Status = strings.TrimSpace(strings.ToLower(in.Status))
+	if in.ID == "" {
+		return CodexCredential{}, fmt.Errorf("id is required")
+	}
+	if in.Scope == "" {
+		in.Scope = "personal"
+	}
+	if in.Status == "" {
+		in.Status = "active"
+	}
+	if in.Weight <= 0 {
+		in.Weight = 1
+	}
+	if in.MaxActiveLeases <= 0 {
+		in.MaxActiveLeases = 1
+	}
+	now := time.Now().UTC()
+	if err := s.q.CreateCodexCredential(context.Background(), sqlitegen.CreateCodexCredentialParams{
+		ID:                in.ID,
+		OwnerUserID:       toNullString(in.OwnerUserID),
+		Scope:             in.Scope,
+		EncryptedAuthBlob: in.EncryptedAuthBlob,
+		Weight:            int64(in.Weight),
+		MaxActiveLeases:   int64(in.MaxActiveLeases),
+		Status:            in.Status,
+		CooldownUntil:     toNullInt64(in.CooldownUntil),
+		LastError:         in.LastError,
+		CreatedAt:         now.UnixNano(),
+		UpdatedAt:         now.UnixNano(),
+	}); err != nil {
+		return CodexCredential{}, err
+	}
+	out, ok, err := s.GetCodexCredential(in.ID)
+	if err != nil {
+		return CodexCredential{}, err
+	}
+	if !ok {
+		return CodexCredential{}, fmt.Errorf("credential %q not found after create", in.ID)
+	}
+	return out, nil
+}
+
+func (s *Store) UpdateCodexCredential(in UpdateCodexCredentialInput) (CodexCredential, error) {
+	in.ID = strings.TrimSpace(in.ID)
+	in.OwnerUserID = strings.TrimSpace(in.OwnerUserID)
+	in.Scope = strings.TrimSpace(strings.ToLower(in.Scope))
+	in.Status = strings.TrimSpace(strings.ToLower(in.Status))
+	if in.ID == "" {
+		return CodexCredential{}, fmt.Errorf("id is required")
+	}
+	if in.Scope == "" {
+		in.Scope = "personal"
+	}
+	if in.Status == "" {
+		in.Status = "active"
+	}
+	if in.Weight <= 0 {
+		in.Weight = 1
+	}
+	if in.MaxActiveLeases <= 0 {
+		in.MaxActiveLeases = 1
+	}
+	rows, err := s.q.UpdateCodexCredential(context.Background(), sqlitegen.UpdateCodexCredentialParams{
+		OwnerUserID:       toNullString(in.OwnerUserID),
+		Scope:             in.Scope,
+		EncryptedAuthBlob: in.EncryptedAuthBlob,
+		Weight:            int64(in.Weight),
+		MaxActiveLeases:   int64(in.MaxActiveLeases),
+		Status:            in.Status,
+		CooldownUntil:     toNullInt64(in.CooldownUntil),
+		LastError:         in.LastError,
+		UpdatedAt:         time.Now().UTC().UnixNano(),
+		ID:                in.ID,
+	})
+	if err != nil {
+		return CodexCredential{}, err
+	}
+	if rows == 0 {
+		return CodexCredential{}, fmt.Errorf("credential %q not found", in.ID)
+	}
+	out, ok, err := s.GetCodexCredential(in.ID)
+	if err != nil {
+		return CodexCredential{}, err
+	}
+	if !ok {
+		return CodexCredential{}, fmt.Errorf("credential %q not found after update", in.ID)
+	}
+	return out, nil
+}
+
+func (s *Store) SetCodexCredentialStatus(credentialID, status string, cooldownUntil *time.Time, lastError string) error {
+	credentialID = strings.TrimSpace(credentialID)
+	status = strings.TrimSpace(strings.ToLower(status))
+	if credentialID == "" {
+		return nil
+	}
+	if status == "" {
+		status = "active"
+	}
+	_, err := s.q.SetCodexCredentialStatus(context.Background(), sqlitegen.SetCodexCredentialStatusParams{
+		Status:        status,
+		CooldownUntil: toNullInt64(cooldownUntil),
+		LastError:     strings.TrimSpace(lastError),
+		UpdatedAt:     time.Now().UTC().UnixNano(),
+		ID:            credentialID,
+	})
+	return err
+}
+
+func (s *Store) GetCodexCredential(credentialID string) (CodexCredential, bool, error) {
+	row, err := s.q.GetCodexCredential(context.Background(), strings.TrimSpace(credentialID))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return CodexCredential{}, false, nil
+		}
+		return CodexCredential{}, false, err
+	}
+	return fromDBCodexCredential(row), true, nil
+}
+
+func (s *Store) ListCodexCredentialsByOwner(ownerUserID string) ([]CodexCredential, error) {
+	rows, err := s.q.ListCodexCredentialsByOwner(context.Background(), toNullString(ownerUserID))
+	if err != nil {
+		return nil, err
+	}
+	out := make([]CodexCredential, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, fromDBCodexCredential(row))
+	}
+	return out, nil
+}
+
+func (s *Store) ListSharedCodexCredentials() ([]CodexCredential, error) {
+	rows, err := s.q.ListSharedCodexCredentials(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	out := make([]CodexCredential, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, fromDBCodexCredential(row))
+	}
+	return out, nil
+}
+
+func (s *Store) ListAllCodexCredentials() ([]CodexCredential, error) {
+	rows, err := s.q.ListAllCodexCredentials(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	out := make([]CodexCredential, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, fromDBCodexCredential(row))
+	}
+	return out, nil
+}
+
+func (s *Store) ListCredentialCandidates(requesterUserID string, now, usageWindowStart time.Time) ([]CredentialCandidate, error) {
+	rows, err := s.q.ListCredentialCandidates(context.Background(), sqlitegen.ListCredentialCandidatesParams{
+		Now:              now.UTC().UnixNano(),
+		UsageWindowStart: usageWindowStart.UTC().UnixNano(),
+		RequesterUserID:  toNullString(requesterUserID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]CredentialCandidate, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, CredentialCandidate{
+			ID:              row.ID,
+			OwnerUserID:     fromNullString(row.OwnerUserID),
+			Scope:           row.Scope,
+			Weight:          int(row.Weight),
+			MaxActiveLeases: int(row.MaxActiveLeases),
+			Status:          row.Status,
+			CooldownUntil:   fromNullTime(row.CooldownUntil),
+			ActiveLeases:    int(row.ActiveLeases),
+			UsageTokens:     row.UsageTokens,
+			UsageRuns:       row.UsageRuns,
+			LastError:       row.LastError,
+			CreatedAt:       time.Unix(0, row.CreatedAt).UTC(),
+			UpdatedAt:       time.Unix(0, row.UpdatedAt).UTC(),
+		})
+	}
+	return out, nil
+}
+
+func (s *Store) TryCreateCredentialLease(in CreateCredentialLeaseInput) (bool, error) {
+	in.ID = strings.TrimSpace(in.ID)
+	in.CredentialID = strings.TrimSpace(in.CredentialID)
+	in.RunID = strings.TrimSpace(in.RunID)
+	in.UserID = strings.TrimSpace(in.UserID)
+	in.Strategy = strings.TrimSpace(in.Strategy)
+	if in.ID == "" || in.CredentialID == "" || in.RunID == "" || in.UserID == "" {
+		return false, fmt.Errorf("id, credential_id, run_id and user_id are required")
+	}
+	if in.Strategy == "" {
+		in.Strategy = "requester_own_then_shared"
+	}
+	if in.AcquiredAt.IsZero() {
+		in.AcquiredAt = time.Now().UTC()
+	}
+	if in.ExpiresAt.IsZero() || !in.ExpiresAt.After(in.AcquiredAt) {
+		in.ExpiresAt = in.AcquiredAt.Add(90 * time.Second)
+	}
+	if in.Now.IsZero() {
+		in.Now = in.AcquiredAt
+	}
+	rows, err := s.q.TryCreateCredentialLease(context.Background(), sqlitegen.TryCreateCredentialLeaseParams{
+		ID:           in.ID,
+		CredentialID: in.CredentialID,
+		RunID:        in.RunID,
+		UserID:       in.UserID,
+		Strategy:     in.Strategy,
+		AcquiredAt:   in.AcquiredAt.UTC().UnixNano(),
+		ExpiresAt:    in.ExpiresAt.UTC().UnixNano(),
+		Now:          sql.NullInt64{Int64: in.Now.UTC().UnixNano(), Valid: true},
+	})
+	if err != nil {
+		return false, err
+	}
+	return rows > 0, nil
+}
+
+func (s *Store) GetCredentialLease(leaseID string) (CredentialLease, bool, error) {
+	row, err := s.q.GetCredentialLease(context.Background(), strings.TrimSpace(leaseID))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return CredentialLease{}, false, nil
+		}
+		return CredentialLease{}, false, err
+	}
+	return fromDBCredentialLease(row), true, nil
+}
+
+func (s *Store) GetActiveCredentialLeaseByRunID(runID string) (CredentialLease, bool, error) {
+	row, err := s.q.GetActiveCredentialLeaseByRunID(context.Background(), strings.TrimSpace(runID))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return CredentialLease{}, false, nil
+		}
+		return CredentialLease{}, false, err
+	}
+	return fromDBCredentialLease(row), true, nil
+}
+
+func (s *Store) RenewCredentialLease(leaseID string, expiresAt, now time.Time) (bool, error) {
+	leaseID = strings.TrimSpace(leaseID)
+	if leaseID == "" {
+		return false, fmt.Errorf("lease id is required")
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if expiresAt.IsZero() || !expiresAt.After(now) {
+		expiresAt = now.Add(90 * time.Second)
+	}
+	rows, err := s.q.RenewCredentialLease(context.Background(), sqlitegen.RenewCredentialLeaseParams{
+		ExpiresAt:   expiresAt.UTC().UnixNano(),
+		ID:          leaseID,
+		ExpiresAt_2: now.UTC().UnixNano(),
+	})
+	if err != nil {
+		return false, err
+	}
+	return rows > 0, nil
+}
+
+func (s *Store) ReleaseCredentialLease(leaseID string) (CredentialLease, bool, error) {
+	leaseID = strings.TrimSpace(leaseID)
+	if leaseID == "" {
+		return CredentialLease{}, false, nil
+	}
+	row, err := s.q.ReleaseCredentialLease(context.Background(), sqlitegen.ReleaseCredentialLeaseParams{
+		ReleasedAt: sql.NullInt64{Int64: time.Now().UTC().UnixNano(), Valid: true},
+		ID:         leaseID,
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return CredentialLease{}, false, nil
+		}
+		return CredentialLease{}, false, err
+	}
+	return fromDBCredentialLease(row), true, nil
+}
+
+func (s *Store) ReleaseCredentialLeaseByRunID(runID string) error {
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return nil
+	}
+	_, err := s.q.ReleaseCredentialLeaseByRunID(context.Background(), sqlitegen.ReleaseCredentialLeaseByRunIDParams{
+		ReleasedAt: sql.NullInt64{Int64: time.Now().UTC().UnixNano(), Valid: true},
+		RunID:      runID,
+	})
+	return err
+}
+
+func (s *Store) ReclaimExpiredCredentialLeases(now time.Time) (int, error) {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	rows, err := s.q.ReclaimExpiredCredentialLeases(context.Background(), sqlitegen.ReclaimExpiredCredentialLeasesParams{
+		ReleasedAt: sql.NullInt64{Int64: now.UTC().UnixNano(), Valid: true},
+		ExpiresAt:  now.UTC().UnixNano(),
+	})
+	if err != nil {
+		return 0, err
+	}
+	return int(rows), nil
+}
+
+func (s *Store) UpsertCredentialUsage(credentialID string, windowStart time.Time, tokens, runs int64) error {
+	credentialID = strings.TrimSpace(credentialID)
+	if credentialID == "" {
+		return nil
+	}
+	if windowStart.IsZero() {
+		windowStart = time.Now().UTC().Truncate(time.Hour)
+	}
+	return s.q.UpsertCredentialUsage(context.Background(), sqlitegen.UpsertCredentialUsageParams{
+		CredentialID: credentialID,
+		WindowStart:  windowStart.UTC().UnixNano(),
+		Tokens:       tokens,
+		Runs:         runs,
+	})
+}
+
+func fromDBUser(row sqlitegen.User) User {
+	return User{
+		ID:            row.ID,
+		ExternalLogin: row.ExternalLogin,
+		Role:          normalizeUserRole(UserRole(row.Role)),
+		CreatedAt:     time.Unix(0, row.CreatedAt).UTC(),
+		UpdatedAt:     time.Unix(0, row.UpdatedAt).UTC(),
+	}
+}
+
+func fromDBCodexCredential(row sqlitegen.CodexCredential) CodexCredential {
+	return CodexCredential{
+		ID:                row.ID,
+		OwnerUserID:       fromNullString(row.OwnerUserID),
+		Scope:             row.Scope,
+		EncryptedAuthBlob: append([]byte(nil), row.EncryptedAuthBlob...),
+		Weight:            int(row.Weight),
+		MaxActiveLeases:   int(row.MaxActiveLeases),
+		Status:            row.Status,
+		CooldownUntil:     fromNullTime(row.CooldownUntil),
+		LastError:         row.LastError,
+		CreatedAt:         time.Unix(0, row.CreatedAt).UTC(),
+		UpdatedAt:         time.Unix(0, row.UpdatedAt).UTC(),
+	}
+}
+
+func fromDBCredentialLease(row sqlitegen.CredentialLease) CredentialLease {
+	return CredentialLease{
+		ID:           row.ID,
+		CredentialID: row.CredentialID,
+		RunID:        row.RunID,
+		UserID:       row.UserID,
+		Strategy:     row.Strategy,
+		AcquiredAt:   time.Unix(0, row.AcquiredAt).UTC(),
+		ExpiresAt:    time.Unix(0, row.ExpiresAt).UTC(),
+		ReleasedAt:   fromNullTime(row.ReleasedAt),
+	}
+}
+
+func toNullString(v string) sql.NullString {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: v, Valid: true}
+}
+
+func fromNullString(v sql.NullString) string {
+	if !v.Valid {
+		return ""
+	}
+	return strings.TrimSpace(v.String)
+}
+
+func fromNullTime(v sql.NullInt64) *time.Time {
+	if !v.Valid {
+		return nil
+	}
+	t := time.Unix(0, v.Int64).UTC()
+	return &t
+}

--- a/internal/state/migrations/00010_credentials_broker.sql
+++ b/internal/state/migrations/00010_credentials_broker.sql
@@ -1,0 +1,89 @@
+-- +goose Up
+ALTER TABLE tasks ADD COLUMN created_by_user_id TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE runs ADD COLUMN created_by_user_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE runs ADD COLUMN credential_id TEXT NOT NULL DEFAULT '';
+
+CREATE INDEX IF NOT EXISTS idx_runs_created_by ON runs (created_by_user_id, seq DESC);
+CREATE INDEX IF NOT EXISTS idx_runs_credential_id ON runs (credential_id, seq DESC);
+
+CREATE TABLE IF NOT EXISTS users (
+  id TEXT PRIMARY KEY,
+  external_login TEXT NOT NULL UNIQUE,
+  role TEXT NOT NULL DEFAULT 'user',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS api_keys (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  key_hash TEXT NOT NULL UNIQUE,
+  label TEXT NOT NULL DEFAULT '',
+  created_at INTEGER NOT NULL,
+  last_used_at INTEGER NOT NULL DEFAULT 0,
+  disabled_at INTEGER,
+  FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_keys_user_id ON api_keys (user_id);
+
+CREATE TABLE IF NOT EXISTS codex_credentials (
+  id TEXT PRIMARY KEY,
+  owner_user_id TEXT,
+  scope TEXT NOT NULL,
+  encrypted_auth_blob BLOB NOT NULL,
+  weight INTEGER NOT NULL DEFAULT 1,
+  max_active_leases INTEGER NOT NULL DEFAULT 1,
+  status TEXT NOT NULL DEFAULT 'active',
+  cooldown_until INTEGER,
+  last_error TEXT NOT NULL DEFAULT '',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY(owner_user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_codex_credentials_owner ON codex_credentials (owner_user_id);
+CREATE INDEX IF NOT EXISTS idx_codex_credentials_scope_status ON codex_credentials (scope, status, cooldown_until);
+
+CREATE TABLE IF NOT EXISTS credential_leases (
+  id TEXT PRIMARY KEY,
+  credential_id TEXT NOT NULL,
+  run_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  strategy TEXT NOT NULL,
+  acquired_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  released_at INTEGER,
+  FOREIGN KEY(credential_id) REFERENCES codex_credentials(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_credential_leases_credential_active ON credential_leases (credential_id, released_at, expires_at);
+CREATE INDEX IF NOT EXISTS idx_credential_leases_run_active ON credential_leases (run_id, released_at, expires_at);
+CREATE INDEX IF NOT EXISTS idx_credential_leases_expires_active ON credential_leases (expires_at, released_at);
+
+CREATE TABLE IF NOT EXISTS credential_usage (
+  credential_id TEXT NOT NULL,
+  window_start INTEGER NOT NULL,
+  tokens INTEGER NOT NULL DEFAULT 0,
+  runs INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (credential_id, window_start),
+  FOREIGN KEY(credential_id) REFERENCES codex_credentials(id) ON DELETE CASCADE
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS credential_usage;
+DROP INDEX IF EXISTS idx_credential_leases_expires_active;
+DROP INDEX IF EXISTS idx_credential_leases_run_active;
+DROP INDEX IF EXISTS idx_credential_leases_credential_active;
+DROP TABLE IF EXISTS credential_leases;
+DROP INDEX IF EXISTS idx_codex_credentials_scope_status;
+DROP INDEX IF EXISTS idx_codex_credentials_owner;
+DROP TABLE IF EXISTS codex_credentials;
+DROP INDEX IF EXISTS idx_api_keys_user_id;
+DROP TABLE IF EXISTS api_keys;
+DROP TABLE IF EXISTS users;
+DROP INDEX IF EXISTS idx_runs_credential_id;
+DROP INDEX IF EXISTS idx_runs_created_by;
+-- SQLite cannot drop columns in-place for tasks.created_by_user_id,
+-- runs.created_by_user_id, and runs.credential_id.

--- a/internal/state/sql/queries.sql
+++ b/internal/state/sql/queries.sql
@@ -522,3 +522,318 @@ WHERE task_id = ?;
 -- name: DeleteTaskAgentSession :execrows
 DELETE FROM task_agent_sessions
 WHERE task_id = ?;
+
+-- name: SetTaskCreatedByUser :execrows
+UPDATE tasks
+SET created_by_user_id = ?, updated_at = ?
+WHERE id = ?;
+
+-- name: SetRunCreatedByUser :execrows
+UPDATE runs
+SET created_by_user_id = ?, updated_at = ?
+WHERE id = ?;
+
+-- name: SetRunCredentialID :execrows
+UPDATE runs
+SET credential_id = ?, updated_at = ?
+WHERE id = ?;
+
+-- name: GetRunCredentialInfo :one
+SELECT id, created_by_user_id, credential_id
+FROM runs
+WHERE id = ?;
+
+-- name: UpsertUser :exec
+INSERT INTO users (
+  id,
+  external_login,
+  role,
+  created_at,
+  updated_at
+)
+VALUES (?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+  external_login = excluded.external_login,
+  role = excluded.role,
+  updated_at = excluded.updated_at;
+
+-- name: GetUserByID :one
+SELECT id, external_login, role, created_at, updated_at
+FROM users
+WHERE id = ?;
+
+-- name: GetUserByExternalLogin :one
+SELECT id, external_login, role, created_at, updated_at
+FROM users
+WHERE external_login = ?;
+
+-- name: UpsertAPIKey :exec
+INSERT INTO api_keys (
+  id,
+  user_id,
+  key_hash,
+  label,
+  created_at,
+  last_used_at,
+  disabled_at
+)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(key_hash) DO UPDATE SET
+  user_id = excluded.user_id,
+  label = excluded.label,
+  disabled_at = excluded.disabled_at;
+
+-- name: GetAPIKeyPrincipal :one
+SELECT
+  api_keys.id AS api_key_id,
+  api_keys.user_id,
+  users.external_login,
+  users.role
+FROM api_keys
+JOIN users ON users.id = api_keys.user_id
+WHERE api_keys.key_hash = ?
+  AND api_keys.disabled_at IS NULL;
+
+-- name: TouchAPIKeyLastUsed :execrows
+UPDATE api_keys
+SET last_used_at = ?
+WHERE id = ?;
+
+-- name: CreateCodexCredential :exec
+INSERT INTO codex_credentials (
+  id,
+  owner_user_id,
+  scope,
+  encrypted_auth_blob,
+  weight,
+  max_active_leases,
+  status,
+  cooldown_until,
+  last_error,
+  created_at,
+  updated_at
+)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+
+-- name: UpdateCodexCredential :execrows
+UPDATE codex_credentials
+SET
+  owner_user_id = ?,
+  scope = ?,
+  encrypted_auth_blob = ?,
+  weight = ?,
+  max_active_leases = ?,
+  status = ?,
+  cooldown_until = ?,
+  last_error = ?,
+  updated_at = ?
+WHERE id = ?;
+
+-- name: SetCodexCredentialStatus :execrows
+UPDATE codex_credentials
+SET
+  status = ?,
+  cooldown_until = ?,
+  last_error = ?,
+  updated_at = ?
+WHERE id = ?;
+
+-- name: GetCodexCredential :one
+SELECT
+  id,
+  owner_user_id,
+  scope,
+  encrypted_auth_blob,
+  weight,
+  max_active_leases,
+  status,
+  cooldown_until,
+  last_error,
+  created_at,
+  updated_at
+FROM codex_credentials
+WHERE id = ?;
+
+-- name: ListCodexCredentialsByOwner :many
+SELECT
+  id,
+  owner_user_id,
+  scope,
+  encrypted_auth_blob,
+  weight,
+  max_active_leases,
+  status,
+  cooldown_until,
+  last_error,
+  created_at,
+  updated_at
+FROM codex_credentials
+WHERE owner_user_id = ?
+ORDER BY created_at DESC;
+
+-- name: ListSharedCodexCredentials :many
+SELECT
+  id,
+  owner_user_id,
+  scope,
+  encrypted_auth_blob,
+  weight,
+  max_active_leases,
+  status,
+  cooldown_until,
+  last_error,
+  created_at,
+  updated_at
+FROM codex_credentials
+WHERE scope = 'shared'
+ORDER BY created_at DESC;
+
+-- name: ListAllCodexCredentials :many
+SELECT
+  id,
+  owner_user_id,
+  scope,
+  encrypted_auth_blob,
+  weight,
+  max_active_leases,
+  status,
+  cooldown_until,
+  last_error,
+  created_at,
+  updated_at
+FROM codex_credentials
+ORDER BY created_at DESC;
+
+-- name: ListCredentialCandidates :many
+SELECT
+  c.id,
+  c.owner_user_id,
+  c.scope,
+  c.weight,
+  c.max_active_leases,
+  c.status,
+  c.cooldown_until,
+  CAST(COALESCE((
+    SELECT COUNT(*)
+    FROM credential_leases AS l
+    WHERE l.credential_id = c.id
+      AND l.released_at IS NULL
+      AND l.expires_at > sqlc.arg(now)
+  ), 0) AS INTEGER) AS active_leases,
+  CAST(COALESCE((
+    SELECT SUM(u.tokens)
+    FROM credential_usage AS u
+    WHERE u.credential_id = c.id
+      AND u.window_start >= sqlc.arg(usage_window_start)
+  ), 0) AS INTEGER) AS usage_tokens,
+  CAST(COALESCE((
+    SELECT SUM(u.runs)
+    FROM credential_usage AS u
+    WHERE u.credential_id = c.id
+      AND u.window_start >= sqlc.arg(usage_window_start)
+  ), 0) AS INTEGER) AS usage_runs,
+  c.last_error,
+  c.created_at,
+  c.updated_at
+FROM codex_credentials AS c
+WHERE c.status = 'active'
+  AND (c.cooldown_until IS NULL OR c.cooldown_until <= sqlc.arg(now))
+  AND (c.scope = 'shared' OR c.owner_user_id = sqlc.arg(requester_user_id))
+ORDER BY c.created_at ASC, c.id ASC;
+
+-- name: TryCreateCredentialLease :execrows
+INSERT INTO credential_leases (
+  id,
+  credential_id,
+  run_id,
+  user_id,
+  strategy,
+  acquired_at,
+  expires_at,
+  released_at
+)
+SELECT
+  sqlc.arg(id),
+  sqlc.arg(credential_id),
+  sqlc.arg(run_id),
+  sqlc.arg(user_id),
+  sqlc.arg(strategy),
+  sqlc.arg(acquired_at),
+  sqlc.arg(expires_at),
+  NULL
+WHERE EXISTS (
+  SELECT 1
+  FROM codex_credentials AS c
+  WHERE c.id = sqlc.arg(credential_id)
+    AND c.status = 'active'
+    AND (c.cooldown_until IS NULL OR c.cooldown_until <= sqlc.arg(now))
+    AND (
+      c.scope = 'shared'
+      OR (c.scope = 'personal' AND c.owner_user_id = sqlc.arg(user_id))
+    )
+    AND (
+      SELECT COUNT(*)
+      FROM credential_leases AS l
+      WHERE l.credential_id = c.id
+        AND l.released_at IS NULL
+        AND l.expires_at > sqlc.arg(now)
+    ) < c.max_active_leases
+)
+AND NOT EXISTS (
+  SELECT 1
+  FROM credential_leases AS existing
+  WHERE existing.run_id = ?3
+    AND existing.released_at IS NULL
+    AND existing.expires_at > ?8
+);
+
+-- name: GetCredentialLease :one
+SELECT id, credential_id, run_id, user_id, strategy, acquired_at, expires_at, released_at
+FROM credential_leases
+WHERE id = ?;
+
+-- name: GetActiveCredentialLeaseByRunID :one
+SELECT id, credential_id, run_id, user_id, strategy, acquired_at, expires_at, released_at
+FROM credential_leases
+WHERE run_id = ?
+  AND released_at IS NULL
+ORDER BY acquired_at DESC
+LIMIT 1;
+
+-- name: RenewCredentialLease :execrows
+UPDATE credential_leases
+SET expires_at = ?
+WHERE id = ?
+  AND released_at IS NULL
+  AND expires_at > ?;
+
+-- name: ReleaseCredentialLease :one
+UPDATE credential_leases
+SET released_at = ?
+WHERE id = ?
+  AND released_at IS NULL
+RETURNING id, credential_id, run_id, user_id, strategy, acquired_at, expires_at, released_at;
+
+-- name: ReleaseCredentialLeaseByRunID :execrows
+UPDATE credential_leases
+SET released_at = ?
+WHERE run_id = ?
+  AND released_at IS NULL;
+
+-- name: ReclaimExpiredCredentialLeases :execrows
+UPDATE credential_leases
+SET released_at = ?
+WHERE released_at IS NULL
+  AND expires_at <= ?;
+
+-- name: UpsertCredentialUsage :exec
+INSERT INTO credential_usage (
+  credential_id,
+  window_start,
+  tokens,
+  runs
+)
+VALUES (?, ?, ?, ?)
+ON CONFLICT(credential_id, window_start) DO UPDATE SET
+  tokens = credential_usage.tokens + excluded.tokens,
+  runs = credential_usage.runs + excluded.runs;

--- a/internal/state/sql/schema.sql
+++ b/internal/state/sql/schema.sql
@@ -4,6 +4,7 @@ CREATE TABLE tasks (
   agent_backend TEXT NOT NULL DEFAULT 'goose',
   issue_number INTEGER NOT NULL DEFAULT 0,
   pr_number INTEGER NOT NULL DEFAULT 0,
+  created_by_user_id TEXT NOT NULL DEFAULT '',
   status TEXT NOT NULL DEFAULT 'open',
   last_run_id TEXT NOT NULL DEFAULT '',
   created_at INTEGER NOT NULL,
@@ -27,6 +28,8 @@ CREATE TABLE runs (
   run_dir TEXT NOT NULL,
   issue_number INTEGER NOT NULL DEFAULT 0,
   pr_number INTEGER NOT NULL DEFAULT 0,
+  created_by_user_id TEXT NOT NULL DEFAULT '',
+  credential_id TEXT NOT NULL DEFAULT '',
   pr_url TEXT NOT NULL DEFAULT '',
   pr_status TEXT NOT NULL DEFAULT 'none',
   head_sha TEXT NOT NULL DEFAULT '',
@@ -40,6 +43,8 @@ CREATE TABLE runs (
 
 CREATE INDEX idx_runs_status_seq ON runs (status, seq DESC);
 CREATE INDEX idx_runs_task_seq ON runs (task_id, seq DESC);
+CREATE INDEX idx_runs_created_by ON runs (created_by_user_id, seq DESC);
+CREATE INDEX idx_runs_credential_id ON runs (credential_id, seq DESC);
 
 CREATE TABLE task_agent_sessions (
   task_id TEXT PRIMARY KEY,
@@ -53,6 +58,70 @@ CREATE TABLE task_agent_sessions (
 );
 
 CREATE INDEX idx_task_agent_sessions_backend_updated ON task_agent_sessions (agent_backend, updated_at DESC);
+
+CREATE TABLE users (
+  id TEXT PRIMARY KEY,
+  external_login TEXT NOT NULL UNIQUE,
+  role TEXT NOT NULL DEFAULT 'user',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE api_keys (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  key_hash TEXT NOT NULL UNIQUE,
+  label TEXT NOT NULL DEFAULT '',
+  created_at INTEGER NOT NULL,
+  last_used_at INTEGER NOT NULL DEFAULT 0,
+  disabled_at INTEGER,
+  FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_api_keys_user_id ON api_keys (user_id);
+
+CREATE TABLE codex_credentials (
+  id TEXT PRIMARY KEY,
+  owner_user_id TEXT,
+  scope TEXT NOT NULL,
+  encrypted_auth_blob BLOB NOT NULL,
+  weight INTEGER NOT NULL DEFAULT 1,
+  max_active_leases INTEGER NOT NULL DEFAULT 1,
+  status TEXT NOT NULL DEFAULT 'active',
+  cooldown_until INTEGER,
+  last_error TEXT NOT NULL DEFAULT '',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY(owner_user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_codex_credentials_owner ON codex_credentials (owner_user_id);
+CREATE INDEX idx_codex_credentials_scope_status ON codex_credentials (scope, status, cooldown_until);
+
+CREATE TABLE credential_leases (
+  id TEXT PRIMARY KEY,
+  credential_id TEXT NOT NULL,
+  run_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  strategy TEXT NOT NULL,
+  acquired_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  released_at INTEGER,
+  FOREIGN KEY(credential_id) REFERENCES codex_credentials(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_credential_leases_credential_active ON credential_leases (credential_id, released_at, expires_at);
+CREATE INDEX idx_credential_leases_run_active ON credential_leases (run_id, released_at, expires_at);
+CREATE INDEX idx_credential_leases_expires_active ON credential_leases (expires_at, released_at);
+
+CREATE TABLE credential_usage (
+  credential_id TEXT NOT NULL,
+  window_start INTEGER NOT NULL,
+  tokens INTEGER NOT NULL DEFAULT 0,
+  runs INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (credential_id, window_start),
+  FOREIGN KEY(credential_id) REFERENCES codex_credentials(id) ON DELETE CASCADE
+);
 
 CREATE TABLE run_leases (
   run_id TEXT PRIMARY KEY,

--- a/internal/state/sqlitegen/models.go
+++ b/internal/state/sqlitegen/models.go
@@ -8,6 +8,48 @@ import (
 	"database/sql"
 )
 
+type ApiKey struct {
+	ID         string        `json:"id"`
+	UserID     string        `json:"user_id"`
+	KeyHash    string        `json:"key_hash"`
+	Label      string        `json:"label"`
+	CreatedAt  int64         `json:"created_at"`
+	LastUsedAt int64         `json:"last_used_at"`
+	DisabledAt sql.NullInt64 `json:"disabled_at"`
+}
+
+type CodexCredential struct {
+	ID                string         `json:"id"`
+	OwnerUserID       sql.NullString `json:"owner_user_id"`
+	Scope             string         `json:"scope"`
+	EncryptedAuthBlob []byte         `json:"encrypted_auth_blob"`
+	Weight            int64          `json:"weight"`
+	MaxActiveLeases   int64          `json:"max_active_leases"`
+	Status            string         `json:"status"`
+	CooldownUntil     sql.NullInt64  `json:"cooldown_until"`
+	LastError         string         `json:"last_error"`
+	CreatedAt         int64          `json:"created_at"`
+	UpdatedAt         int64          `json:"updated_at"`
+}
+
+type CredentialLease struct {
+	ID           string        `json:"id"`
+	CredentialID string        `json:"credential_id"`
+	RunID        string        `json:"run_id"`
+	UserID       string        `json:"user_id"`
+	Strategy     string        `json:"strategy"`
+	AcquiredAt   int64         `json:"acquired_at"`
+	ExpiresAt    int64         `json:"expires_at"`
+	ReleasedAt   sql.NullInt64 `json:"released_at"`
+}
+
+type CredentialUsage struct {
+	CredentialID string `json:"credential_id"`
+	WindowStart  int64  `json:"window_start"`
+	Tokens       int64  `json:"tokens"`
+	Runs         int64  `json:"runs"`
+}
+
 type Delivery struct {
 	ID          string        `json:"id"`
 	Status      string        `json:"status"`
@@ -20,29 +62,31 @@ type Delivery struct {
 }
 
 type Run struct {
-	Seq          int64         `json:"seq"`
-	ID           string        `json:"id"`
-	TaskID       string        `json:"task_id"`
-	Repo         string        `json:"repo"`
-	Task         string        `json:"task"`
-	AgentBackend string        `json:"agent_backend"`
-	BaseBranch   string        `json:"base_branch"`
-	HeadBranch   string        `json:"head_branch"`
-	Trigger      string        `json:"trigger"`
-	Debug        bool          `json:"debug"`
-	Status       string        `json:"status"`
-	RunDir       string        `json:"run_dir"`
-	IssueNumber  int64         `json:"issue_number"`
-	PrNumber     int64         `json:"pr_number"`
-	PrUrl        string        `json:"pr_url"`
-	PrStatus     string        `json:"pr_status"`
-	HeadSha      string        `json:"head_sha"`
-	Context      string        `json:"context"`
-	Error        string        `json:"error"`
-	CreatedAt    int64         `json:"created_at"`
-	UpdatedAt    int64         `json:"updated_at"`
-	StartedAt    sql.NullInt64 `json:"started_at"`
-	CompletedAt  sql.NullInt64 `json:"completed_at"`
+	Seq             int64         `json:"seq"`
+	ID              string        `json:"id"`
+	TaskID          string        `json:"task_id"`
+	Repo            string        `json:"repo"`
+	Task            string        `json:"task"`
+	AgentBackend    string        `json:"agent_backend"`
+	BaseBranch      string        `json:"base_branch"`
+	HeadBranch      string        `json:"head_branch"`
+	Trigger         string        `json:"trigger"`
+	Debug           bool          `json:"debug"`
+	Status          string        `json:"status"`
+	RunDir          string        `json:"run_dir"`
+	IssueNumber     int64         `json:"issue_number"`
+	PrNumber        int64         `json:"pr_number"`
+	CreatedByUserID string        `json:"created_by_user_id"`
+	CredentialID    string        `json:"credential_id"`
+	PrUrl           string        `json:"pr_url"`
+	PrStatus        string        `json:"pr_status"`
+	HeadSha         string        `json:"head_sha"`
+	Context         string        `json:"context"`
+	Error           string        `json:"error"`
+	CreatedAt       int64         `json:"created_at"`
+	UpdatedAt       int64         `json:"updated_at"`
+	StartedAt       sql.NullInt64 `json:"started_at"`
+	CompletedAt     sql.NullInt64 `json:"completed_at"`
 }
 
 type RunCancel struct {
@@ -72,15 +116,16 @@ type RunLease struct {
 }
 
 type Task struct {
-	ID           string `json:"id"`
-	Repo         string `json:"repo"`
-	AgentBackend string `json:"agent_backend"`
-	IssueNumber  int64  `json:"issue_number"`
-	PrNumber     int64  `json:"pr_number"`
-	Status       string `json:"status"`
-	LastRunID    string `json:"last_run_id"`
-	CreatedAt    int64  `json:"created_at"`
-	UpdatedAt    int64  `json:"updated_at"`
+	ID              string `json:"id"`
+	Repo            string `json:"repo"`
+	AgentBackend    string `json:"agent_backend"`
+	IssueNumber     int64  `json:"issue_number"`
+	PrNumber        int64  `json:"pr_number"`
+	CreatedByUserID string `json:"created_by_user_id"`
+	Status          string `json:"status"`
+	LastRunID       string `json:"last_run_id"`
+	CreatedAt       int64  `json:"created_at"`
+	UpdatedAt       int64  `json:"updated_at"`
 }
 
 type TaskAgentSession struct {
@@ -92,4 +137,12 @@ type TaskAgentSession struct {
 	LastRunID        string `json:"last_run_id"`
 	CreatedAt        int64  `json:"created_at"`
 	UpdatedAt        int64  `json:"updated_at"`
+}
+
+type User struct {
+	ID            string `json:"id"`
+	ExternalLogin string `json:"external_login"`
+	Role          string `json:"role"`
+	CreatedAt     int64  `json:"created_at"`
+	UpdatedAt     int64  `json:"updated_at"`
 }

--- a/internal/state/sqlitegen/queries.sql.go
+++ b/internal/state/sqlitegen/queries.sql.go
@@ -18,9 +18,35 @@ ORDER BY seq DESC
 LIMIT 1
 `
 
-func (q *Queries) ActiveRunForTask(ctx context.Context, taskID string) (Run, error) {
+type ActiveRunForTaskRow struct {
+	Seq          int64         `json:"seq"`
+	ID           string        `json:"id"`
+	TaskID       string        `json:"task_id"`
+	Repo         string        `json:"repo"`
+	Task         string        `json:"task"`
+	AgentBackend string        `json:"agent_backend"`
+	BaseBranch   string        `json:"base_branch"`
+	HeadBranch   string        `json:"head_branch"`
+	Trigger      string        `json:"trigger"`
+	Debug        bool          `json:"debug"`
+	Status       string        `json:"status"`
+	RunDir       string        `json:"run_dir"`
+	IssueNumber  int64         `json:"issue_number"`
+	PrNumber     int64         `json:"pr_number"`
+	PrUrl        string        `json:"pr_url"`
+	PrStatus     string        `json:"pr_status"`
+	HeadSha      string        `json:"head_sha"`
+	Context      string        `json:"context"`
+	Error        string        `json:"error"`
+	CreatedAt    int64         `json:"created_at"`
+	UpdatedAt    int64         `json:"updated_at"`
+	StartedAt    sql.NullInt64 `json:"started_at"`
+	CompletedAt  sql.NullInt64 `json:"completed_at"`
+}
+
+func (q *Queries) ActiveRunForTask(ctx context.Context, taskID string) (ActiveRunForTaskRow, error) {
 	row := q.db.QueryRowContext(ctx, activeRunForTask, taskID)
-	var i Run
+	var i ActiveRunForTaskRow
 	err := row.Scan(
 		&i.Seq,
 		&i.ID,
@@ -208,9 +234,35 @@ type ClaimNextQueuedRunParams struct {
 	StartedAt sql.NullInt64 `json:"started_at"`
 }
 
-func (q *Queries) ClaimNextQueuedRun(ctx context.Context, arg ClaimNextQueuedRunParams) (Run, error) {
+type ClaimNextQueuedRunRow struct {
+	Seq          int64         `json:"seq"`
+	ID           string        `json:"id"`
+	TaskID       string        `json:"task_id"`
+	Repo         string        `json:"repo"`
+	Task         string        `json:"task"`
+	AgentBackend string        `json:"agent_backend"`
+	BaseBranch   string        `json:"base_branch"`
+	HeadBranch   string        `json:"head_branch"`
+	Trigger      string        `json:"trigger"`
+	Debug        bool          `json:"debug"`
+	Status       string        `json:"status"`
+	RunDir       string        `json:"run_dir"`
+	IssueNumber  int64         `json:"issue_number"`
+	PrNumber     int64         `json:"pr_number"`
+	PrUrl        string        `json:"pr_url"`
+	PrStatus     string        `json:"pr_status"`
+	HeadSha      string        `json:"head_sha"`
+	Context      string        `json:"context"`
+	Error        string        `json:"error"`
+	CreatedAt    int64         `json:"created_at"`
+	UpdatedAt    int64         `json:"updated_at"`
+	StartedAt    sql.NullInt64 `json:"started_at"`
+	CompletedAt  sql.NullInt64 `json:"completed_at"`
+}
+
+func (q *Queries) ClaimNextQueuedRun(ctx context.Context, arg ClaimNextQueuedRunParams) (ClaimNextQueuedRunRow, error) {
 	row := q.db.QueryRowContext(ctx, claimNextQueuedRun, arg.UpdatedAt, arg.StartedAt)
-	var i Run
+	var i ClaimNextQueuedRunRow
 	err := row.Scan(
 		&i.Seq,
 		&i.ID,
@@ -301,9 +353,35 @@ type ClaimNextQueuedRunForTaskParams struct {
 	TaskID    string        `json:"task_id"`
 }
 
-func (q *Queries) ClaimNextQueuedRunForTask(ctx context.Context, arg ClaimNextQueuedRunForTaskParams) (Run, error) {
+type ClaimNextQueuedRunForTaskRow struct {
+	Seq          int64         `json:"seq"`
+	ID           string        `json:"id"`
+	TaskID       string        `json:"task_id"`
+	Repo         string        `json:"repo"`
+	Task         string        `json:"task"`
+	AgentBackend string        `json:"agent_backend"`
+	BaseBranch   string        `json:"base_branch"`
+	HeadBranch   string        `json:"head_branch"`
+	Trigger      string        `json:"trigger"`
+	Debug        bool          `json:"debug"`
+	Status       string        `json:"status"`
+	RunDir       string        `json:"run_dir"`
+	IssueNumber  int64         `json:"issue_number"`
+	PrNumber     int64         `json:"pr_number"`
+	PrUrl        string        `json:"pr_url"`
+	PrStatus     string        `json:"pr_status"`
+	HeadSha      string        `json:"head_sha"`
+	Context      string        `json:"context"`
+	Error        string        `json:"error"`
+	CreatedAt    int64         `json:"created_at"`
+	UpdatedAt    int64         `json:"updated_at"`
+	StartedAt    sql.NullInt64 `json:"started_at"`
+	CompletedAt  sql.NullInt64 `json:"completed_at"`
+}
+
+func (q *Queries) ClaimNextQueuedRunForTask(ctx context.Context, arg ClaimNextQueuedRunForTaskParams) (ClaimNextQueuedRunForTaskRow, error) {
 	row := q.db.QueryRowContext(ctx, claimNextQueuedRunForTask, arg.UpdatedAt, arg.StartedAt, arg.TaskID)
-	var i Run
+	var i ClaimNextQueuedRunForTaskRow
 	err := row.Scan(
 		&i.Seq,
 		&i.ID,
@@ -416,6 +494,54 @@ func (q *Queries) CountRunLeasesByOwner(ctx context.Context, ownerID string) (in
 	var count int64
 	err := row.Scan(&count)
 	return count, err
+}
+
+const createCodexCredential = `-- name: CreateCodexCredential :exec
+INSERT INTO codex_credentials (
+  id,
+  owner_user_id,
+  scope,
+  encrypted_auth_blob,
+  weight,
+  max_active_leases,
+  status,
+  cooldown_until,
+  last_error,
+  created_at,
+  updated_at
+)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+`
+
+type CreateCodexCredentialParams struct {
+	ID                string         `json:"id"`
+	OwnerUserID       sql.NullString `json:"owner_user_id"`
+	Scope             string         `json:"scope"`
+	EncryptedAuthBlob []byte         `json:"encrypted_auth_blob"`
+	Weight            int64          `json:"weight"`
+	MaxActiveLeases   int64          `json:"max_active_leases"`
+	Status            string         `json:"status"`
+	CooldownUntil     sql.NullInt64  `json:"cooldown_until"`
+	LastError         string         `json:"last_error"`
+	CreatedAt         int64          `json:"created_at"`
+	UpdatedAt         int64          `json:"updated_at"`
+}
+
+func (q *Queries) CreateCodexCredential(ctx context.Context, arg CreateCodexCredentialParams) error {
+	_, err := q.db.ExecContext(ctx, createCodexCredential,
+		arg.ID,
+		arg.OwnerUserID,
+		arg.Scope,
+		arg.EncryptedAuthBlob,
+		arg.Weight,
+		arg.MaxActiveLeases,
+		arg.Status,
+		arg.CooldownUntil,
+		arg.LastError,
+		arg.CreatedAt,
+		arg.UpdatedAt,
+	)
+	return err
 }
 
 const deleteOldestDeliveries = `-- name: DeleteOldestDeliveries :exec
@@ -571,15 +697,155 @@ func (q *Queries) FindTaskByPR(ctx context.Context, arg FindTaskByPRParams) (Fin
 	return i, err
 }
 
+const getAPIKeyPrincipal = `-- name: GetAPIKeyPrincipal :one
+SELECT
+  api_keys.id AS api_key_id,
+  api_keys.user_id,
+  users.external_login,
+  users.role
+FROM api_keys
+JOIN users ON users.id = api_keys.user_id
+WHERE api_keys.key_hash = ?
+  AND api_keys.disabled_at IS NULL
+`
+
+type GetAPIKeyPrincipalRow struct {
+	ApiKeyID      string `json:"api_key_id"`
+	UserID        string `json:"user_id"`
+	ExternalLogin string `json:"external_login"`
+	Role          string `json:"role"`
+}
+
+func (q *Queries) GetAPIKeyPrincipal(ctx context.Context, keyHash string) (GetAPIKeyPrincipalRow, error) {
+	row := q.db.QueryRowContext(ctx, getAPIKeyPrincipal, keyHash)
+	var i GetAPIKeyPrincipalRow
+	err := row.Scan(
+		&i.ApiKeyID,
+		&i.UserID,
+		&i.ExternalLogin,
+		&i.Role,
+	)
+	return i, err
+}
+
+const getActiveCredentialLeaseByRunID = `-- name: GetActiveCredentialLeaseByRunID :one
+SELECT id, credential_id, run_id, user_id, strategy, acquired_at, expires_at, released_at
+FROM credential_leases
+WHERE run_id = ?
+  AND released_at IS NULL
+ORDER BY acquired_at DESC
+LIMIT 1
+`
+
+func (q *Queries) GetActiveCredentialLeaseByRunID(ctx context.Context, runID string) (CredentialLease, error) {
+	row := q.db.QueryRowContext(ctx, getActiveCredentialLeaseByRunID, runID)
+	var i CredentialLease
+	err := row.Scan(
+		&i.ID,
+		&i.CredentialID,
+		&i.RunID,
+		&i.UserID,
+		&i.Strategy,
+		&i.AcquiredAt,
+		&i.ExpiresAt,
+		&i.ReleasedAt,
+	)
+	return i, err
+}
+
+const getCodexCredential = `-- name: GetCodexCredential :one
+SELECT
+  id,
+  owner_user_id,
+  scope,
+  encrypted_auth_blob,
+  weight,
+  max_active_leases,
+  status,
+  cooldown_until,
+  last_error,
+  created_at,
+  updated_at
+FROM codex_credentials
+WHERE id = ?
+`
+
+func (q *Queries) GetCodexCredential(ctx context.Context, id string) (CodexCredential, error) {
+	row := q.db.QueryRowContext(ctx, getCodexCredential, id)
+	var i CodexCredential
+	err := row.Scan(
+		&i.ID,
+		&i.OwnerUserID,
+		&i.Scope,
+		&i.EncryptedAuthBlob,
+		&i.Weight,
+		&i.MaxActiveLeases,
+		&i.Status,
+		&i.CooldownUntil,
+		&i.LastError,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getCredentialLease = `-- name: GetCredentialLease :one
+SELECT id, credential_id, run_id, user_id, strategy, acquired_at, expires_at, released_at
+FROM credential_leases
+WHERE id = ?
+`
+
+func (q *Queries) GetCredentialLease(ctx context.Context, id string) (CredentialLease, error) {
+	row := q.db.QueryRowContext(ctx, getCredentialLease, id)
+	var i CredentialLease
+	err := row.Scan(
+		&i.ID,
+		&i.CredentialID,
+		&i.RunID,
+		&i.UserID,
+		&i.Strategy,
+		&i.AcquiredAt,
+		&i.ExpiresAt,
+		&i.ReleasedAt,
+	)
+	return i, err
+}
+
 const getRun = `-- name: GetRun :one
 SELECT seq, id, task_id, repo, task, agent_backend, base_branch, head_branch, trigger, debug, status, run_dir, issue_number, pr_number, pr_url, pr_status, head_sha, context, error, created_at, updated_at, started_at, completed_at
 FROM runs
 WHERE id = ?
 `
 
-func (q *Queries) GetRun(ctx context.Context, id string) (Run, error) {
+type GetRunRow struct {
+	Seq          int64         `json:"seq"`
+	ID           string        `json:"id"`
+	TaskID       string        `json:"task_id"`
+	Repo         string        `json:"repo"`
+	Task         string        `json:"task"`
+	AgentBackend string        `json:"agent_backend"`
+	BaseBranch   string        `json:"base_branch"`
+	HeadBranch   string        `json:"head_branch"`
+	Trigger      string        `json:"trigger"`
+	Debug        bool          `json:"debug"`
+	Status       string        `json:"status"`
+	RunDir       string        `json:"run_dir"`
+	IssueNumber  int64         `json:"issue_number"`
+	PrNumber     int64         `json:"pr_number"`
+	PrUrl        string        `json:"pr_url"`
+	PrStatus     string        `json:"pr_status"`
+	HeadSha      string        `json:"head_sha"`
+	Context      string        `json:"context"`
+	Error        string        `json:"error"`
+	CreatedAt    int64         `json:"created_at"`
+	UpdatedAt    int64         `json:"updated_at"`
+	StartedAt    sql.NullInt64 `json:"started_at"`
+	CompletedAt  sql.NullInt64 `json:"completed_at"`
+}
+
+func (q *Queries) GetRun(ctx context.Context, id string) (GetRunRow, error) {
 	row := q.db.QueryRowContext(ctx, getRun, id)
-	var i Run
+	var i GetRunRow
 	err := row.Scan(
 		&i.Seq,
 		&i.ID,
@@ -623,6 +889,25 @@ func (q *Queries) GetRunCancel(ctx context.Context, runID string) (RunCancel, er
 		&i.Source,
 		&i.RequestedAt,
 	)
+	return i, err
+}
+
+const getRunCredentialInfo = `-- name: GetRunCredentialInfo :one
+SELECT id, created_by_user_id, credential_id
+FROM runs
+WHERE id = ?
+`
+
+type GetRunCredentialInfoRow struct {
+	ID              string `json:"id"`
+	CreatedByUserID string `json:"created_by_user_id"`
+	CredentialID    string `json:"credential_id"`
+}
+
+func (q *Queries) GetRunCredentialInfo(ctx context.Context, id string) (GetRunCredentialInfoRow, error) {
+	row := q.db.QueryRowContext(ctx, getRunCredentialInfo, id)
+	var i GetRunCredentialInfoRow
+	err := row.Scan(&i.ID, &i.CreatedByUserID, &i.CredentialID)
 	return i, err
 }
 
@@ -749,6 +1034,44 @@ func (q *Queries) GetTaskAgentSession(ctx context.Context, taskID string) (TaskA
 	return i, err
 }
 
+const getUserByExternalLogin = `-- name: GetUserByExternalLogin :one
+SELECT id, external_login, role, created_at, updated_at
+FROM users
+WHERE external_login = ?
+`
+
+func (q *Queries) GetUserByExternalLogin(ctx context.Context, externalLogin string) (User, error) {
+	row := q.db.QueryRowContext(ctx, getUserByExternalLogin, externalLogin)
+	var i User
+	err := row.Scan(
+		&i.ID,
+		&i.ExternalLogin,
+		&i.Role,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getUserByID = `-- name: GetUserByID :one
+SELECT id, external_login, role, created_at, updated_at
+FROM users
+WHERE id = ?
+`
+
+func (q *Queries) GetUserByID(ctx context.Context, id string) (User, error) {
+	row := q.db.QueryRowContext(ctx, getUserByID, id)
+	var i User
+	err := row.Scan(
+		&i.ID,
+		&i.ExternalLogin,
+		&i.Role,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const insertRun = `-- name: InsertRun :one
 INSERT INTO runs (
   id,
@@ -803,7 +1126,33 @@ type InsertRunParams struct {
 	CompletedAt  sql.NullInt64 `json:"completed_at"`
 }
 
-func (q *Queries) InsertRun(ctx context.Context, arg InsertRunParams) (Run, error) {
+type InsertRunRow struct {
+	Seq          int64         `json:"seq"`
+	ID           string        `json:"id"`
+	TaskID       string        `json:"task_id"`
+	Repo         string        `json:"repo"`
+	Task         string        `json:"task"`
+	AgentBackend string        `json:"agent_backend"`
+	BaseBranch   string        `json:"base_branch"`
+	HeadBranch   string        `json:"head_branch"`
+	Trigger      string        `json:"trigger"`
+	Debug        bool          `json:"debug"`
+	Status       string        `json:"status"`
+	RunDir       string        `json:"run_dir"`
+	IssueNumber  int64         `json:"issue_number"`
+	PrNumber     int64         `json:"pr_number"`
+	PrUrl        string        `json:"pr_url"`
+	PrStatus     string        `json:"pr_status"`
+	HeadSha      string        `json:"head_sha"`
+	Context      string        `json:"context"`
+	Error        string        `json:"error"`
+	CreatedAt    int64         `json:"created_at"`
+	UpdatedAt    int64         `json:"updated_at"`
+	StartedAt    sql.NullInt64 `json:"started_at"`
+	CompletedAt  sql.NullInt64 `json:"completed_at"`
+}
+
+func (q *Queries) InsertRun(ctx context.Context, arg InsertRunParams) (InsertRunRow, error) {
 	row := q.db.QueryRowContext(ctx, insertRun,
 		arg.ID,
 		arg.TaskID,
@@ -828,7 +1177,7 @@ func (q *Queries) InsertRun(ctx context.Context, arg InsertRunParams) (Run, erro
 		arg.StartedAt,
 		arg.CompletedAt,
 	)
-	var i Run
+	var i InsertRunRow
 	err := row.Scan(
 		&i.Seq,
 		&i.ID,
@@ -878,9 +1227,35 @@ ORDER BY seq DESC
 LIMIT 1
 `
 
-func (q *Queries) LastRunForTask(ctx context.Context, taskID string) (Run, error) {
+type LastRunForTaskRow struct {
+	Seq          int64         `json:"seq"`
+	ID           string        `json:"id"`
+	TaskID       string        `json:"task_id"`
+	Repo         string        `json:"repo"`
+	Task         string        `json:"task"`
+	AgentBackend string        `json:"agent_backend"`
+	BaseBranch   string        `json:"base_branch"`
+	HeadBranch   string        `json:"head_branch"`
+	Trigger      string        `json:"trigger"`
+	Debug        bool          `json:"debug"`
+	Status       string        `json:"status"`
+	RunDir       string        `json:"run_dir"`
+	IssueNumber  int64         `json:"issue_number"`
+	PrNumber     int64         `json:"pr_number"`
+	PrUrl        string        `json:"pr_url"`
+	PrStatus     string        `json:"pr_status"`
+	HeadSha      string        `json:"head_sha"`
+	Context      string        `json:"context"`
+	Error        string        `json:"error"`
+	CreatedAt    int64         `json:"created_at"`
+	UpdatedAt    int64         `json:"updated_at"`
+	StartedAt    sql.NullInt64 `json:"started_at"`
+	CompletedAt  sql.NullInt64 `json:"completed_at"`
+}
+
+func (q *Queries) LastRunForTask(ctx context.Context, taskID string) (LastRunForTaskRow, error) {
 	row := q.db.QueryRowContext(ctx, lastRunForTask, taskID)
-	var i Run
+	var i LastRunForTaskRow
 	err := row.Scan(
 		&i.Seq,
 		&i.ID,
@@ -909,6 +1284,208 @@ func (q *Queries) LastRunForTask(ctx context.Context, taskID string) (Run, error
 	return i, err
 }
 
+const listAllCodexCredentials = `-- name: ListAllCodexCredentials :many
+SELECT
+  id,
+  owner_user_id,
+  scope,
+  encrypted_auth_blob,
+  weight,
+  max_active_leases,
+  status,
+  cooldown_until,
+  last_error,
+  created_at,
+  updated_at
+FROM codex_credentials
+ORDER BY created_at DESC
+`
+
+func (q *Queries) ListAllCodexCredentials(ctx context.Context) ([]CodexCredential, error) {
+	rows, err := q.db.QueryContext(ctx, listAllCodexCredentials)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []CodexCredential{}
+	for rows.Next() {
+		var i CodexCredential
+		if err := rows.Scan(
+			&i.ID,
+			&i.OwnerUserID,
+			&i.Scope,
+			&i.EncryptedAuthBlob,
+			&i.Weight,
+			&i.MaxActiveLeases,
+			&i.Status,
+			&i.CooldownUntil,
+			&i.LastError,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listCodexCredentialsByOwner = `-- name: ListCodexCredentialsByOwner :many
+SELECT
+  id,
+  owner_user_id,
+  scope,
+  encrypted_auth_blob,
+  weight,
+  max_active_leases,
+  status,
+  cooldown_until,
+  last_error,
+  created_at,
+  updated_at
+FROM codex_credentials
+WHERE owner_user_id = ?
+ORDER BY created_at DESC
+`
+
+func (q *Queries) ListCodexCredentialsByOwner(ctx context.Context, ownerUserID sql.NullString) ([]CodexCredential, error) {
+	rows, err := q.db.QueryContext(ctx, listCodexCredentialsByOwner, ownerUserID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []CodexCredential{}
+	for rows.Next() {
+		var i CodexCredential
+		if err := rows.Scan(
+			&i.ID,
+			&i.OwnerUserID,
+			&i.Scope,
+			&i.EncryptedAuthBlob,
+			&i.Weight,
+			&i.MaxActiveLeases,
+			&i.Status,
+			&i.CooldownUntil,
+			&i.LastError,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listCredentialCandidates = `-- name: ListCredentialCandidates :many
+SELECT
+  c.id,
+  c.owner_user_id,
+  c.scope,
+  c.weight,
+  c.max_active_leases,
+  c.status,
+  c.cooldown_until,
+  CAST(COALESCE((
+    SELECT COUNT(*)
+    FROM credential_leases AS l
+    WHERE l.credential_id = c.id
+      AND l.released_at IS NULL
+      AND l.expires_at > ?1
+  ), 0) AS INTEGER) AS active_leases,
+  CAST(COALESCE((
+    SELECT SUM(u.tokens)
+    FROM credential_usage AS u
+    WHERE u.credential_id = c.id
+      AND u.window_start >= ?2
+  ), 0) AS INTEGER) AS usage_tokens,
+  CAST(COALESCE((
+    SELECT SUM(u.runs)
+    FROM credential_usage AS u
+    WHERE u.credential_id = c.id
+      AND u.window_start >= ?2
+  ), 0) AS INTEGER) AS usage_runs,
+  c.last_error,
+  c.created_at,
+  c.updated_at
+FROM codex_credentials AS c
+WHERE c.status = 'active'
+  AND (c.cooldown_until IS NULL OR c.cooldown_until <= ?1)
+  AND (c.scope = 'shared' OR c.owner_user_id = ?3)
+ORDER BY c.created_at ASC, c.id ASC
+`
+
+type ListCredentialCandidatesParams struct {
+	Now              int64          `json:"now"`
+	UsageWindowStart int64          `json:"usage_window_start"`
+	RequesterUserID  sql.NullString `json:"requester_user_id"`
+}
+
+type ListCredentialCandidatesRow struct {
+	ID              string         `json:"id"`
+	OwnerUserID     sql.NullString `json:"owner_user_id"`
+	Scope           string         `json:"scope"`
+	Weight          int64          `json:"weight"`
+	MaxActiveLeases int64          `json:"max_active_leases"`
+	Status          string         `json:"status"`
+	CooldownUntil   sql.NullInt64  `json:"cooldown_until"`
+	ActiveLeases    int64          `json:"active_leases"`
+	UsageTokens     int64          `json:"usage_tokens"`
+	UsageRuns       int64          `json:"usage_runs"`
+	LastError       string         `json:"last_error"`
+	CreatedAt       int64          `json:"created_at"`
+	UpdatedAt       int64          `json:"updated_at"`
+}
+
+func (q *Queries) ListCredentialCandidates(ctx context.Context, arg ListCredentialCandidatesParams) ([]ListCredentialCandidatesRow, error) {
+	rows, err := q.db.QueryContext(ctx, listCredentialCandidates, arg.Now, arg.UsageWindowStart, arg.RequesterUserID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListCredentialCandidatesRow{}
+	for rows.Next() {
+		var i ListCredentialCandidatesRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.OwnerUserID,
+			&i.Scope,
+			&i.Weight,
+			&i.MaxActiveLeases,
+			&i.Status,
+			&i.CooldownUntil,
+			&i.ActiveLeases,
+			&i.UsageTokens,
+			&i.UsageRuns,
+			&i.LastError,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listRunningRuns = `-- name: ListRunningRuns :many
 SELECT seq, id, task_id, repo, task, agent_backend, base_branch, head_branch, trigger, debug, status, run_dir, issue_number, pr_number, pr_url, pr_status, head_sha, context, error, created_at, updated_at, started_at, completed_at
 FROM runs
@@ -916,15 +1493,41 @@ WHERE status = 'running'
 ORDER BY seq DESC
 `
 
-func (q *Queries) ListRunningRuns(ctx context.Context) ([]Run, error) {
+type ListRunningRunsRow struct {
+	Seq          int64         `json:"seq"`
+	ID           string        `json:"id"`
+	TaskID       string        `json:"task_id"`
+	Repo         string        `json:"repo"`
+	Task         string        `json:"task"`
+	AgentBackend string        `json:"agent_backend"`
+	BaseBranch   string        `json:"base_branch"`
+	HeadBranch   string        `json:"head_branch"`
+	Trigger      string        `json:"trigger"`
+	Debug        bool          `json:"debug"`
+	Status       string        `json:"status"`
+	RunDir       string        `json:"run_dir"`
+	IssueNumber  int64         `json:"issue_number"`
+	PrNumber     int64         `json:"pr_number"`
+	PrUrl        string        `json:"pr_url"`
+	PrStatus     string        `json:"pr_status"`
+	HeadSha      string        `json:"head_sha"`
+	Context      string        `json:"context"`
+	Error        string        `json:"error"`
+	CreatedAt    int64         `json:"created_at"`
+	UpdatedAt    int64         `json:"updated_at"`
+	StartedAt    sql.NullInt64 `json:"started_at"`
+	CompletedAt  sql.NullInt64 `json:"completed_at"`
+}
+
+func (q *Queries) ListRunningRuns(ctx context.Context) ([]ListRunningRunsRow, error) {
 	rows, err := q.db.QueryContext(ctx, listRunningRuns)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []Run{}
+	items := []ListRunningRunsRow{}
 	for rows.Next() {
-		var i Run
+		var i ListRunningRunsRow
 		if err := rows.Scan(
 			&i.Seq,
 			&i.ID,
@@ -970,15 +1573,41 @@ ORDER BY seq DESC
 LIMIT ?
 `
 
-func (q *Queries) ListRuns(ctx context.Context, limit int64) ([]Run, error) {
+type ListRunsRow struct {
+	Seq          int64         `json:"seq"`
+	ID           string        `json:"id"`
+	TaskID       string        `json:"task_id"`
+	Repo         string        `json:"repo"`
+	Task         string        `json:"task"`
+	AgentBackend string        `json:"agent_backend"`
+	BaseBranch   string        `json:"base_branch"`
+	HeadBranch   string        `json:"head_branch"`
+	Trigger      string        `json:"trigger"`
+	Debug        bool          `json:"debug"`
+	Status       string        `json:"status"`
+	RunDir       string        `json:"run_dir"`
+	IssueNumber  int64         `json:"issue_number"`
+	PrNumber     int64         `json:"pr_number"`
+	PrUrl        string        `json:"pr_url"`
+	PrStatus     string        `json:"pr_status"`
+	HeadSha      string        `json:"head_sha"`
+	Context      string        `json:"context"`
+	Error        string        `json:"error"`
+	CreatedAt    int64         `json:"created_at"`
+	UpdatedAt    int64         `json:"updated_at"`
+	StartedAt    sql.NullInt64 `json:"started_at"`
+	CompletedAt  sql.NullInt64 `json:"completed_at"`
+}
+
+func (q *Queries) ListRuns(ctx context.Context, limit int64) ([]ListRunsRow, error) {
 	rows, err := q.db.QueryContext(ctx, listRuns, limit)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []Run{}
+	items := []ListRunsRow{}
 	for rows.Next() {
-		var i Run
+		var i ListRunsRow
 		if err := rows.Scan(
 			&i.Seq,
 			&i.ID,
@@ -1017,6 +1646,59 @@ func (q *Queries) ListRuns(ctx context.Context, limit int64) ([]Run, error) {
 	return items, nil
 }
 
+const listSharedCodexCredentials = `-- name: ListSharedCodexCredentials :many
+SELECT
+  id,
+  owner_user_id,
+  scope,
+  encrypted_auth_blob,
+  weight,
+  max_active_leases,
+  status,
+  cooldown_until,
+  last_error,
+  created_at,
+  updated_at
+FROM codex_credentials
+WHERE scope = 'shared'
+ORDER BY created_at DESC
+`
+
+func (q *Queries) ListSharedCodexCredentials(ctx context.Context) ([]CodexCredential, error) {
+	rows, err := q.db.QueryContext(ctx, listSharedCodexCredentials)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []CodexCredential{}
+	for rows.Next() {
+		var i CodexCredential
+		if err := rows.Scan(
+			&i.ID,
+			&i.OwnerUserID,
+			&i.Scope,
+			&i.EncryptedAuthBlob,
+			&i.Weight,
+			&i.MaxActiveLeases,
+			&i.Status,
+			&i.CooldownUntil,
+			&i.LastError,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const markTaskCompleted = `-- name: MarkTaskCompleted :execrows
 UPDATE tasks
 SET status = 'completed', updated_at = ?
@@ -1030,6 +1712,26 @@ type MarkTaskCompletedParams struct {
 
 func (q *Queries) MarkTaskCompleted(ctx context.Context, arg MarkTaskCompletedParams) (int64, error) {
 	result, err := q.db.ExecContext(ctx, markTaskCompleted, arg.UpdatedAt, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const reclaimExpiredCredentialLeases = `-- name: ReclaimExpiredCredentialLeases :execrows
+UPDATE credential_leases
+SET released_at = ?
+WHERE released_at IS NULL
+  AND expires_at <= ?
+`
+
+type ReclaimExpiredCredentialLeasesParams struct {
+	ReleasedAt sql.NullInt64 `json:"released_at"`
+	ExpiresAt  int64         `json:"expires_at"`
+}
+
+func (q *Queries) ReclaimExpiredCredentialLeases(ctx context.Context, arg ReclaimExpiredCredentialLeasesParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, reclaimExpiredCredentialLeases, arg.ReleasedAt, arg.ExpiresAt)
 	if err != nil {
 		return 0, err
 	}
@@ -1061,6 +1763,55 @@ func (q *Queries) RecordDelivery(ctx context.Context, arg RecordDeliveryParams) 
 	return err
 }
 
+const releaseCredentialLease = `-- name: ReleaseCredentialLease :one
+UPDATE credential_leases
+SET released_at = ?
+WHERE id = ?
+  AND released_at IS NULL
+RETURNING id, credential_id, run_id, user_id, strategy, acquired_at, expires_at, released_at
+`
+
+type ReleaseCredentialLeaseParams struct {
+	ReleasedAt sql.NullInt64 `json:"released_at"`
+	ID         string        `json:"id"`
+}
+
+func (q *Queries) ReleaseCredentialLease(ctx context.Context, arg ReleaseCredentialLeaseParams) (CredentialLease, error) {
+	row := q.db.QueryRowContext(ctx, releaseCredentialLease, arg.ReleasedAt, arg.ID)
+	var i CredentialLease
+	err := row.Scan(
+		&i.ID,
+		&i.CredentialID,
+		&i.RunID,
+		&i.UserID,
+		&i.Strategy,
+		&i.AcquiredAt,
+		&i.ExpiresAt,
+		&i.ReleasedAt,
+	)
+	return i, err
+}
+
+const releaseCredentialLeaseByRunID = `-- name: ReleaseCredentialLeaseByRunID :execrows
+UPDATE credential_leases
+SET released_at = ?
+WHERE run_id = ?
+  AND released_at IS NULL
+`
+
+type ReleaseCredentialLeaseByRunIDParams struct {
+	ReleasedAt sql.NullInt64 `json:"released_at"`
+	RunID      string        `json:"run_id"`
+}
+
+func (q *Queries) ReleaseCredentialLeaseByRunID(ctx context.Context, arg ReleaseCredentialLeaseByRunIDParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, releaseCredentialLeaseByRunID, arg.ReleasedAt, arg.RunID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const releaseDeliveryClaim = `-- name: ReleaseDeliveryClaim :execrows
 DELETE FROM deliveries
 WHERE id = ? AND claim_token = ?
@@ -1073,6 +1824,28 @@ type ReleaseDeliveryClaimParams struct {
 
 func (q *Queries) ReleaseDeliveryClaim(ctx context.Context, arg ReleaseDeliveryClaimParams) (int64, error) {
 	result, err := q.db.ExecContext(ctx, releaseDeliveryClaim, arg.ID, arg.ClaimToken)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const renewCredentialLease = `-- name: RenewCredentialLease :execrows
+UPDATE credential_leases
+SET expires_at = ?
+WHERE id = ?
+  AND released_at IS NULL
+  AND expires_at > ?
+`
+
+type RenewCredentialLeaseParams struct {
+	ExpiresAt   int64  `json:"expires_at"`
+	ID          string `json:"id"`
+	ExpiresAt_2 int64  `json:"expires_at_2"`
+}
+
+func (q *Queries) RenewCredentialLease(ctx context.Context, arg RenewCredentialLeaseParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, renewCredentialLease, arg.ExpiresAt, arg.ID, arg.ExpiresAt_2)
 	if err != nil {
 		return 0, err
 	}
@@ -1101,6 +1874,98 @@ func (q *Queries) RenewRunLease(ctx context.Context, arg RenewRunLeaseParams) (i
 		arg.RunID,
 		arg.OwnerID,
 	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const setCodexCredentialStatus = `-- name: SetCodexCredentialStatus :execrows
+UPDATE codex_credentials
+SET
+  status = ?,
+  cooldown_until = ?,
+  last_error = ?,
+  updated_at = ?
+WHERE id = ?
+`
+
+type SetCodexCredentialStatusParams struct {
+	Status        string        `json:"status"`
+	CooldownUntil sql.NullInt64 `json:"cooldown_until"`
+	LastError     string        `json:"last_error"`
+	UpdatedAt     int64         `json:"updated_at"`
+	ID            string        `json:"id"`
+}
+
+func (q *Queries) SetCodexCredentialStatus(ctx context.Context, arg SetCodexCredentialStatusParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, setCodexCredentialStatus,
+		arg.Status,
+		arg.CooldownUntil,
+		arg.LastError,
+		arg.UpdatedAt,
+		arg.ID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const setRunCreatedByUser = `-- name: SetRunCreatedByUser :execrows
+UPDATE runs
+SET created_by_user_id = ?, updated_at = ?
+WHERE id = ?
+`
+
+type SetRunCreatedByUserParams struct {
+	CreatedByUserID string `json:"created_by_user_id"`
+	UpdatedAt       int64  `json:"updated_at"`
+	ID              string `json:"id"`
+}
+
+func (q *Queries) SetRunCreatedByUser(ctx context.Context, arg SetRunCreatedByUserParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, setRunCreatedByUser, arg.CreatedByUserID, arg.UpdatedAt, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const setRunCredentialID = `-- name: SetRunCredentialID :execrows
+UPDATE runs
+SET credential_id = ?, updated_at = ?
+WHERE id = ?
+`
+
+type SetRunCredentialIDParams struct {
+	CredentialID string `json:"credential_id"`
+	UpdatedAt    int64  `json:"updated_at"`
+	ID           string `json:"id"`
+}
+
+func (q *Queries) SetRunCredentialID(ctx context.Context, arg SetRunCredentialIDParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, setRunCredentialID, arg.CredentialID, arg.UpdatedAt, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const setTaskCreatedByUser = `-- name: SetTaskCreatedByUser :execrows
+UPDATE tasks
+SET created_by_user_id = ?, updated_at = ?
+WHERE id = ?
+`
+
+type SetTaskCreatedByUserParams struct {
+	CreatedByUserID string `json:"created_by_user_id"`
+	UpdatedAt       int64  `json:"updated_at"`
+	ID              string `json:"id"`
+}
+
+func (q *Queries) SetTaskCreatedByUser(ctx context.Context, arg SetTaskCreatedByUserParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, setTaskCreatedByUser, arg.CreatedByUserID, arg.UpdatedAt, arg.ID)
 	if err != nil {
 		return 0, err
 	}
@@ -1159,6 +2024,25 @@ func (q *Queries) SetTaskPR(ctx context.Context, arg SetTaskPRParams) (int64, er
 	return result.RowsAffected()
 }
 
+const touchAPIKeyLastUsed = `-- name: TouchAPIKeyLastUsed :execrows
+UPDATE api_keys
+SET last_used_at = ?
+WHERE id = ?
+`
+
+type TouchAPIKeyLastUsedParams struct {
+	LastUsedAt int64  `json:"last_used_at"`
+	ID         string `json:"id"`
+}
+
+func (q *Queries) TouchAPIKeyLastUsed(ctx context.Context, arg TouchAPIKeyLastUsedParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, touchAPIKeyLastUsed, arg.LastUsedAt, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const trimOldRuns = `-- name: TrimOldRuns :exec
 DELETE FROM runs
 WHERE id IN (
@@ -1172,6 +2056,128 @@ WHERE id IN (
 func (q *Queries) TrimOldRuns(ctx context.Context, offset int64) error {
 	_, err := q.db.ExecContext(ctx, trimOldRuns, offset)
 	return err
+}
+
+const tryCreateCredentialLease = `-- name: TryCreateCredentialLease :execrows
+INSERT INTO credential_leases (
+  id,
+  credential_id,
+  run_id,
+  user_id,
+  strategy,
+  acquired_at,
+  expires_at,
+  released_at
+)
+SELECT
+  ?1,
+  ?2,
+  ?3,
+  ?4,
+  ?5,
+  ?6,
+  ?7,
+  NULL
+WHERE EXISTS (
+  SELECT 1
+  FROM codex_credentials AS c
+  WHERE c.id = ?2
+    AND c.status = 'active'
+    AND (c.cooldown_until IS NULL OR c.cooldown_until <= ?8)
+    AND (
+      c.scope = 'shared'
+      OR (c.scope = 'personal' AND c.owner_user_id = ?4)
+    )
+    AND (
+      SELECT COUNT(*)
+      FROM credential_leases AS l
+      WHERE l.credential_id = c.id
+        AND l.released_at IS NULL
+        AND l.expires_at > ?8
+    ) < c.max_active_leases
+)
+AND NOT EXISTS (
+  SELECT 1
+  FROM credential_leases AS existing
+  WHERE existing.run_id = ?3
+    AND existing.released_at IS NULL
+    AND existing.expires_at > ?8
+)
+`
+
+type TryCreateCredentialLeaseParams struct {
+	ID           string        `json:"id"`
+	CredentialID string        `json:"credential_id"`
+	RunID        string        `json:"run_id"`
+	UserID       string        `json:"user_id"`
+	Strategy     string        `json:"strategy"`
+	AcquiredAt   int64         `json:"acquired_at"`
+	ExpiresAt    int64         `json:"expires_at"`
+	Now          sql.NullInt64 `json:"now"`
+}
+
+func (q *Queries) TryCreateCredentialLease(ctx context.Context, arg TryCreateCredentialLeaseParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, tryCreateCredentialLease,
+		arg.ID,
+		arg.CredentialID,
+		arg.RunID,
+		arg.UserID,
+		arg.Strategy,
+		arg.AcquiredAt,
+		arg.ExpiresAt,
+		arg.Now,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const updateCodexCredential = `-- name: UpdateCodexCredential :execrows
+UPDATE codex_credentials
+SET
+  owner_user_id = ?,
+  scope = ?,
+  encrypted_auth_blob = ?,
+  weight = ?,
+  max_active_leases = ?,
+  status = ?,
+  cooldown_until = ?,
+  last_error = ?,
+  updated_at = ?
+WHERE id = ?
+`
+
+type UpdateCodexCredentialParams struct {
+	OwnerUserID       sql.NullString `json:"owner_user_id"`
+	Scope             string         `json:"scope"`
+	EncryptedAuthBlob []byte         `json:"encrypted_auth_blob"`
+	Weight            int64          `json:"weight"`
+	MaxActiveLeases   int64          `json:"max_active_leases"`
+	Status            string         `json:"status"`
+	CooldownUntil     sql.NullInt64  `json:"cooldown_until"`
+	LastError         string         `json:"last_error"`
+	UpdatedAt         int64          `json:"updated_at"`
+	ID                string         `json:"id"`
+}
+
+func (q *Queries) UpdateCodexCredential(ctx context.Context, arg UpdateCodexCredentialParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, updateCodexCredential,
+		arg.OwnerUserID,
+		arg.Scope,
+		arg.EncryptedAuthBlob,
+		arg.Weight,
+		arg.MaxActiveLeases,
+		arg.Status,
+		arg.CooldownUntil,
+		arg.LastError,
+		arg.UpdatedAt,
+		arg.ID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const updateRun = `-- name: UpdateRun :execrows
@@ -1287,6 +2293,76 @@ func (q *Queries) UpdateRunExecutionState(ctx context.Context, arg UpdateRunExec
 		return 0, err
 	}
 	return result.RowsAffected()
+}
+
+const upsertAPIKey = `-- name: UpsertAPIKey :exec
+INSERT INTO api_keys (
+  id,
+  user_id,
+  key_hash,
+  label,
+  created_at,
+  last_used_at,
+  disabled_at
+)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(key_hash) DO UPDATE SET
+  user_id = excluded.user_id,
+  label = excluded.label,
+  disabled_at = excluded.disabled_at
+`
+
+type UpsertAPIKeyParams struct {
+	ID         string        `json:"id"`
+	UserID     string        `json:"user_id"`
+	KeyHash    string        `json:"key_hash"`
+	Label      string        `json:"label"`
+	CreatedAt  int64         `json:"created_at"`
+	LastUsedAt int64         `json:"last_used_at"`
+	DisabledAt sql.NullInt64 `json:"disabled_at"`
+}
+
+func (q *Queries) UpsertAPIKey(ctx context.Context, arg UpsertAPIKeyParams) error {
+	_, err := q.db.ExecContext(ctx, upsertAPIKey,
+		arg.ID,
+		arg.UserID,
+		arg.KeyHash,
+		arg.Label,
+		arg.CreatedAt,
+		arg.LastUsedAt,
+		arg.DisabledAt,
+	)
+	return err
+}
+
+const upsertCredentialUsage = `-- name: UpsertCredentialUsage :exec
+INSERT INTO credential_usage (
+  credential_id,
+  window_start,
+  tokens,
+  runs
+)
+VALUES (?, ?, ?, ?)
+ON CONFLICT(credential_id, window_start) DO UPDATE SET
+  tokens = credential_usage.tokens + excluded.tokens,
+  runs = credential_usage.runs + excluded.runs
+`
+
+type UpsertCredentialUsageParams struct {
+	CredentialID string `json:"credential_id"`
+	WindowStart  int64  `json:"window_start"`
+	Tokens       int64  `json:"tokens"`
+	Runs         int64  `json:"runs"`
+}
+
+func (q *Queries) UpsertCredentialUsage(ctx context.Context, arg UpsertCredentialUsageParams) error {
+	_, err := q.db.ExecContext(ctx, upsertCredentialUsage,
+		arg.CredentialID,
+		arg.WindowStart,
+		arg.Tokens,
+		arg.Runs,
+	)
+	return err
 }
 
 const upsertRunCancel = `-- name: UpsertRunCancel :exec
@@ -1478,6 +2554,40 @@ func (q *Queries) UpsertTaskAgentSession(ctx context.Context, arg UpsertTaskAgen
 		arg.SessionKey,
 		arg.SessionRoot,
 		arg.LastRunID,
+		arg.CreatedAt,
+		arg.UpdatedAt,
+	)
+	return err
+}
+
+const upsertUser = `-- name: UpsertUser :exec
+INSERT INTO users (
+  id,
+  external_login,
+  role,
+  created_at,
+  updated_at
+)
+VALUES (?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+  external_login = excluded.external_login,
+  role = excluded.role,
+  updated_at = excluded.updated_at
+`
+
+type UpsertUserParams struct {
+	ID            string `json:"id"`
+	ExternalLogin string `json:"external_login"`
+	Role          string `json:"role"`
+	CreatedAt     int64  `json:"created_at"`
+	UpdatedAt     int64  `json:"updated_at"`
+}
+
+func (q *Queries) UpsertUser(ctx context.Context, arg UpsertUserParams) error {
+	_, err := q.db.ExecContext(ctx, upsertUser,
+		arg.ID,
+		arg.ExternalLogin,
+		arg.Role,
 		arg.CreatedAt,
 		arg.UpdatedAt,
 	)

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -971,38 +971,63 @@ func fromDBFindTaskByPRRow(t sqlitegen.FindTaskByPRRow) Task {
 	return fromDBTaskParts(t.ID, t.Repo, t.AgentBackend, t.IssueNumber, t.PrNumber, t.Status, t.PendingInput, t.LastRunID, t.CreatedAt, t.UpdatedAt)
 }
 
-func fromDBRun(r sqlitegen.Run) Run {
+func fromDBRunParts(id, taskID, repo, task, agentBackend, baseBranch, headBranch, trigger string, debug bool, status, runDir string, issueNumber, prNumber int64, prURL, prStatus, headSHA, contextValue, errText string, createdAt, updatedAt int64, startedAt, completedAt sql.NullInt64) Run {
 	out := Run{
-		ID:           r.ID,
-		TaskID:       r.TaskID,
-		Repo:         r.Repo,
-		Task:         r.Task,
-		AgentBackend: agent.NormalizeBackend(r.AgentBackend),
-		BaseBranch:   r.BaseBranch,
-		HeadBranch:   r.HeadBranch,
-		Trigger:      r.Trigger,
-		Debug:        r.Debug,
-		Status:       CanonicalRunStatus(RunStatus(r.Status)),
-		RunDir:       r.RunDir,
-		IssueNumber:  int(r.IssueNumber),
-		PRNumber:     int(r.PrNumber),
-		PRURL:        r.PrUrl,
-		PRStatus:     normalizePRStatus(PRStatus(r.PrStatus)),
-		HeadSHA:      r.HeadSha,
-		Context:      r.Context,
-		Error:        r.Error,
-		CreatedAt:    time.Unix(0, r.CreatedAt).UTC(),
-		UpdatedAt:    time.Unix(0, r.UpdatedAt).UTC(),
+		ID:           id,
+		TaskID:       taskID,
+		Repo:         repo,
+		Task:         task,
+		AgentBackend: agent.NormalizeBackend(agentBackend),
+		BaseBranch:   baseBranch,
+		HeadBranch:   headBranch,
+		Trigger:      trigger,
+		Debug:        debug,
+		Status:       CanonicalRunStatus(RunStatus(status)),
+		RunDir:       runDir,
+		IssueNumber:  int(issueNumber),
+		PRNumber:     int(prNumber),
+		PRURL:        prURL,
+		PRStatus:     normalizePRStatus(PRStatus(prStatus)),
+		HeadSHA:      headSHA,
+		Context:      contextValue,
+		Error:        errText,
+		CreatedAt:    time.Unix(0, createdAt).UTC(),
+		UpdatedAt:    time.Unix(0, updatedAt).UTC(),
 	}
-	if r.StartedAt.Valid {
-		t := time.Unix(0, r.StartedAt.Int64).UTC()
+	if startedAt.Valid {
+		t := time.Unix(0, startedAt.Int64).UTC()
 		out.StartedAt = &t
 	}
-	if r.CompletedAt.Valid {
-		t := time.Unix(0, r.CompletedAt.Int64).UTC()
+	if completedAt.Valid {
+		t := time.Unix(0, completedAt.Int64).UTC()
 		out.CompletedAt = &t
 	}
 	return out
+}
+
+func fromDBRun(row any) Run {
+	switch r := row.(type) {
+	case sqlitegen.Run:
+		return fromDBRunParts(r.ID, r.TaskID, r.Repo, r.Task, r.AgentBackend, r.BaseBranch, r.HeadBranch, r.Trigger, r.Debug, r.Status, r.RunDir, r.IssueNumber, r.PrNumber, r.PrUrl, r.PrStatus, r.HeadSha, r.Context, r.Error, r.CreatedAt, r.UpdatedAt, r.StartedAt, r.CompletedAt)
+	case sqlitegen.InsertRunRow:
+		return fromDBRunParts(r.ID, r.TaskID, r.Repo, r.Task, r.AgentBackend, r.BaseBranch, r.HeadBranch, r.Trigger, r.Debug, r.Status, r.RunDir, r.IssueNumber, r.PrNumber, r.PrUrl, r.PrStatus, r.HeadSha, r.Context, r.Error, r.CreatedAt, r.UpdatedAt, r.StartedAt, r.CompletedAt)
+	case sqlitegen.GetRunRow:
+		return fromDBRunParts(r.ID, r.TaskID, r.Repo, r.Task, r.AgentBackend, r.BaseBranch, r.HeadBranch, r.Trigger, r.Debug, r.Status, r.RunDir, r.IssueNumber, r.PrNumber, r.PrUrl, r.PrStatus, r.HeadSha, r.Context, r.Error, r.CreatedAt, r.UpdatedAt, r.StartedAt, r.CompletedAt)
+	case sqlitegen.ListRunsRow:
+		return fromDBRunParts(r.ID, r.TaskID, r.Repo, r.Task, r.AgentBackend, r.BaseBranch, r.HeadBranch, r.Trigger, r.Debug, r.Status, r.RunDir, r.IssueNumber, r.PrNumber, r.PrUrl, r.PrStatus, r.HeadSha, r.Context, r.Error, r.CreatedAt, r.UpdatedAt, r.StartedAt, r.CompletedAt)
+	case sqlitegen.ListRunningRunsRow:
+		return fromDBRunParts(r.ID, r.TaskID, r.Repo, r.Task, r.AgentBackend, r.BaseBranch, r.HeadBranch, r.Trigger, r.Debug, r.Status, r.RunDir, r.IssueNumber, r.PrNumber, r.PrUrl, r.PrStatus, r.HeadSha, r.Context, r.Error, r.CreatedAt, r.UpdatedAt, r.StartedAt, r.CompletedAt)
+	case sqlitegen.LastRunForTaskRow:
+		return fromDBRunParts(r.ID, r.TaskID, r.Repo, r.Task, r.AgentBackend, r.BaseBranch, r.HeadBranch, r.Trigger, r.Debug, r.Status, r.RunDir, r.IssueNumber, r.PrNumber, r.PrUrl, r.PrStatus, r.HeadSha, r.Context, r.Error, r.CreatedAt, r.UpdatedAt, r.StartedAt, r.CompletedAt)
+	case sqlitegen.ActiveRunForTaskRow:
+		return fromDBRunParts(r.ID, r.TaskID, r.Repo, r.Task, r.AgentBackend, r.BaseBranch, r.HeadBranch, r.Trigger, r.Debug, r.Status, r.RunDir, r.IssueNumber, r.PrNumber, r.PrUrl, r.PrStatus, r.HeadSha, r.Context, r.Error, r.CreatedAt, r.UpdatedAt, r.StartedAt, r.CompletedAt)
+	case sqlitegen.ClaimNextQueuedRunRow:
+		return fromDBRunParts(r.ID, r.TaskID, r.Repo, r.Task, r.AgentBackend, r.BaseBranch, r.HeadBranch, r.Trigger, r.Debug, r.Status, r.RunDir, r.IssueNumber, r.PrNumber, r.PrUrl, r.PrStatus, r.HeadSha, r.Context, r.Error, r.CreatedAt, r.UpdatedAt, r.StartedAt, r.CompletedAt)
+	case sqlitegen.ClaimNextQueuedRunForTaskRow:
+		return fromDBRunParts(r.ID, r.TaskID, r.Repo, r.Task, r.AgentBackend, r.BaseBranch, r.HeadBranch, r.Trigger, r.Debug, r.Status, r.RunDir, r.IssueNumber, r.PrNumber, r.PrUrl, r.PrStatus, r.HeadSha, r.Context, r.Error, r.CreatedAt, r.UpdatedAt, r.StartedAt, r.CompletedAt)
+	default:
+		return Run{}
+	}
 }
 
 func fromDBRunExecution(r sqlitegen.RunExecution) RunExecution {


### PR DESCRIPTION
Add multi-credential support with per-run allocation and lease lifecycle.
Includes SQLite/sqlc schema changes, strategy implementations, auth/user ownership wiring,
credential CRUD endpoints with owner/admin checks, broker integration into run execution,
and unit/integration coverage for strategy selection, broker behavior, and authz.

<details><summary>Goose Details</summary>

```

    __( O)>  ● new session · codex gpt-5.4
   \____)    20260308_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: "/usr/local/bin/codex"
Model: gpt-5.4
Reasoning effort: high
Skip git check: false
Prompt length: 5847 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Suggestion

The user has 7 extensions with 16 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
Consider asking if they'd like to disable some extensions to improve tool selection accuracy.

# Response Guidelines

Use Markdown formatting for all responses.

Human: <info-msg>
It is currently 2026-03-08 07:19:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

</info-msg>
# Rascal Run Instructions

Run ID: run_9a55a9a34b4e4de3
Task ID: rtzll/rascal#106
Repository: rtzll/rascal
Issue: #106

## Task

Pluggable Codex Credential Broker with Allocation Strategies (MVP + Tests)

## Context
Rascal currently uses one global Codex auth file (`RASCAL_CODEX_AUTH_PATH`) for all runs.  
We need multi-credential support so heavy users can consume idle team capacity, with strategy-based allocation and strong isolation/audit.

## Goals
1. Support multiple Codex credentials (personal + shared pool).
2. Allocate credentials per run via pluggable strategy.
3. Add lease lifecycle (acquire, heartbeat/TTL, release, expiry reclaim).
4. Prevent cross-user secret mutation/access.
5. Ship with multiple strategies and full tests.

## Non-Goals (for this issue)
1. Perfect fairness.
2. UI.
3. External secret manager integration (Vault/KMS can be follow-up; keep internal encryption abstraction now).

## Proposed Design

### Core interfaces
```go
type CredentialBroker interface {
  Acquire(ctx context.Context, req AcquireRequest) (Lease, error)
  Renew(ctx context.Context, leaseID string) error
  Release(ctx context.Context, leaseID string) error
}

type AllocationStrategy interface {
  Name() string
  Select(req AcquireRequest, candidates []CredentialState) (credentialID string, err error)
}
```

### Strategies to implement now
1. `requester_own_then_shared`
2. `shared_least_active_leases`
3. `shared_weighted_usage`
4. `priority_burst` (ignore fairness; prioritize high-throughput callers)
5. `hybrid_reserve_plus_pool` (optional reserve per user/team + shared burst)

### Data model (SQLite for now)
Add tables:
1. `users` (`id`, `external_login`, `role`, `created_at`, `updated_at`)
2. `codex_credentials` (`id`, `owner_user_id NULL`, `scope personal|shared`, `encrypted_auth_blob`, `weight`, `max_active_leases`, `status active|cooldown|disabled`, `cooldown_until`, `last_error`, timestamps)
3. `credential_leases` (`id`, `credential_id`, `run_id`, `user_id`, `strategy`, `acquired_at`, `expires_at`, `released_at`)
4. `credential_usage` (`credential_id`, `window_start`, `tokens`, `runs`) for usage-based scoring

Add ownership columns:
1. `runs.created_by_user_id`
2. `tasks.created_by_user_id`

### Security model
1. API key -> user resolved server-side only.
2. Keys stored hashed, never plaintext after creation.
3. Credential blobs encrypted at rest.
4. Non-admin users can CRUD only their own credentials.
5. Shared credentials admin-only.
6. Every run stores `created_by_user_id` + selected `credential_id` for audit.

### Runtime behavior
1. On run start, broker acquires a lease and materializes auth to run dir (ephemeral file).
2. Runner receives that path via env.
3. Lease renewed during run; released on terminal state.
4. On lease loss/expiry, run is canceled and credential enters cooldown if needed.

## Config
Add:
1. `RASCAL_CREDENTIAL_STRATEGY` (default: `requester_own_then_shared`)
2. `RASCAL_CREDENTIAL_LEASE_TTL` (default e.g. `90s`)
3. `RASCAL_CREDENTIAL_RENEW_INTERVAL` (default e.g. `30s`)

## Implementation Checklist
- [ ] Add DB migrations + sqlc queries for users/credentials/leases/usage and ownership columns.
- [ ] Add `internal/credentials` package (`broker.go`, `strategy.go`, `strategies/*.go`, `models.go`).
- [ ] Wire auth context -> `user_id` in `rascald`.
- [ ] Update run/task creation to persist `created_by_user_id`.
- [ ] Integrate broker into run scheduling/start path.
- [ ] Add credential cooldown/error handling.
- [ ] Add API endpoints for credential management (owner/admin checks).
- [ ] Add config parsing + defaults.
- [ ] Add audit log events for key actions.

## Test Plan

### Unit tests
- [ ] Each strategy selection logic with deterministic fixtures/tie-break rules.
- [ ] Broker acquire/release/renew/reclaim behavior.
- [ ] Cooldown transitions and disabled credential exclusion.
- [ ] Authz tests: owner vs admin vs other user.

### Concurrency tests
- [ ] Parallel acquire attempts never double-lease same credential beyond limits.
- [ ] Lease expiry reclaim works under contention.

### Integration tests
- [ ] Run creation attaches requester identity.
- [ ] Scheduler acquires credential and writes ephemeral auth file.
- [ ] Cancel/failure/success all release lease.
- [ ] `requester_own_then_shared` and `shared_weighted_usage` behavior in realistic multi-user scenarios.

## Acceptance Criteria
1. Multiple users can run concurrently with isolated auth.
2. At least 4 strategies are selectable by config and covered by tests.
3. No user can mutate or read another user’s personal credential.
4. Heavy users can consume unused shared capacity.
5. All new paths have unit + integration coverage and pass CI.

## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run tests or explain why tests could not run.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label 'rascal' on issue #106


Assistant: 
Image files: 0
============================
{"type":"message","message":{"id":null,"role":"assistant","created":1772956171,"content":[{"type":"text","text":"I’m implementing issue `#106` end-to-end in this repo, starting by mapping the current auth/run/data flow so I can add credential brokering, strategies, migrations, and tests with minimal disruption. I’ll update the task plan now with explicit requirements, then inspect relevant packages and existing DB/query patterns.\n\nI’ve identified the core areas (`internal/state`, `internal/config`, `cmd/rascald`, `internal/runner`) and I’m now reading schema/store/auth flow to anchor the broker integration points before editing.\n\nI’ve confirmed the current behavior: a single global Codex auth file is copied into each run dir during queueing. Next I’m tracing `runner.Spec` and env wiring so broker leases can materialize per-run credentials at start and be renewed/released safely.\n\nI’ve finished mapping the auth/run/storage flow and I’m now implementing the core data-layer changes first: migrations, schema/sqlc queries, and state methods for users, API keys, credentials, and credential leases. After that I’ll wire broker + server integration and then add tests.\n\nI’m now adding the new sqlc query surface for identity/credentials/leases plus run/task ownership updates, while keeping existing run/task query contracts stable to avoid broad regressions.\n\nSQL generation completed successfully. I’m now implementing `internal/credentials` and corresponding `state` methods against the generated query API, then I’ll wire server auth/broker integration.\n\nI’m wiring server startup to bootstrap user/key auth, initialize the credential cipher/strategy broker from config, and register credential-management routes with owner/admin checks.\n\nI’m integrating lease acquisition/materialization directly into run execution now, then threading credential lease renewal/release through the detached supervisor loop so lease loss actively cancels the run.\n\nI found environment-precedence regressions causing existing session-mode tests to fail. I’m switching these loaders to use `os.LookupEnv` precedence so explicitly empty Goose env vars override ambient Agent env vars, restoring deterministic behavior.\n\nI’m adding focused API authorization tests for owner/admin boundaries on credential CRUD, using direct handler invocation with injected principals to validate access control behavior without interactive setup.\n\nI’ve finished the core implementation and tests; now I’m running `gofmt` and then executing targeted plus full test suites to verify everything compiles and behavior remains stable.\n\nImplemented the credential broker MVP with pluggable allocation strategies, run-scoped credential leases, ownership/auth wiring, credential CRUD API authz, and tests.\n\n- Added schema + migration for multi-credential brokering and ownership/audit fields: [00010_credentials_broker.sql](/work/repo/internal/state/migrations/00010_credentials_broker.sql), [schema.sql](/work/repo/internal/state/sql/schema.sql), [queries.sql](/work/repo/internal/state/sql/queries.sql), regenerated [queries.sql.go](/work/repo/internal/state/sqlitegen/queries.sql.go).\n- Added state-layer credential/user/key/lease APIs: [credentials.go](/work/repo/internal/state/credentials.go), plus run row compatibility updates in [store.go](/work/repo/internal/state/store.go).\n- Implemented `internal/credentials` package with broker + encryption + models: [broker.go](/work/repo/internal/credentials/broker.go), [crypto.go](/work/repo/internal/credentials/crypto.go), [strategy.go](/work/repo/internal/credentials/strategy.go), [models.go](/work/repo/internal/credentials/models.go).\n- Implemented 5 strategies under [internal/credentials/strategies](/work/repo/internal/credentials/strategies): requester-own-then-shared, shared-least-active, shared-weighted-usage, priority-burst, hybrid-reserve-plus-pool.\n- Wired auth principal resolution (hashed API key lookup + bootstrap), requester identity persistence, credential lease acquire/renew/release, ephemeral auth file materialization, and cooldown transitions in [main.go](/work/repo/cmd/rascald/main.go).\n- Added credential management endpoints with owner/admin authorization in [main.go](/work/repo/cmd/rascald/main.go): `GET/POST /v1/credentials`, `GET/PATCH/DELETE /v1/credentials/{id}`.\n- Added config for broker strategy/TTL/renew/encryption key and session env precedence fixes in [config.go](/work/repo/internal/config/config.go) and [main.go](/work/repo/cmd/rascal-runner/main.go).\n- Added tests for strategies, broker lifecycle/concurrency/cooldown, API authz, identity persistence, and scheduler credential file behavior: [strategies_test.go](/work/repo/internal/credentials/strategies/strategies_test.go), [broker_test.go](/work/repo/internal/credentials/broker_test.go), [credentials_test.go](/work/repo/cmd/rascald/credentials_test.go).\n\nTests run:\n- `go test ./...` (passes)\n\nAlso wrote commit message file:\n- [/rascal-meta/commit_message.txt](/rascal-meta/commit_message.txt)"}],"metadata":{"userVisible":true,"agentVisible":true}}}
{"type":"complete","total_tokens":16782005}

```

</details>

Closes #106

---

Rascal run `run_9a55a9a34b4e4de3` completed in 30m 14s · 16.78M tokens