### PR TITLE
refactor(state): remove legacy run/task compatibility fallbacks

### DIFF
--- a/cmd/rascal/main.go
+++ b/cmd/rascal/main.go
@@ -1035,7 +1035,7 @@ func (a *app) newPSCmd() *cobra.Command {
 							tw,
 							"%s\t%s\t%s\t%s\t%s\t%s\n",
 							run.ID,
-							psStatusLabel(run),
+							string(run.Status),
 							run.Repo,
 							psIssueLabel(run),
 							psPRLabel(run),
@@ -2389,16 +2389,7 @@ func (a *app) fetchRun(runID string) (state.Run, error) {
 	return out.Run, nil
 }
 
-func psStatusLabel(run state.Run) string {
-	switch run.Status {
-	case state.StatusReview:
-		return "review"
-	default:
-		return string(run.Status)
-	}
-}
-
-const allowedPSStatusValues = "queued, running, awaiting_feedback, succeeded, failed, canceled"
+const allowedPSStatusValues = "queued, running, review, succeeded, failed, canceled"
 
 func parsePSStatusFilter(raw string) (map[state.RunStatus]struct{}, error) {
 	raw = strings.TrimSpace(raw)
@@ -2413,7 +2404,7 @@ func parsePSStatusFilter(raw string) (map[state.RunStatus]struct{}, error) {
 			out[state.StatusQueued] = struct{}{}
 		case "running":
 			out[state.StatusRunning] = struct{}{}
-		case "awaiting_feedback":
+		case "review":
 			out[state.StatusReview] = struct{}{}
 		case "succeeded":
 			out[state.StatusSucceeded] = struct{}{}
@@ -2434,15 +2425,14 @@ func filterRunsByStatus(runs []state.Run, statuses map[state.RunStatus]struct{})
 	}
 	filtered := make([]state.Run, 0, len(runs))
 	for _, run := range runs {
-		if _, ok := statuses[state.CanonicalRunStatus(run.Status)]; ok {
+		if _, ok := statuses[run.Status]; ok {
 			filtered = append(filtered, run)
 		}
 	}
 	return filtered
 }
-
 func psPRLabel(run state.Run) string {
-	prStatus := effectivePRStatus(run)
+	prStatus := normalizedPRStatus(run.PRStatus)
 	if run.PRNumber <= 0 {
 		if strings.TrimSpace(run.PRURL) == "" {
 			return "-"
@@ -2475,23 +2465,12 @@ func psCreatedLabel(createdAt time.Time) string {
 	return createdAt.UTC().Format("2006-01-02 15:04")
 }
 
-func effectivePRStatus(run state.Run) state.PRStatus {
-	switch run.PRStatus {
+func normalizedPRStatus(status state.PRStatus) state.PRStatus {
+	switch status {
 	case state.PRStatusOpen, state.PRStatusMerged, state.PRStatusClosedUnmerged:
-		return run.PRStatus
-	}
-	if run.PRNumber <= 0 && strings.TrimSpace(run.PRURL) == "" {
-		return state.PRStatusNone
-	}
-	switch run.Status {
-	case state.StatusReview:
-		return state.PRStatusOpen
-	case state.StatusSucceeded:
-		return state.PRStatusMerged
-	case state.StatusCanceled:
-		return state.PRStatusClosedUnmerged
+		return status
 	default:
-		return state.PRStatusOpen
+		return state.PRStatusNone
 	}
 }
 

--- a/cmd/rascal/main_test.go
+++ b/cmd/rascal/main_test.go
@@ -801,7 +801,7 @@ func TestPSAllCannotBeCombinedWithLimit(t *testing.T) {
 }
 
 func TestParsePSStatusFilter(t *testing.T) {
-	got, err := parsePSStatusFilter(" Running,awaiting_feedback,FAILED,canceled ")
+	got, err := parsePSStatusFilter(" Running,review,FAILED,canceled ")
 	if err != nil {
 		t.Fatalf("parsePSStatusFilter unexpected error: %v", err)
 	}
@@ -828,7 +828,7 @@ func TestParsePSStatusFilterInvalidValue(t *testing.T) {
 	if !strings.Contains(err.Error(), `invalid --status value "not_real"`) {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "allowed values: queued, running, awaiting_feedback, succeeded, failed, canceled") {
+	if !strings.Contains(err.Error(), "allowed values: queued, running, review, succeeded, failed, canceled") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -885,7 +885,7 @@ func TestPSStatusFilterRendersOnlyMatchingRuns(t *testing.T) {
 	cmd := a.newPSCmd()
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
-	cmd.SetArgs([]string{"--status", "running,AWAITING_FEEDBACK"})
+	cmd.SetArgs([]string{"--status", "running,REVIEW"})
 	stdout, err := captureStdout(func() error { return cmd.Execute() })
 	if err != nil {
 		t.Fatalf("ps --status execute: %v", err)
@@ -897,7 +897,7 @@ func TestPSStatusFilterRendersOnlyMatchingRuns(t *testing.T) {
 		t.Fatalf("expected running run to remain, got:\n%s", stdout)
 	}
 	if !strings.Contains(stdout, "run_review") {
-		t.Fatalf("expected awaiting_feedback alias to include review run, got:\n%s", stdout)
+		t.Fatalf("expected review filter to include review run, got:\n%s", stdout)
 	}
 }
 
@@ -922,19 +922,24 @@ func TestPSStatusFilterInvalidValueReturnsInputError(t *testing.T) {
 
 func TestPSStatusAndPRLabels(t *testing.T) {
 	run := state.Run{Status: state.StatusReview, PRNumber: 77}
-	if got := psStatusLabel(run); got != "review" {
-		t.Fatalf("psStatusLabel review = %q, want review", got)
+	if got := string(run.Status); got != "review" {
+		t.Fatalf("run status = %q, want review", got)
 	}
-	if got := psPRLabel(run); got != "#77 open" {
-		t.Fatalf("psPRLabel review = %q, want #77 open", got)
+	if got := psPRLabel(run); got != "#77" {
+		t.Fatalf("psPRLabel review without pr_status = %q, want #77", got)
 	}
 
-	run = state.Run{Status: state.StatusSucceeded, PRNumber: 77}
+	run = state.Run{Status: state.StatusReview, PRNumber: 77, PRStatus: state.PRStatusOpen}
+	if got := psPRLabel(run); got != "#77 open" {
+		t.Fatalf("psPRLabel open = %q, want #77 open", got)
+	}
+
+	run = state.Run{Status: state.StatusSucceeded, PRNumber: 77, PRStatus: state.PRStatusMerged}
 	if got := psPRLabel(run); got != "#77 merged" {
 		t.Fatalf("psPRLabel succeeded = %q, want #77 merged", got)
 	}
 
-	run = state.Run{Status: state.StatusCanceled, PRNumber: 77}
+	run = state.Run{Status: state.StatusCanceled, PRNumber: 77, PRStatus: state.PRStatusClosedUnmerged}
 	if got := psPRLabel(run); got != "#77 closed" {
 		t.Fatalf("psPRLabel canceled = %q, want #77 closed", got)
 	}
@@ -945,8 +950,13 @@ func TestPSStatusAndPRLabels(t *testing.T) {
 	}
 
 	run = state.Run{Status: state.StatusQueued, PRURL: "https://example.com/pr/77"}
+	if got := psPRLabel(run); got != "link" {
+		t.Fatalf("psPRLabel pr_url-only = %q, want link", got)
+	}
+
+	run = state.Run{Status: state.StatusQueued, PRURL: "https://example.com/pr/77", PRStatus: state.PRStatusOpen}
 	if got := psPRLabel(run); got != "open" {
-		t.Fatalf("psPRLabel pr_url-only = %q, want open", got)
+		t.Fatalf("psPRLabel pr_url-only open = %q, want open", got)
 	}
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -190,7 +190,7 @@ background worker.
 Key persisted entities:
 
 - `runs`: user-visible execution records and final outcome.
-- `tasks`: long-lived task identity across retries and follow-up feedback.
+- `tasks`: long-lived task identity across retries and follow-up feedback; API responses include a derived `pending_input` flag (computed from queued runs, not stored as a task column).
 - `run_leases`: supervision ownership and heartbeat expiry.
 - `run_executions`: detached execution handle metadata for adoption and cleanup.
 - `run_cancels`: persisted cancel intent.

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -464,7 +464,6 @@ func (s *Store) UpdateRun(id string, fn func(*Run) error) (Run, error) {
 	if err := fn(&r); err != nil {
 		return Run{}, fmt.Errorf("apply run update for %q: %w", id, err)
 	}
-	r.Status = CanonicalRunStatus(r.Status)
 	if err := ValidateRunStatusTransition(prevStatus, r.Status); err != nil {
 		return Run{}, fmt.Errorf("validate run status transition for %q: %w", id, err)
 	}
@@ -1111,7 +1110,7 @@ func fromDBRunParts(id, taskID, repo, task, agentBackend, baseBranch, headBranch
 		HeadBranch:   headBranch,
 		Trigger:      trigger,
 		Debug:        debug,
-		Status:       CanonicalRunStatus(RunStatus(status)),
+		Status:       RunStatus(status),
 		RunDir:       runDir,
 		IssueNumber:  int(issueNumber),
 		PRNumber:     int(prNumber),
@@ -1188,16 +1187,6 @@ func fromDBTaskAgentSession(s sqlitegen.TaskAgentSession) TaskAgentSession {
 
 func toDBUpdateRunParams(r Run) sqlitegen.UpdateRunParams {
 	prStatus := normalizePRStatus(r.PRStatus)
-	if prStatus == PRStatusNone && r.PRNumber > 0 {
-		switch r.Status {
-		case StatusSucceeded:
-			prStatus = PRStatusMerged
-		case StatusCanceled:
-			prStatus = PRStatusClosedUnmerged
-		default:
-			prStatus = PRStatusOpen
-		}
-	}
 	return sqlitegen.UpdateRunParams{
 		TaskID:       r.TaskID,
 		Repo:         r.Repo,
@@ -1207,7 +1196,7 @@ func toDBUpdateRunParams(r Run) sqlitegen.UpdateRunParams {
 		HeadBranch:   r.HeadBranch,
 		Trigger:      r.Trigger,
 		Debug:        r.Debug,
-		Status:       string(CanonicalRunStatus(r.Status)),
+		Status:       string(r.Status),
 		RunDir:       r.RunDir,
 		IssueNumber:  int64(r.IssueNumber),
 		PrNumber:     int64(r.PRNumber),

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -333,6 +333,55 @@ func TestStoreUpsertRunTokenUsage(t *testing.T) {
 	}
 }
 
+func TestStoreUpdateRunDoesNotInferPRStatusFromRunStatus(t *testing.T) {
+	t.Parallel()
+
+	store, err := New(filepath.Join(t.TempDir(), "state.db"), 200)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	if _, err := store.UpsertTask(UpsertTaskInput{ID: "task-pr-status", Repo: "owner/repo"}); err != nil {
+		t.Fatalf("upsert task: %v", err)
+	}
+	run, err := store.AddRun(CreateRunInput{
+		ID:         "run_pr_status",
+		TaskID:     "task-pr-status",
+		Repo:       "owner/repo",
+		Task:       "pr status behavior",
+		BaseBranch: "main",
+		RunDir:     "/tmp/run_pr_status",
+		PRNumber:   42,
+	})
+	if err != nil {
+		t.Fatalf("add run: %v", err)
+	}
+	if run.PRStatus != PRStatusOpen {
+		t.Fatalf("initial pr status = %s, want open", run.PRStatus)
+	}
+
+	if _, err := store.SetRunStatus(run.ID, StatusRunning, ""); err != nil {
+		t.Fatalf("set running: %v", err)
+	}
+	if _, err := store.UpdateRun(run.ID, func(r *Run) error {
+		r.Status = StatusReview
+		r.PRStatus = PRStatusNone
+		return nil
+	}); err != nil {
+		t.Fatalf("set review with explicit none pr status: %v", err)
+	}
+
+	if _, err := store.SetRunStatus(run.ID, StatusCanceled, "canceled"); err != nil {
+		t.Fatalf("set canceled: %v", err)
+	}
+	got, ok := store.GetRun(run.ID)
+	if !ok {
+		t.Fatalf("run %s not found", run.ID)
+	}
+	if got.PRStatus != PRStatusNone {
+		t.Fatalf("pr status = %s, want none", got.PRStatus)
+	}
+}
+
 func TestStoreSeenDelivery(t *testing.T) {
 	t.Parallel()
 

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -50,12 +50,8 @@ var runStatusTransitions = map[RunStatus]map[RunStatus]struct{}{
 	},
 }
 
-func CanonicalRunStatus(status RunStatus) RunStatus {
-	return status
-}
-
 func IsFinalRunStatus(status RunStatus) bool {
-	switch CanonicalRunStatus(status) {
+	switch status {
 	case StatusReview, StatusSucceeded, StatusFailed, StatusCanceled:
 		return true
 	default:
@@ -64,8 +60,6 @@ func IsFinalRunStatus(status RunStatus) bool {
 }
 
 func ValidateRunStatusTransition(from, to RunStatus) error {
-	from = CanonicalRunStatus(from)
-	to = CanonicalRunStatus(to)
 	next, ok := runStatusTransitions[from]
 	if !ok {
 		return fmt.Errorf("invalid current run status %q", from)
@@ -130,8 +124,9 @@ type Task struct {
 	IssueNumber  int           `json:"issue_number,omitempty"`
 	PRNumber     int           `json:"pr_number,omitempty"`
 	Status       TaskStatus    `json:"status"`
-	PendingInput bool          `json:"pending_input"`
-	LastRunID    string        `json:"last_run_id,omitempty"`
+	// PendingInput is derived at read time from whether the task has queued runs.
+	PendingInput bool   `json:"pending_input"`
+	LastRunID    string `json:"last_run_id,omitempty"`
 
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`


### PR DESCRIPTION
Drop runtime fallback inference for run/pr status handling now that migrations
normalize old rows, and simplify CLI PR/status rendering to rely on persisted
canonical fields. Keep task pending_input as a derived API field and document it.

<details><summary>Goose Details</summary>

```

    __( O)>  ● new session · codex gpt-5.4
   \____)    20260308_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: "/usr/local/bin/codex"
Model: gpt-5.4
Reasoning effort: high
Skip git check: false
Prompt length: 3449 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Suggestion

The user has 7 extensions with 16 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
Consider asking if they'd like to disable some extensions to improve tool selection accuracy.

# Response Guidelines

Use Markdown formatting for all responses.

Human: <info-msg>
It is currently 2026-03-08 09:26:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

</info-msg>
# Rascal Run Instructions

Run ID: run_c3ce21c6334f2475
Task ID: rtzll/rascal#103
Repository: rtzll/rascal
Issue: #103

## Task

refactor(state): remove legacy run/task compatibility fallbacks

## Summary
The state layer still carries compatibility logic for older run/task representations. Examples include migration-time handling of `awaiting_feedback`, fallback inference of `pr_status` from `run.Status`, and the synthesized `pending_input` task field after removing the stored column.

Relevant code:
- `internal/state/migrations/00005_task_pending_input_derived.sql`
- `internal/state/migrations/00006_run_pr_status.sql`
- `internal/state/migrations/00007_run_status_review.sql`
- `internal/state/sql/queries.sql`
- `internal/state/types.go`
- `cmd/rascal/main.go` (`effectivePRStatus`)

## Goal
Finish the migration to the current state model and remove compatibility fallbacks that are no longer needed.

## Scope
- Decide the canonical run/task model and enforce it in one place.
- Remove runtime fallback inference that only exists for old rows, once migrations already cover the conversion.
- Remove or justify the remaining `pending_input` synthetic field; if it stays, document why it is still part of the public task model.
- Simplify related status helpers and CLI rendering.

## Out Of Scope
- Schema changes unrelated to the old compatibility paths.
- Broader state redesign beyond cleanup of historical representations.

## Expected Outcome
- The runtime code operates on one canonical set of statuses and task fields.
- Migration files remain as historical artifacts, but active code stops carrying unnecessary compatibility logic.
- CLI status rendering becomes simpler and less inference-driven.

## Acceptance Criteria
- Active code does not rely on deprecated status names like `awaiting_feedback`.
- `pr_status` is either always persisted/normalized or its fallback path is intentionally retained and documented.
- Any behavior change in task/run JSON output is reflected in tests.
- No behavior-changing cleanup is submitted until all tests pass.

## Testing Requirements
- Run `go test ./...`.
- Update state-store tests and CLI output tests that depend on old inferred behavior.
- Add coverage for the final canonical behavior if removing compatibility branches reduces test depth.

## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run tests or explain why tests could not run.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label 'rascal' on issue #103


Assistant: 
Image files: 0
============================
{"type":"message","message":{"id":null,"role":"assistant","created":1772962429,"content":[{"type":"text","text":"I’ll implement the state-layer cleanup for issue `#103` by first mapping all remaining compatibility fallbacks (`awaiting_feedback`, `pr_status` inference, synthetic `pending_input`) and then making minimal, scoped edits with test updates. I’m updating the task plan now and then inspecting the relevant files.\n\nI found the key compatibility hotspots in `internal/state/sql/queries.sql`, `internal/state/types.go`, and `cmd/rascal/main.go` (`effectivePRStatus`). Next I’m reading those files and the nearby tests to pin down the canonical behavior before editing.\n\nI confirmed the migrations already normalize legacy data (`awaiting_feedback` → `review`, and `pr_status` column added). I’m now checking `store.go` and tests for any remaining runtime canonicalization or inferred fields that can be removed safely.\n\nI found additional compatibility logic in `internal/state/store.go`: it still infers `pr_status` from run fields and status when missing. I’m checking generation tooling next so we can safely update `queries.sql`/models and keep generated code in sync.\n\nI’ve narrowed the cleanup to three concrete runtime fallbacks: `effectivePRStatus` in CLI, PR-status inference in `state.toDBUpdateRunParams`, and no-op canonical run-status mapping helpers. I’m verifying all run-update paths set `pr_status` explicitly so we can remove inference safely.\n\nI have enough context and I’m proceeding with minimal code edits: remove PR/run legacy inference paths, keep `pending_input` as a derived API field with explicit documentation, and update tests to assert the canonical non-inferred behavior. I’ll patch `state` and CLI files now, then run the full test suite.\n\nI’ve applied the core runtime cleanup and updated CLI expectations to stop inferring PR state from run status. I’m adding a focused store test that guarantees `pr_status` is no longer backfilled during updates, then I’ll run formatting and tests.\n\nEdits are in place and formatted. I’m reviewing the diff for correctness and then running `go test ./...` to validate behavior and catch any regressions tied to the removed fallbacks.\n\nThe full test run is in progress; dependencies are being fetched first. I’m polling until completion and will address any failures immediately.\n\nImplemented the refactor for issue `#103` and removed the active legacy compatibility fallbacks.\n\n**What changed**\n- Removed no-op run status canonicalization plumbing and now enforce transitions directly on canonical statuses.\n[types.go](/work/repo/internal/state/types.go)  \n[store.go](/work/repo/internal/state/store.go)\n\n- Removed runtime `pr_status` backfill inference from `run.Status` during run updates. `pr_status` is now persisted/used as-is (normalized only to known enum values).\n[store.go](/work/repo/internal/state/store.go)\n\n- Simplified CLI `ps` rendering to stop inferring PR state from run status; it now uses persisted `pr_status`.\n[main.go](/work/repo/cmd/rascal/main.go)\n\n- Updated CLI tests for canonical non-inferred PR label behavior.\n[main_test.go](/work/repo/cmd/rascal/main_test.go)\n\n- Added store coverage to ensure PR status is not inferred from run status during updates.\n[store_test.go](/work/repo/internal/state/store_test.go)\n\n- Kept `pending_input` as a derived public task field and documented why it remains in the task model.\n[types.go](/work/repo/internal/state/types.go)  \n[architecture.md](/work/repo/docs/architecture.md)\n\n**Validation**\n- Ran full test suite: `go test ./...` (pass).\n\n**Commit message file**\n- Wrote: `/rascal-meta/commit_message.txt` with:\n  - `refactor(state): remove legacy run/task compatibility fallbacks`"}],"metadata":{"userVisible":true,"agentVisible":true}}}
{"type":"complete","total_tokens":2682743}

```

</details>

Closes #103

---

Rascal run `run_c3ce21c6334f2475` completed in 7m 15s · 2.68M tokens