### PR TITLE
chore(runner): simplify Goose session modes and align defaults

### DIFF
--- a/cmd/rascal-runner/main_test.go
+++ b/cmd/rascal-runner/main_test.go
@@ -238,7 +238,7 @@ func TestLoadConfigRespectsGooseSessionEnv(t *testing.T) {
 	t.Setenv("GH_TOKEN", "token")
 	t.Setenv("RASCAL_META_DIR", metaDir)
 	t.Setenv("RASCAL_WORK_ROOT", workRoot)
-	t.Setenv("RASCAL_GOOSE_SESSION_MODE", "pr-only")
+	t.Setenv("RASCAL_GOOSE_SESSION_MODE", "all")
 	t.Setenv("RASCAL_GOOSE_SESSION_RESUME", "true")
 	t.Setenv("RASCAL_GOOSE_SESSION_KEY", "owner-repo-3-abc123")
 	t.Setenv("RASCAL_GOOSE_SESSION_NAME", "rascal-owner-repo-3-abc123")
@@ -248,8 +248,8 @@ func TestLoadConfigRespectsGooseSessionEnv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loadConfig returned error: %v", err)
 	}
-	if cfg.GooseSessionMode != runner.GooseSessionModePROnly {
-		t.Fatalf("GooseSessionMode = %q, want %q", cfg.GooseSessionMode, runner.GooseSessionModePROnly)
+	if cfg.GooseSessionMode != runner.GooseSessionModeAll {
+		t.Fatalf("GooseSessionMode = %q, want %q", cfg.GooseSessionMode, runner.GooseSessionModeAll)
 	}
 	if !cfg.GooseSessionResume {
 		t.Fatal("GooseSessionResume should be true")
@@ -311,7 +311,7 @@ func TestRunGooseUsesNamedResumeSessionWhenEnabled(t *testing.T) {
 		InstructionsPath:   filepath.Join(root, "instructions.md"),
 		GooseLogPath:       filepath.Join(root, "agent.ndjson"),
 		GooseDebug:         false,
-		GooseSessionMode:   runner.GooseSessionModePROnly,
+		GooseSessionMode:   runner.GooseSessionModeAll,
 		GooseSessionResume: true,
 		GooseSessionName:   "rascal-owner-repo-task-abc123",
 		GooseSessionKey:    "owner-repo-task-abc123",
@@ -362,7 +362,7 @@ func TestRunGooseSkipsResumeWhenNamedSessionIsMissing(t *testing.T) {
 		InstructionsPath:   filepath.Join(root, "instructions.md"),
 		GooseLogPath:       filepath.Join(root, "agent.ndjson"),
 		GooseDebug:         false,
-		GooseSessionMode:   runner.GooseSessionModePROnly,
+		GooseSessionMode:   runner.GooseSessionModeAll,
 		GooseSessionResume: true,
 		GooseSessionName:   "rascal-owner-repo-task-missing",
 		GooseSessionKey:    "owner-repo-task-missing",
@@ -412,7 +412,7 @@ func TestRunGooseFallsBackToFreshSessionOnResumeStateError(t *testing.T) {
 		InstructionsPath:   filepath.Join(root, "instructions.md"),
 		GooseLogPath:       filepath.Join(root, "agent.ndjson"),
 		GooseDebug:         false,
-		GooseSessionMode:   runner.GooseSessionModePROnly,
+		GooseSessionMode:   runner.GooseSessionModeAll,
 		GooseSessionResume: true,
 		GooseSessionName:   "rascal-owner-repo-task-abc123",
 		GooseSessionKey:    "owner-repo-task-abc123",
@@ -518,7 +518,7 @@ func TestRunGooseDoesNotFallbackOnUnrelatedFailure(t *testing.T) {
 		InstructionsPath:   filepath.Join(root, "instructions.md"),
 		GooseLogPath:       filepath.Join(root, "agent.ndjson"),
 		GooseDebug:         false,
-		GooseSessionMode:   runner.GooseSessionModePROnly,
+		GooseSessionMode:   runner.GooseSessionModeAll,
 		GooseSessionResume: true,
 		GooseSessionName:   "rascal-owner-repo-task-abc123",
 		GooseSessionKey:    "owner-repo-task-abc123",
@@ -570,7 +570,7 @@ func TestRunGooseKeepsResumeWhenSessionPreflightFails(t *testing.T) {
 		InstructionsPath:   filepath.Join(root, "instructions.md"),
 		GooseLogPath:       filepath.Join(root, "agent.ndjson"),
 		GooseDebug:         false,
-		GooseSessionMode:   runner.GooseSessionModePROnly,
+		GooseSessionMode:   runner.GooseSessionModeAll,
 		GooseSessionResume: true,
 		GooseSessionName:   "rascal-owner-repo-task-abc123",
 		GooseSessionKey:    "owner-repo-task-abc123",

--- a/cmd/rascald/main_test.go
+++ b/cmd/rascald/main_test.go
@@ -2035,7 +2035,7 @@ func TestExecuteRunRetriesLauncherFailure(t *testing.T) {
 	}
 }
 
-func TestExecuteRunSetsGooseSessionSpecForPROnlyCommentTrigger(t *testing.T) {
+func TestExecuteRunSetsGooseSessionSpecForAllMode(t *testing.T) {
 	t.Parallel()
 	launcher := &fakeLauncher{}
 	s := newTestServer(t, launcher)
@@ -2043,7 +2043,7 @@ func TestExecuteRunSetsGooseSessionSpecForPROnlyCommentTrigger(t *testing.T) {
 
 	s.cfg.AgentBackend = agent.BackendGoose
 	sessionRoot := filepath.Join(t.TempDir(), "goose-sessions")
-	s.cfg.GooseSessionMode = "pr-only"
+	s.cfg.GooseSessionMode = "all"
 	s.cfg.GooseSessionRoot = sessionRoot
 	s.cfg.GooseSessionTTLDays = 0
 
@@ -2067,7 +2067,7 @@ func TestExecuteRunSetsGooseSessionSpecForPROnlyCommentTrigger(t *testing.T) {
 	}
 	spec := launcher.specs[0]
 	if !spec.GooseSessionResume {
-		t.Fatal("expected GooseSessionResume=true for pr-only comment trigger")
+		t.Fatal("expected GooseSessionResume=true for all mode")
 	}
 	if spec.GooseSessionTaskKey == "" {
 		t.Fatal("expected GooseSessionTaskKey to be populated")
@@ -2080,14 +2080,14 @@ func TestExecuteRunSetsGooseSessionSpecForPROnlyCommentTrigger(t *testing.T) {
 	}
 }
 
-func TestExecuteRunDisablesGooseSessionSpecForNonPROnlyTrigger(t *testing.T) {
+func TestExecuteRunDisablesGooseSessionSpecForOffMode(t *testing.T) {
 	t.Parallel()
 	launcher := &fakeLauncher{}
 	s := newTestServer(t, launcher)
 	defer waitForServerIdle(t, s)
 
 	s.cfg.AgentBackend = agent.BackendGoose
-	s.cfg.GooseSessionMode = "pr-only"
+	s.cfg.GooseSessionMode = "off"
 	s.cfg.GooseSessionRoot = filepath.Join(t.TempDir(), "goose-sessions")
 	s.cfg.GooseSessionTTLDays = 0
 
@@ -2111,7 +2111,7 @@ func TestExecuteRunDisablesGooseSessionSpecForNonPROnlyTrigger(t *testing.T) {
 	}
 	spec := launcher.specs[0]
 	if spec.GooseSessionResume {
-		t.Fatal("expected GooseSessionResume=false for non PR-only trigger")
+		t.Fatal("expected GooseSessionResume=false for off mode")
 	}
 	if spec.GooseSessionTaskDir != "" || spec.GooseSessionTaskKey != "" || spec.GooseSessionName != "" {
 		t.Fatalf("expected empty goose session fields when resume disabled, got dir=%q key=%q name=%q", spec.GooseSessionTaskDir, spec.GooseSessionTaskKey, spec.GooseSessionName)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,7 +98,7 @@ These are the main layers in the Go codebase.
 
 2. Agent abstraction
 
-- `internal/agent` defines backend normalization (`goose`, `codex`) and session policy (`off`, `pr-only`, `all`).
+- `internal/agent` defines backend normalization (`goose`, `codex`) and session policy (`off`, `all`).
 - This keeps backend/session decisions out of the higher-level orchestrator flow.
 
 3. Execution abstraction
@@ -237,8 +237,8 @@ Each run directory stores metadata and artifacts such as:
 
 ## Session Behavior
 
-- Session policy is configured at the orchestrator via `off`, `pr-only`, or `all`.
-- `pr-only` currently resumes for `pr_comment`, `pr_review`, `pr_review_comment`, `retry`, and `issue_edited`.
+- Session policy is configured at the orchestrator via `off` or `all`.
+- `all` enables session resume for every trigger.
 - Goose resumes by named Goose session plus mounted session storage.
 - Codex resumes by reusing a task-scoped `CODEX_HOME` and the discovered backend session id.
 - If a task switches backend between runs, Rascal starts a fresh session for the new backend and replaces the stored task session record.
@@ -301,7 +301,7 @@ Common optional:
 - `RASCAL_META_DIR` (default: `/rascal-meta`)
 - `RASCAL_WORK_ROOT` (default: `/work`)
 - `RASCAL_REPO_DIR` (default: `${RASCAL_WORK_ROOT}/repo`)
-- `RASCAL_AGENT_SESSION_MODE` (`off`, `pr-only`, `all`; orchestrator default: `all`)
+- `RASCAL_AGENT_SESSION_MODE` (`off` or `all`; orchestrator default: `all`)
 - `RASCAL_AGENT_SESSION_RESUME` (set by orchestrator per run)
 - `RASCAL_AGENT_SESSION_KEY` (stable task-scoped key when resume is enabled)
 - `RASCAL_AGENT_SESSION_ID` (backend session id when known)

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -83,19 +83,11 @@ for the same task/PR, without any background process.
 
 Server env controls:
 
-- `RASCAL_AGENT_SESSION_MODE=off|pr-only|all` (default: `all`)
+- `RASCAL_AGENT_SESSION_MODE=off|all` (default: `all`)
 - `RASCAL_AGENT_SESSION_ROOT` (default: `${RASCAL_DATA_DIR}/agent-sessions`)
 - `RASCAL_AGENT_SESSION_TTL_DAYS` (default: `14`, set `0` to disable cleanup)
 
 Older Goose-specific env names are still accepted as compatibility aliases.
-
-`pr-only` resumes for iterative PR triggers:
-
-- `pr_comment`
-- `pr_review`
-- `pr_review_comment`
-- `retry`
-- `issue_edited` (same task)
 
 To reset a task session manually, delete its directory under
 `${RASCAL_AGENT_SESSION_ROOT}`.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -31,15 +31,14 @@ func (b Backend) String() string {
 type SessionMode string
 
 const (
-	SessionModeOff    SessionMode = "off"
-	SessionModePROnly SessionMode = "pr-only"
-	SessionModeAll    SessionMode = "all"
+	SessionModeOff SessionMode = "off"
+	SessionModeAll SessionMode = "all"
 )
 
 func NormalizeSessionMode(raw string) SessionMode {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case string(SessionModePROnly):
-		return SessionModePROnly
+	case string(SessionModeOff):
+		return SessionModeOff
 	case string(SessionModeAll):
 		return SessionModeAll
 	default:
@@ -48,19 +47,7 @@ func NormalizeSessionMode(raw string) SessionMode {
 }
 
 func SessionEnabled(mode SessionMode, trigger string) bool {
-	switch NormalizeSessionMode(string(mode)) {
-	case SessionModeAll:
-		return true
-	case SessionModePROnly:
-		switch strings.TrimSpace(trigger) {
-		case "pr_comment", "pr_review", "pr_review_comment", "retry", "issue_edited":
-			return true
-		default:
-			return false
-		}
-	default:
-		return false
-	}
+	return NormalizeSessionMode(string(mode)) == SessionModeAll
 }
 
 func SessionTaskKey(repo, taskID string) string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -308,23 +308,13 @@ func loadAgentBackend() agent.Backend {
 }
 
 func loadAgentSessionMode() agent.SessionMode {
-	if raw, ok := os.LookupEnv("RASCAL_GOOSE_SESSION_MODE"); ok {
-		mode := agent.NormalizeSessionMode(raw)
-		if mode == "" || mode == agent.SessionModeOff {
+	for _, key := range []string{"RASCAL_GOOSE_SESSION_MODE", "RASCAL_AGENT_SESSION_MODE"} {
+		if raw, ok := os.LookupEnv(key); ok {
 			if strings.TrimSpace(raw) == "" {
 				return agent.SessionModeAll
 			}
+			return agent.NormalizeSessionMode(raw)
 		}
-		return mode
-	}
-	if raw, ok := os.LookupEnv("RASCAL_AGENT_SESSION_MODE"); ok {
-		mode := agent.NormalizeSessionMode(raw)
-		if mode == "" || mode == agent.SessionModeOff {
-			if strings.TrimSpace(raw) == "" {
-				return agent.SessionModeAll
-			}
-		}
-		return mode
 	}
 	return agent.SessionModeAll
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -149,13 +149,13 @@ func TestLoadServerConfigDefaultsAgentBackendToCodex(t *testing.T) {
 
 func TestLoadServerConfigGooseSessionOverrides(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "goose-root")
-	t.Setenv("RASCAL_GOOSE_SESSION_MODE", "PR-ONLY")
+	t.Setenv("RASCAL_GOOSE_SESSION_MODE", "OFF")
 	t.Setenv("RASCAL_GOOSE_SESSION_ROOT", root)
 	t.Setenv("RASCAL_GOOSE_SESSION_TTL_DAYS", "0")
 
 	cfg := LoadServerConfig()
-	if cfg.GooseSessionMode != "pr-only" {
-		t.Fatalf("GooseSessionMode = %q, want pr-only", cfg.GooseSessionMode)
+	if cfg.GooseSessionMode != "off" {
+		t.Fatalf("GooseSessionMode = %q, want off", cfg.GooseSessionMode)
 	}
 	if cfg.GooseSessionRoot != root {
 		t.Fatalf("GooseSessionRoot = %q, want %q", cfg.GooseSessionRoot, root)

--- a/internal/runner/docker_test.go
+++ b/internal/runner/docker_test.go
@@ -212,7 +212,7 @@ exit 0
 		Trigger:             "pr_comment",
 		Debug:               true,
 		RunDir:              runDir,
-		GooseSessionMode:    GooseSessionModePROnly,
+		GooseSessionMode:    GooseSessionModeAll,
 		GooseSessionResume:  true,
 		GooseSessionTaskDir: sessionDir,
 		GooseSessionTaskKey: "owner-repo-1-abc123",
@@ -230,7 +230,7 @@ exit 0
 	if !strings.Contains(call, "-e GOOSE_PATH_ROOT=/rascal-goose-session") {
 		t.Fatalf("expected persistent goose path root env, got:\n%s", call)
 	}
-	if !strings.Contains(call, "-e RASCAL_GOOSE_SESSION_MODE=pr-only") {
+	if !strings.Contains(call, "-e RASCAL_GOOSE_SESSION_MODE=all") {
 		t.Fatalf("expected session mode env, got:\n%s", call)
 	}
 	if !strings.Contains(call, "-e RASCAL_GOOSE_SESSION_RESUME=true") {
@@ -291,7 +291,7 @@ exit 0
 		Trigger:          "issue_label",
 		Debug:            false,
 		RunDir:           runDir,
-		GooseSessionMode: GooseSessionModePROnly,
+		GooseSessionMode: GooseSessionModeAll,
 	})
 	if err != nil {
 		t.Fatalf("launcher start: %v", err)
@@ -346,7 +346,7 @@ exit 0
 		Debug:        true,
 		RunDir:       runDir,
 		AgentSession: SessionSpec{
-			Mode:             agent.SessionModePROnly,
+			Mode:             agent.SessionModeAll,
 			Resume:           true,
 			TaskDir:          sessionDir,
 			TaskKey:          "owner-repo-1-abc123",

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -7,9 +7,8 @@ import (
 )
 
 const (
-	GooseSessionModeOff    = string(agent.SessionModeOff)
-	GooseSessionModePROnly = string(agent.SessionModePROnly)
-	GooseSessionModeAll    = string(agent.SessionModeAll)
+	GooseSessionModeOff = string(agent.SessionModeOff)
+	GooseSessionModeAll = string(agent.SessionModeAll)
 )
 
 func NormalizeGooseSessionMode(mode string) string {

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -9,14 +9,12 @@ func TestNormalizeGooseSessionMode(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]string{
-		"":         GooseSessionModeOff,
-		"off":      GooseSessionModeOff,
-		"pr-only":  GooseSessionModePROnly,
-		"PR-ONLY":  GooseSessionModePROnly,
-		"all":      GooseSessionModeAll,
-		"unknown":  GooseSessionModeOff,
-		"  all  ":  GooseSessionModeAll,
-		" pr-only": GooseSessionModePROnly,
+		"":        GooseSessionModeOff,
+		"off":     GooseSessionModeOff,
+		"OFF":     GooseSessionModeOff,
+		"all":     GooseSessionModeAll,
+		"unknown": GooseSessionModeOff,
+		"  all  ": GooseSessionModeAll,
 	}
 	for in, want := range tests {
 		if got := NormalizeGooseSessionMode(in); got != want {
@@ -34,13 +32,8 @@ func TestGooseSessionEnabled(t *testing.T) {
 	if !GooseSessionEnabled(GooseSessionModeAll, "issue_label") {
 		t.Fatal("all mode should enable sessions for all triggers")
 	}
-	for _, trigger := range []string{"pr_comment", "pr_review", "pr_review_comment", "retry", "issue_edited"} {
-		if !GooseSessionEnabled(GooseSessionModePROnly, trigger) {
-			t.Fatalf("pr-only mode should enable trigger %q", trigger)
-		}
-	}
-	if GooseSessionEnabled(GooseSessionModePROnly, "issue_label") {
-		t.Fatal("pr-only mode should not enable issue_label")
+	if GooseSessionEnabled(GooseSessionModeOff, "issue_label") {
+		t.Fatal("off mode should disable sessions for all triggers")
 	}
 }
 


### PR DESCRIPTION
Drop `pr-only` and retain only `all` (default) and `off` for agent session persistence.
Align normalization logic, runner/server tests, and docs with the reduced mode surface.

<details><summary>Agent Details</summary>

<pre><code>
    __( O)&gt;  ● new session · codex gpt-5.4
   \____)    20260308_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: &#34;/usr/local/bin/codex&#34;
Model: gpt-5.4
Reasoning effort: high
Skip git check: false
Prompt length: 3025 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Suggestion

The user has 7 extensions with 16 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
Consider asking if they&#39;d like to disable some extensions to improve tool selection accuracy.

# Response Guidelines

Use Markdown formatting for all responses.

Human: &lt;info-msg&gt;
It is currently 2026-03-08 10:44:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

&lt;/info-msg&gt;
# Rascal Run Instructions

Run ID: run_714fe7800782f038
Task ID: rtzll/rascal#104
Repository: rtzll/rascal
Issue: #104

## Task

chore(runner): simplify Goose session modes and align defaults

## Summary
Goose session persistence currently supports three modes (`off`, `pr-only`, `all`), but the deployed env hardcodes `all`, the server default is `all`, and docs disagree about the default. That usually means the option surface is larger than the product really wants to own.

Relevant code:
- `internal/config/config.go`
- `internal/runner/session.go`
- `internal/deploy/deploy.go`
- `docs/architecture.md`
- `docs/operations.md`
- runner and server tests that cover session-mode behavior

## Goal
Choose the session persistence modes Rascal actually intends to support and remove or consolidate the rest.

## Scope
- Decide whether Rascal should support one mode, two modes, or the full current matrix.
- Align code defaults, deployed defaults, docs, and tests.
- Remove dead branches if `pr-only` or `off` are no longer part of the intended product surface.
- Keep the implementation and docs consistent with the final decision.

## Out Of Scope
- Redesigning session persistence internals beyond what is needed to simplify the mode surface.

## Expected Outcome
- Session persistence behavior is easy to explain.
- Defaults match across code, deploy output, and docs.
- Tests cover the actual supported modes only.

## Acceptance Criteria
- There is one authoritative default.
- Docs and help text match the implemented default and supported modes.
- If modes are removed, related tests and docs are deleted or updated rather than left stale.
- No cleanup is submitted until all tests pass.

## Testing Requirements
- Run `go test ./...`.
- Update session-mode tests and any runner/server tests that assume old defaults.
- Add coverage for the retained final mode set if needed.

## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run tests or explain why tests could not run.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label &#39;rascal&#39; on issue #104


Assistant: 
Image files: 0
============================
{&#34;type&#34;:&#34;message&#34;,&#34;message&#34;:{&#34;id&#34;:null,&#34;role&#34;:&#34;assistant&#34;,&#34;created&#34;:1772967082,&#34;content&#34;:[{&#34;type&#34;:&#34;text&#34;,&#34;text&#34;:&#34;I’m going to simplify the Goose session mode surface end-to-end: inspect current mode handling/defaults in code, deploy, docs, and tests, then implement a single consistent decision and run `go test ./...`. I’ll start by updating the task plan and scanning the relevant files.\n\nI found mode handling in `internal/agent`, `config`, `runner/session`, deploy defaults, and multiple docs/tests still referencing `off|pr-only|all`. Next I’m reading those files to decide the smallest consistent surface and remove dead branches.\n\nI confirmed the mode enum is centralized in `internal/agent` and currently still includes `off`, `pr-only`, and `all`; config defaults to `all` already. I’m now checking how run execution and env generation consume this so we can safely remove unused branches.\n\nI found additional session-mode behavior in `cmd/rascald` and `cmd/rascal-runner` tests, so I’m reviewing those next before deciding the retained mode set. That will prevent partial cleanup that misses runner/server assumptions.\n\nI confirmed server/deploy already treat `all` as default; the extra complexity is mainly `pr-only` branching and docs/tests around it. I’m now checking architecture/operations docs plus runner and server tests so I can apply one coherent cleanup pass.\n\nI’ve settled on keeping two explicit modes: `all` (default) and `off`, and removing `pr-only`. I’m starting code edits in the mode normalization and session-enable logic, then I’ll propagate that through tests/docs.\n\nI’ve updated core code and most tests/docs to the two-mode model (`off|all`). I’m now doing a consistency sweep for leftover `pr-only` references and then running formatting/tests.\n\nCode and docs are now switched to `off|all` only, with `all` as the single default across config/deploy/docs. I’m running full test suite (`go test ./...`) now and will fix any failures before finishing.\n\nAll tests passed. I’m now writing the requested commit message file with a conventional commit title reflecting this scope.\n\nImplemented: session persistence now supports only `all` (default) and `off`; `pr-only` was removed.\n\nUpdated code and tests in:\n- [internal/agent/agent.go](/work/repo/internal/agent/agent.go)\n- [internal/config/config.go](/work/repo/internal/config/config.go)\n- [internal/config/config_test.go](/work/repo/internal/config/config_test.go)\n- [internal/runner/session.go](/work/repo/internal/runner/session.go)\n- [internal/runner/session_test.go](/work/repo/internal/runner/session_test.go)\n- [internal/runner/docker_test.go](/work/repo/internal/runner/docker_test.go)\n- [cmd/rascald/main_test.go](/work/repo/cmd/rascald/main_test.go)\n- [cmd/rascal-runner/main_test.go](/work/repo/cmd/rascal-runner/main_test.go)\n- [docs/architecture.md](/work/repo/docs/architecture.md)\n- [docs/operations.md](/work/repo/docs/operations.md)\n\nBehavior alignment:\n- Authoritative default remains `all` (unchanged in deploy output and server defaults).\n- Session enablement logic now maps cleanly: `all =&gt; enabled`, `off =&gt; disabled`.\n- Docs now describe only supported modes and matching defaults.\n\nValidation:\n- Ran `go test ./...` successfully (all packages passed).\n\nRequested commit message file written:\n- `/rascal-meta/commit_message.txt`&#34;}],&#34;metadata&#34;:{&#34;userVisible&#34;:true,&#34;agentVisible&#34;:true}}}
{&#34;type&#34;:&#34;complete&#34;,&#34;total_tokens&#34;:2969983}
</code></pre>

</details>

Closes #104

---

Rascal run `run_714fe7800782f038` completed in 6m 51s · 2.97M tokens