### PR TITLE
refactor(cli): remove SSH API transport and standardize API path

### DIFF
--- a/cmd/rascal/auth_credentials_test.go
+++ b/cmd/rascal/auth_credentials_test.go
@@ -523,13 +523,11 @@ func newCredentialTestApp(srv *httptest.Server) *app {
 		cfg: config.ClientConfig{
 			ServerURL: srv.URL,
 			APIToken:  "test-token",
-			Transport: "http",
 		},
 		client: apiClient{
-			baseURL:   srv.URL,
-			token:     "test-token",
-			http:      srv.Client(),
-			transport: "http",
+			baseURL: srv.URL,
+			token:   "test-token",
+			http:    srv.Client(),
 		},
 		output: "json",
 	}

--- a/cmd/rascal/doctor_remote.go
+++ b/cmd/rascal/doctor_remote.go
@@ -190,45 +190,14 @@ func checkServerHealth(baseURL string) (bool, string) {
 	return false, "server health check failed"
 }
 
-func checkServerHealthSSH(cfg deployConfig) (bool, string) {
-	checkCmd := strings.Join([]string{
-		"set -u",
-		"  if command -v curl >/dev/null 2>&1; then",
-		"    if curl -fsS --max-time 5 http://127.0.0.1:8080/readyz >/dev/null 2>&1 || curl -fsS --max-time 5 http://127.0.0.1:8080/healthz >/dev/null 2>&1; then",
-		"      echo ok",
-		"      exit 0",
-		"    fi",
-		"  fi",
-		"  if command -v wget >/dev/null 2>&1; then",
-		"    if wget -q -T 5 -O - http://127.0.0.1:8080/readyz >/dev/null 2>&1 || wget -q -T 5 -O - http://127.0.0.1:8080/healthz >/dev/null 2>&1; then",
-		"      echo ok",
-		"      exit 0",
-		"    fi",
-		"  fi",
-		"if systemctl is-active --quiet 'rascal@blue' || systemctl is-active --quiet 'rascal@green'; then",
-		"  echo ok",
-		"  exit 0",
-		"fi",
-		"exit 1",
-	}, "\n")
-	out, err := runLocalCapture("ssh", sshArgs(cfg, checkCmd)...)
-	if err != nil {
-		return false, err.Error()
-	}
-	if strings.TrimSpace(out) != "ok" {
-		return false, "remote health probe did not return ok"
-	}
-	return true, ""
-}
-
-func waitForServerHealthSSH(cfg deployConfig, timeout time.Duration) error {
+func waitForServerHealth(baseURL string, timeout time.Duration) error {
 	if timeout <= 0 {
 		timeout = 60 * time.Second
 	}
 	deadline := time.Now().Add(timeout)
 	var lastErr string
 	for time.Now().Before(deadline) {
-		ok, errText := checkServerHealthSSH(cfg)
+		ok, errText := checkServerHealth(baseURL)
 		if ok {
 			return nil
 		}

--- a/cmd/rascal/doctor_remote_test.go
+++ b/cmd/rascal/doctor_remote_test.go
@@ -57,31 +57,6 @@ func TestRunRemoteDoctorUsesSlotUnitsOnly(t *testing.T) {
 	}
 }
 
-func TestCheckServerHealthSSHUsesSlotUnitsOnly(t *testing.T) {
-	logDir := setupDoctorRemoteFakes(t)
-
-	ok, errText := checkServerHealthSSH(deployConfig{
-		Host:    "example-host",
-		SSHUser: "root",
-		SSHPort: 22,
-	})
-	if !ok {
-		t.Fatalf("expected remote ssh health check to pass, got err=%q", errText)
-	}
-
-	sshLog, err := os.ReadFile(filepath.Join(logDir, "ssh_calls.log"))
-	if err != nil {
-		t.Fatalf("read ssh log: %v", err)
-	}
-	sshCalls := string(sshLog)
-	if !strings.Contains(sshCalls, "systemctl is-active --quiet 'rascal@green'") {
-		t.Fatalf("expected slot unit fallback in ssh health check, got:\n%s", sshCalls)
-	}
-	if containsLegacySingleUnitRef(sshCalls) {
-		t.Fatalf("unexpected legacy single-unit command in ssh health check:\n%s", sshCalls)
-	}
-}
-
 func setupDoctorRemoteFakes(t *testing.T) string {
 	t.Helper()
 

--- a/cmd/rascal/infra.go
+++ b/cmd/rascal/infra.go
@@ -416,7 +416,7 @@ var (
 	deployToExistingHostFn          = deployToExistingHost
 	runRemoteDoctorFn               = runRemoteDoctor
 	remoteCaddyDomainConfiguredFn   = remoteCaddyDomainConfigured
-	waitForServerHealthSSHFn        = waitForServerHealthSSH
+	waitForServerHealthFn           = waitForServerHealth
 	seedBootstrapSharedCredentialFn = seedBootstrapSharedCredential
 )
 
@@ -577,22 +577,14 @@ func (a *app) runDeployExisting(input deployExistingInput) (deployExistingResult
 	}
 
 	if expandedAuthPath != "" {
-		if err := waitForServerHealthSSHFn(deployConfig{
-			Host:       host,
-			SSHUser:    cfg.SSHUser,
-			SSHKeyPath: cfg.SSHKeyPath,
-			SSHPort:    cfg.SSHPort,
-		}, 90*time.Second); err != nil {
+		seedBaseURL := "http://" + host + ":8080"
+		if err := waitForServerHealthFn(seedBaseURL, 90*time.Second); err != nil {
 			return deployExistingResult{}, fmt.Errorf("server health check failed before credential seeding: %w", err)
 		}
 		if _, err := seedBootstrapSharedCredentialFn(apiClient{
-			token:     apiToken,
-			http:      &http.Client{Timeout: 30 * time.Second},
-			transport: "ssh",
-			sshHost:   host,
-			sshUser:   cfg.SSHUser,
-			sshKey:    cfg.SSHKeyPath,
-			sshPort:   cfg.SSHPort,
+			baseURL: seedBaseURL,
+			token:   apiToken,
+			http:    &http.Client{Timeout: 30 * time.Second},
 		}, expandedAuthPath); err != nil {
 			if input.RawErrors {
 				return deployExistingResult{}, fmt.Errorf("seed stored credential: %w", err)

--- a/cmd/rascal/infra_test.go
+++ b/cmd/rascal/infra_test.go
@@ -62,13 +62,13 @@ func TestRunDeployExistingSkipsHealthyHost(t *testing.T) {
 	origRunRemoteDoctor := runRemoteDoctorFn
 	origDeploy := deployToExistingHostFn
 	origCaddy := remoteCaddyDomainConfiguredFn
-	origHealth := waitForServerHealthSSHFn
+	origHealth := waitForServerHealthFn
 	origSeed := seedBootstrapSharedCredentialFn
 	t.Cleanup(func() {
 		runRemoteDoctorFn = origRunRemoteDoctor
 		deployToExistingHostFn = origDeploy
 		remoteCaddyDomainConfiguredFn = origCaddy
-		waitForServerHealthSSHFn = origHealth
+		waitForServerHealthFn = origHealth
 		seedBootstrapSharedCredentialFn = origSeed
 	})
 
@@ -93,7 +93,7 @@ func TestRunDeployExistingSkipsHealthyHost(t *testing.T) {
 		return nil
 	}
 
-	waitForServerHealthSSHFn = func(cfg deployConfig, timeout time.Duration) error { return nil }
+	waitForServerHealthFn = func(baseURL string, timeout time.Duration) error { return nil }
 	seedBootstrapSharedCredentialFn = func(client apiClient, authFilePath string) (credentialRecord, error) {
 		return credentialRecord{}, nil
 	}
@@ -121,11 +121,11 @@ func TestRunDeployExistingSkipsHealthyHost(t *testing.T) {
 
 func TestRunDeployExistingUsesConfiguredHost(t *testing.T) {
 	origDeploy := deployToExistingHostFn
-	origHealth := waitForServerHealthSSHFn
+	origHealth := waitForServerHealthFn
 	origSeed := seedBootstrapSharedCredentialFn
 	t.Cleanup(func() {
 		deployToExistingHostFn = origDeploy
-		waitForServerHealthSSHFn = origHealth
+		waitForServerHealthFn = origHealth
 		seedBootstrapSharedCredentialFn = origSeed
 	})
 
@@ -134,7 +134,7 @@ func TestRunDeployExistingUsesConfiguredHost(t *testing.T) {
 		deployHost = cfg.Host
 		return nil
 	}
-	waitForServerHealthSSHFn = func(cfg deployConfig, timeout time.Duration) error { return nil }
+	waitForServerHealthFn = func(baseURL string, timeout time.Duration) error { return nil }
 	seedBootstrapSharedCredentialFn = func(client apiClient, authFilePath string) (credentialRecord, error) {
 		return credentialRecord{}, nil
 	}
@@ -163,18 +163,18 @@ func TestRunDeployExistingUsesConfiguredHost(t *testing.T) {
 
 func TestRunDeployExistingUsesCanonicalRuntimeTokenEnv(t *testing.T) {
 	origDeploy := deployToExistingHostFn
-	origHealth := waitForServerHealthSSHFn
+	origHealth := waitForServerHealthFn
 	origSeed := seedBootstrapSharedCredentialFn
 	t.Cleanup(func() {
 		deployToExistingHostFn = origDeploy
-		waitForServerHealthSSHFn = origHealth
+		waitForServerHealthFn = origHealth
 		seedBootstrapSharedCredentialFn = origSeed
 	})
 
 	deployToExistingHostFn = func(cfg deployConfig) error {
 		return nil
 	}
-	waitForServerHealthSSHFn = func(cfg deployConfig, timeout time.Duration) error { return nil }
+	waitForServerHealthFn = func(baseURL string, timeout time.Duration) error { return nil }
 	seedBootstrapSharedCredentialFn = func(client apiClient, authFilePath string) (credentialRecord, error) {
 		return credentialRecord{}, nil
 	}
@@ -214,11 +214,11 @@ func TestRunDeployExistingIgnoresLegacyRuntimeTokenEnv(t *testing.T) {
 
 func TestRunDeployExistingSeedsStoredCredentialWhenCodexAuthProvided(t *testing.T) {
 	origDeploy := deployToExistingHostFn
-	origHealth := waitForServerHealthSSHFn
+	origHealth := waitForServerHealthFn
 	origSeed := seedBootstrapSharedCredentialFn
 	t.Cleanup(func() {
 		deployToExistingHostFn = origDeploy
-		waitForServerHealthSSHFn = origHealth
+		waitForServerHealthFn = origHealth
 		seedBootstrapSharedCredentialFn = origSeed
 	})
 
@@ -233,7 +233,7 @@ func TestRunDeployExistingSeedsStoredCredentialWhenCodexAuthProvided(t *testing.
 		return nil
 	}
 	healthCalls := 0
-	waitForServerHealthSSHFn = func(cfg deployConfig, timeout time.Duration) error {
+	waitForServerHealthFn = func(baseURL string, timeout time.Duration) error {
 		healthCalls++
 		return nil
 	}
@@ -267,7 +267,7 @@ func TestRunDeployExistingSeedsStoredCredentialWhenCodexAuthProvided(t *testing.
 	if gotAuthPath != authPath {
 		t.Fatalf("seed auth path = %q, want %q", gotAuthPath, authPath)
 	}
-	if gotClient.transport != "ssh" || gotClient.sshHost != "203.0.113.10" || gotClient.token != "cfg-api-token" {
+	if gotClient.baseURL != "http://203.0.113.10:8080" || gotClient.token != "cfg-api-token" {
 		t.Fatalf("unexpected seed client: %+v", gotClient)
 	}
 }

--- a/cmd/rascal/main.go
+++ b/cmd/rascal/main.go
@@ -32,14 +32,9 @@ import (
 )
 
 type apiClient struct {
-	baseURL   string
-	token     string
-	http      *http.Client
-	transport string
-	sshHost   string
-	sshUser   string
-	sshKey    string
-	sshPort   int
+	baseURL string
+	token   string
+	http    *http.Client
 }
 
 type app struct {
@@ -48,11 +43,6 @@ type app struct {
 	serverURLFlag   string
 	apiTokenFlag    string
 	defaultRepoFlag string
-	transportFlag   string
-	sshHostFlag     string
-	sshUserFlag     string
-	sshKeyFlag      string
-	sshPortFlag     int
 	output          string
 	noColor         bool
 	quiet           bool
@@ -61,7 +51,6 @@ type app struct {
 	serverSource    string
 	tokenSource     string
 	repoSource      string
-	transportSource string
 }
 
 type cliError struct {
@@ -135,11 +124,6 @@ func newRootCmd() *cobra.Command {
 	root.PersistentFlags().StringVar(&a.serverURLFlag, "server-url", "", "orchestrator URL")
 	root.PersistentFlags().StringVar(&a.apiTokenFlag, "api-token", "", "orchestrator API token")
 	root.PersistentFlags().StringVar(&a.defaultRepoFlag, "default-repo", "", "default repository in OWNER/REPO form")
-	root.PersistentFlags().StringVar(&a.transportFlag, "transport", "", "API transport: auto|http|ssh")
-	root.PersistentFlags().StringVar(&a.sshHostFlag, "client-ssh-host", "", "SSH target host for API transport=ssh/auto")
-	root.PersistentFlags().StringVar(&a.sshUserFlag, "client-ssh-user", "", "SSH target user for API transport=ssh/auto")
-	root.PersistentFlags().StringVar(&a.sshKeyFlag, "client-ssh-key", "", "SSH private key path for API transport=ssh/auto")
-	root.PersistentFlags().IntVar(&a.sshPortFlag, "client-ssh-port", 0, "SSH target port for API transport=ssh/auto")
 	root.PersistentFlags().StringVar(&a.output, "output", "table", "output format: table|json|toml")
 	root.PersistentFlags().BoolVar(&a.noColor, "no-color", false, "disable ANSI color/style output (also set by NO_COLOR)")
 	root.PersistentFlags().BoolVarP(&a.quiet, "quiet", "q", false, "reduce non-essential output")
@@ -227,7 +211,6 @@ func (a *app) initConfig() error {
 		DefaultRepo: strings.TrimSpace(v.GetString("default_repo")),
 		Host:        strings.TrimSpace(v.GetString("host")),
 		Domain:      strings.TrimSpace(v.GetString("domain")),
-		Transport:   strings.TrimSpace(v.GetString("transport")),
 		SSHHost:     strings.TrimSpace(v.GetString("ssh_host")),
 		SSHUser:     strings.TrimSpace(v.GetString("ssh_user")),
 		SSHKey:      strings.TrimSpace(v.GetString("ssh_key")),
@@ -264,35 +247,10 @@ func (a *app) initConfig() error {
 	} else {
 		a.repoSource = "unset"
 	}
-	if strings.TrimSpace(a.transportFlag) != "" {
-		a.cfg.Transport = strings.ToLower(strings.TrimSpace(a.transportFlag))
-		a.transportSource = "flag"
-	} else if strings.TrimSpace(os.Getenv("RASCAL_TRANSPORT")) != "" {
-		a.transportSource = "env"
-	} else if v.InConfig("transport") {
-		a.transportSource = "config"
-	} else {
-		a.transportSource = "default"
-	}
-	if strings.TrimSpace(a.sshHostFlag) != "" {
-		a.cfg.SSHHost = strings.TrimSpace(a.sshHostFlag)
-	}
-	if strings.TrimSpace(a.sshUserFlag) != "" {
-		a.cfg.SSHUser = strings.TrimSpace(a.sshUserFlag)
-	}
-	if strings.TrimSpace(a.sshKeyFlag) != "" {
-		a.cfg.SSHKey = strings.TrimSpace(a.sshKeyFlag)
-	}
-	if a.sshPortFlag > 0 {
-		a.cfg.SSHPort = a.sshPortFlag
-	}
 
 	a.cfg.ServerURL = strings.TrimRight(a.cfg.ServerURL, "/")
 	if a.cfg.ServerURL == "" {
 		a.cfg.ServerURL = "http://127.0.0.1:8080"
-	}
-	if a.cfg.Transport == "" {
-		a.cfg.Transport = "auto"
 	}
 	if a.cfg.SSHHost == "" {
 		a.cfg.SSHHost = strings.TrimSpace(a.cfg.Host)
@@ -303,20 +261,11 @@ func (a *app) initConfig() error {
 	if a.cfg.SSHPort <= 0 {
 		a.cfg.SSHPort = 22
 	}
-	resolvedTransport := resolveTransport(a.cfg.Transport, a.cfg.ServerURL, a.cfg.SSHHost)
 
 	a.client = apiClient{
-		baseURL:   a.cfg.ServerURL,
-		token:     a.cfg.APIToken,
-		http:      &http.Client{Timeout: 30 * time.Second},
-		transport: resolvedTransport,
-		sshHost:   strings.TrimSpace(a.cfg.SSHHost),
-		sshUser:   strings.TrimSpace(a.cfg.SSHUser),
-		sshKey:    strings.TrimSpace(a.cfg.SSHKey),
-		sshPort:   a.cfg.SSHPort,
-	}
-	if a.transportSource == "default" {
-		a.transportSource = "resolved"
+		baseURL: a.cfg.ServerURL,
+		token:   a.cfg.APIToken,
+		http:    &http.Client{Timeout: 30 * time.Second},
 	}
 
 	switch strings.ToLower(strings.TrimSpace(a.output)) {
@@ -330,16 +279,6 @@ func (a *app) initConfig() error {
 			Hint:    "use --output table|json|toml",
 		}
 	}
-	switch strings.ToLower(strings.TrimSpace(a.cfg.Transport)) {
-	case "", "auto", "http", "ssh":
-	default:
-		return &cliError{
-			Code:    exitInput,
-			Message: fmt.Sprintf("unsupported transport %q", a.cfg.Transport),
-			Hint:    "use --transport auto|http|ssh",
-		}
-	}
-
 	return nil
 }
 
@@ -415,7 +354,6 @@ func (a *app) newInitCmd() *cobra.Command {
 		defaultRepo    string
 		host           string
 		domain         string
-		transport      string
 		sshHost        string
 		sshUser        string
 		sshKey         string
@@ -434,7 +372,6 @@ func (a *app) newInitCmd() *cobra.Command {
 			defaultRepo = firstNonEmpty(strings.TrimSpace(defaultRepo), a.cfg.DefaultRepo)
 			host = firstNonEmpty(strings.TrimSpace(host), a.cfg.Host)
 			domain = firstNonEmpty(strings.TrimSpace(domain), a.cfg.Domain)
-			transport = firstNonEmpty(strings.ToLower(strings.TrimSpace(transport)), a.cfg.Transport)
 			sshHost = firstNonEmpty(strings.TrimSpace(sshHost), a.cfg.SSHHost, host)
 			sshUser = firstNonEmpty(strings.TrimSpace(sshUser), a.cfg.SSHUser, "root")
 			sshKey = firstNonEmpty(strings.TrimSpace(sshKey), a.cfg.SSHKey)
@@ -462,9 +399,6 @@ func (a *app) newInitCmd() *cobra.Command {
 				if domain, err = promptString(reader, "Domain (optional)", domain); err != nil {
 					return err
 				}
-				if transport, err = promptString(reader, "Transport (auto|http|ssh)", transport); err != nil {
-					return err
-				}
 				if sshHost, err = promptString(reader, "SSH Host (optional)", sshHost); err != nil {
 					return err
 				}
@@ -479,15 +413,6 @@ func (a *app) newInitCmd() *cobra.Command {
 			if strings.TrimSpace(serverURL) == "" {
 				return &cliError{Code: exitInput, Message: "server URL is required", Hint: "pass --server-url or run interactively"}
 			}
-			transport = strings.ToLower(strings.TrimSpace(transport))
-			if transport == "" {
-				transport = "auto"
-			}
-			switch transport {
-			case "auto", "http", "ssh":
-			default:
-				return &cliError{Code: exitInput, Message: "invalid transport", Hint: "transport must be one of: auto|http|ssh"}
-			}
 
 			cfg := config.ClientConfig{
 				ServerURL:   strings.TrimRight(serverURL, "/"),
@@ -495,7 +420,6 @@ func (a *app) newInitCmd() *cobra.Command {
 				DefaultRepo: strings.TrimSpace(defaultRepo),
 				Host:        strings.TrimSpace(host),
 				Domain:      strings.TrimSpace(domain),
-				Transport:   transport,
 				SSHHost:     strings.TrimSpace(sshHost),
 				SSHUser:     firstNonEmpty(strings.TrimSpace(sshUser), "root"),
 				SSHKey:      strings.TrimSpace(sshKey),
@@ -513,11 +437,10 @@ func (a *app) newInitCmd() *cobra.Command {
 	cmd.Flags().StringVar(&defaultRepo, "default-repo", "", "default repository in OWNER/REPO form")
 	cmd.Flags().StringVar(&host, "host", "", "default server host/IP for bootstrap/deploy")
 	cmd.Flags().StringVar(&domain, "domain", "", "default domain for server URL and Caddy")
-	cmd.Flags().StringVar(&transport, "transport", "", "default transport: auto|http|ssh")
-	cmd.Flags().StringVar(&sshHost, "ssh-host", "", "default SSH target host for transport=ssh/auto")
-	cmd.Flags().StringVar(&sshUser, "ssh-user", "", "default SSH target user for transport=ssh/auto")
-	cmd.Flags().StringVar(&sshKey, "ssh-key", "", "default SSH private key path for transport=ssh/auto")
-	cmd.Flags().IntVar(&sshPort, "ssh-port", 0, "default SSH target port for transport=ssh/auto")
+	cmd.Flags().StringVar(&sshHost, "ssh-host", "", "default SSH target host for remote operations")
+	cmd.Flags().StringVar(&sshUser, "ssh-user", "", "default SSH target user for remote operations")
+	cmd.Flags().StringVar(&sshKey, "ssh-key", "", "default SSH private key path for remote operations")
+	cmd.Flags().IntVar(&sshPort, "ssh-port", 0, "default SSH target port for remote operations")
 	cmd.Flags().BoolVar(&nonInteractive, "non-interactive", false, "disable prompts and rely on flags")
 	return cmd
 }
@@ -814,9 +737,6 @@ func (a *app) newBootstrapCmd() *cobra.Command {
 				}
 				if sshPort > 0 {
 					save.SSHPort = sshPort
-				}
-				if strings.TrimSpace(save.Transport) == "" {
-					save.Transport = "auto"
 				}
 				if err := config.SaveClientConfig(a.configPath, save); err != nil {
 					return fmt.Errorf("save client config: %w", err)
@@ -1513,22 +1433,7 @@ func (a *app) newDoctorCmd() *cobra.Command {
 			}
 
 			effectiveSSHHost := firstNonEmpty(strings.TrimSpace(host), strings.TrimSpace(a.cfg.SSHHost), strings.TrimSpace(a.cfg.Host))
-			resolvedTransport := resolveTransport(a.cfg.Transport, a.cfg.ServerURL, effectiveSSHHost)
-			healthOK, healthErr := false, ""
-			if resolvedTransport == "ssh" {
-				if effectiveSSHHost == "" {
-					healthErr = "ssh transport selected but no ssh host is configured"
-				} else {
-					healthOK, healthErr = checkServerHealthSSH(deployConfig{
-						Host:       effectiveSSHHost,
-						SSHUser:    firstNonEmpty(strings.TrimSpace(sshUser), strings.TrimSpace(a.cfg.SSHUser), "root"),
-						SSHKeyPath: firstNonEmpty(strings.TrimSpace(sshKey), strings.TrimSpace(a.cfg.SSHKey)),
-						SSHPort:    firstPositive(sshPort, a.cfg.SSHPort, 22),
-					})
-				}
-			} else {
-				healthOK, healthErr = checkServerHealth(a.cfg.ServerURL)
-			}
+			healthOK, healthErr := checkServerHealth(a.cfg.ServerURL)
 			healthMessage := ""
 			if !healthOK {
 				healthMessage = healthErr
@@ -1573,8 +1478,6 @@ func (a *app) newDoctorCmd() *cobra.Command {
 				"server_url":          a.cfg.ServerURL,
 				"host":                a.cfg.Host,
 				"domain":              a.cfg.Domain,
-				"transport":           a.cfg.Transport,
-				"resolved_transport":  resolvedTransport,
 				"ssh_host":            a.cfg.SSHHost,
 				"effective_ssh_host":  effectiveSSHHost,
 				"ssh_user":            a.cfg.SSHUser,
@@ -1602,7 +1505,6 @@ func (a *app) newDoctorCmd() *cobra.Command {
 					a.println("config file: missing")
 				}
 				a.println("server: %s (%s)", a.cfg.ServerURL, a.serverSource)
-				a.println("transport: %s (resolved=%s)", a.cfg.Transport, resolvedTransport)
 				if strings.TrimSpace(effectiveSSHHost) != "" {
 					a.println("ssh target: %s@%s:%d", firstNonEmpty(strings.TrimSpace(sshUser), strings.TrimSpace(a.cfg.SSHUser), "root"), effectiveSSHHost, firstPositive(sshPort, a.cfg.SSHPort, 22))
 				}
@@ -1885,7 +1787,6 @@ rascal config view --output json
 				"default_repo":        a.cfg.DefaultRepo,
 				"host":                a.cfg.Host,
 				"domain":              a.cfg.Domain,
-				"transport":           a.cfg.Transport,
 				"ssh_host":            a.cfg.SSHHost,
 				"ssh_user":            a.cfg.SSHUser,
 				"ssh_key":             a.cfg.SSHKey,
@@ -1893,11 +1794,9 @@ rascal config view --output json
 				"server_source":       a.serverSource,
 				"api_token_source":    a.tokenSource,
 				"default_repo_source": a.repoSource,
-				"transport_source":    a.transportSource,
-				"resolved_transport":  a.client.transport,
 			}
 			return a.emit(view, func() error {
-				for _, key := range []string{"config_path", "server_url", "api_token", "default_repo", "host", "domain", "transport", "ssh_host", "ssh_user", "ssh_key", "ssh_port", "server_source", "api_token_source", "default_repo_source", "transport_source", "resolved_transport"} {
+				for _, key := range []string{"config_path", "server_url", "api_token", "default_repo", "host", "domain", "ssh_host", "ssh_user", "ssh_key", "ssh_port", "server_source", "api_token_source", "default_repo_source"} {
 					a.println("%s: %v", key, view[key])
 				}
 				return nil
@@ -1935,8 +1834,6 @@ rascal config get default_repo
 				a.println(cfg.Host)
 			case "domain":
 				a.println(cfg.Domain)
-			case "transport":
-				a.println(cfg.Transport)
 			case "ssh_host":
 				a.println(cfg.SSHHost)
 			case "ssh_user":
@@ -1962,7 +1859,7 @@ Supported keys:
 `), keys),
 		Example: strings.TrimSpace(`
 rascal config set default_repo OWNER/REPO
-rascal config set transport ssh
+rascal config set ssh_host 203.0.113.10
 `),
 		Args: cobra.ExactArgs(2),
 		RunE: func(_ *cobra.Command, args []string) error {
@@ -1982,14 +1879,6 @@ rascal config set transport ssh
 				cfg.Host = val
 			case "domain":
 				cfg.Domain = val
-			case "transport":
-				transport := strings.ToLower(val)
-				switch transport {
-				case "auto", "http", "ssh":
-					cfg.Transport = transport
-				default:
-					return &cliError{Code: exitInput, Message: "invalid transport", Hint: "transport must be one of: auto|http|ssh"}
-				}
 			case "ssh_host":
 				cfg.SSHHost = val
 			case "ssh_user":
@@ -2506,7 +2395,6 @@ func loadFileConfig(path string) (config.ClientConfig, error) {
 		DefaultRepo: strings.TrimSpace(v.GetString("default_repo")),
 		Host:        strings.TrimSpace(v.GetString("host")),
 		Domain:      strings.TrimSpace(v.GetString("domain")),
-		Transport:   strings.TrimSpace(v.GetString("transport")),
 		SSHHost:     strings.TrimSpace(v.GetString("ssh_host")),
 		SSHUser:     strings.TrimSpace(v.GetString("ssh_user")),
 		SSHKey:      strings.TrimSpace(v.GetString("ssh_key")),
@@ -2786,13 +2674,6 @@ func (c apiClient) doJSON(method, path string, payload any) (*http.Response, err
 }
 
 func (c apiClient) do(method, path string, body io.Reader) (*http.Response, error) {
-	if strings.EqualFold(c.transport, "ssh") {
-		return c.doOverSSH(method, path, body)
-	}
-	return c.doOverHTTP(method, path, body)
-}
-
-func (c apiClient) doOverHTTP(method, path string, body io.Reader) (*http.Response, error) {
 	req, err := http.NewRequest(method, c.baseURL+path, body)
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
@@ -2807,98 +2688,6 @@ func (c apiClient) doOverHTTP(method, path string, body io.Reader) (*http.Respon
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
-	}
-	return resp, nil
-}
-
-func (c apiClient) doOverSSH(method, path string, body io.Reader) (*http.Response, error) {
-	sshHost := strings.TrimSpace(c.sshHost)
-	if sshHost == "" {
-		return nil, fmt.Errorf("ssh transport selected but ssh host is missing")
-	}
-	sshUser := firstNonEmpty(strings.TrimSpace(c.sshUser), "root")
-	sshPort := c.sshPort
-	if sshPort <= 0 {
-		sshPort = 22
-	}
-	sshKey := strings.TrimSpace(c.sshKey)
-
-	var payload []byte
-	if body != nil {
-		data, err := io.ReadAll(body)
-		if err != nil {
-			return nil, fmt.Errorf("read request body: %w", err)
-		}
-		payload = data
-	}
-
-	curlArgs := []string{
-		"curl", "-sS", "-i", "--raw",
-		"-X", shellSingleQuote(strings.TrimSpace(method)),
-		"-H", shellSingleQuote("Accept: application/json"),
-	}
-	if c.token != "" {
-		curlArgs = append(curlArgs, "-H", shellSingleQuote("Authorization: Bearer "+c.token))
-	}
-	if len(payload) > 0 {
-		curlArgs = append(curlArgs, "-H", shellSingleQuote("Content-Type: application/json"), "--data-binary", "@-")
-	}
-	curlCmd := strings.Join(curlArgs, " ")
-	remoteCmd := strings.Join([]string{
-		"set -eu",
-		"slot=''",
-		"if [ -f /etc/rascal/active_slot ]; then slot=$(tr -d '[:space:]' </etc/rascal/active_slot); fi",
-		"case \"$slot\" in",
-		fmt.Sprintf("  %s) port=%d ;;", rascalSlotBlue, rascalSlotBluePort),
-		fmt.Sprintf("  %s) port=%d ;;", rascalSlotGreen, rascalSlotGreenPort),
-		fmt.Sprintf("  *) if systemctl is-active --quiet 'rascal@green'; then port=%d; elif systemctl is-active --quiet 'rascal@blue'; then port=%d; else port=%d; fi ;;", rascalSlotGreenPort, rascalSlotBluePort, rascalSlotBluePort),
-		"esac",
-		"url=$(printf 'http://127.0.0.1:%s%s' \"$port\" " + shellSingleQuote(path) + ")",
-		curlCmd + " \"$url\"",
-	}, "\n")
-
-	cfg := deployConfig{
-		Host:       sshHost,
-		SSHUser:    sshUser,
-		SSHKeyPath: sshKey,
-		SSHPort:    sshPort,
-	}
-	cmd := exec.Command("ssh", sshArgs(cfg, remoteCmd)...)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if len(payload) > 0 {
-		cmd.Stdin = bytes.NewReader(payload)
-	}
-	if err := cmd.Run(); err != nil {
-		errOut := strings.TrimSpace(stderr.String())
-		if errOut == "" {
-			errOut = strings.TrimSpace(stdout.String())
-		}
-		if errOut == "" {
-			return nil, fmt.Errorf("ssh request failed: %w", err)
-		}
-		return nil, fmt.Errorf("ssh request failed: %w (%s)", err, errOut)
-	}
-
-	raw := stdout.Bytes()
-	resp, err := parseRawHTTPResponse(raw, method)
-	if err != nil {
-		errOut := strings.TrimSpace(stderr.String())
-		if errOut != "" {
-			return nil, fmt.Errorf("parse ssh response: %w (%s)", err, errOut)
-		}
-		return nil, fmt.Errorf("parse ssh response: %w", err)
-	}
-	return resp, nil
-}
-
-func parseRawHTTPResponse(raw []byte, method string) (*http.Response, error) {
-	reader := bufio.NewReader(bytes.NewReader(raw))
-	req := &http.Request{Method: method}
-	resp, err := http.ReadResponse(reader, req)
-	if err != nil {
-		return nil, fmt.Errorf("parse raw HTTP response: %w", err)
 	}
 	return resp, nil
 }
@@ -2919,13 +2708,6 @@ func randomToken(numBytes int) (string, error) {
 }
 
 type deployConfig = deployengine.Config
-
-const (
-	rascalSlotBlue      = deployengine.SlotBlue
-	rascalSlotGreen     = deployengine.SlotGreen
-	rascalSlotBluePort  = deployengine.SlotBluePort
-	rascalSlotGreenPort = deployengine.SlotGreenPort
-)
 
 func deployToExistingHost(cfg deployConfig) error {
 	if err := deployengine.Execute(cfg); err != nil {
@@ -3152,7 +2934,6 @@ func supportedConfigKeys() []string {
 		"default_repo",
 		"host",
 		"domain",
-		"transport",
 		"ssh_host",
 		"ssh_user",
 		"ssh_key",
@@ -3191,17 +2972,7 @@ func configSourceFromEnvConfig(envKey, configKey string, settings map[string]any
 	return fallback
 }
 
-func (a *app) configSourceFromFlagEnvConfig(flagSet bool, envKey, configKey string, settings map[string]any, fallback string) string {
-	if flagSet {
-		return "flag"
-	}
-	return configSourceFromEnvConfig(envKey, configKey, settings, fallback)
-}
-
 func (a *app) sshHostSource(settings map[string]any) string {
-	if strings.TrimSpace(a.sshHostFlag) != "" {
-		return "flag"
-	}
 	if strings.TrimSpace(os.Getenv("RASCAL_SSH_HOST")) != "" {
 		return "env"
 	}
@@ -3226,43 +2997,17 @@ func (a *app) effectiveConfigValue(key string, settings map[string]any) (any, st
 		return a.cfg.Host, configSourceFromEnvConfig("RASCAL_HOST", "host", settings, "unset")
 	case "domain":
 		return a.cfg.Domain, configSourceFromEnvConfig("RASCAL_DOMAIN", "domain", settings, "unset")
-	case "transport":
-		return a.cfg.Transport, a.transportSource
 	case "ssh_host":
 		return a.cfg.SSHHost, a.sshHostSource(settings)
 	case "ssh_user":
-		return a.cfg.SSHUser, a.configSourceFromFlagEnvConfig(strings.TrimSpace(a.sshUserFlag) != "", "RASCAL_SSH_USER", "ssh_user", settings, "default")
+		return a.cfg.SSHUser, configSourceFromEnvConfig("RASCAL_SSH_USER", "ssh_user", settings, "default")
 	case "ssh_key":
-		return a.cfg.SSHKey, a.configSourceFromFlagEnvConfig(strings.TrimSpace(a.sshKeyFlag) != "", "RASCAL_SSH_KEY", "ssh_key", settings, "unset")
+		return a.cfg.SSHKey, configSourceFromEnvConfig("RASCAL_SSH_KEY", "ssh_key", settings, "unset")
 	case "ssh_port":
-		return a.cfg.SSHPort, a.configSourceFromFlagEnvConfig(a.sshPortFlag > 0, "RASCAL_SSH_PORT", "ssh_port", settings, "default")
+		return a.cfg.SSHPort, configSourceFromEnvConfig("RASCAL_SSH_PORT", "ssh_port", settings, "default")
 	default:
 		return "", "unset"
 	}
-}
-
-func resolveTransport(configured, serverURL, sshHost string) string {
-	mode := strings.ToLower(strings.TrimSpace(configured))
-	switch mode {
-	case "http", "ssh":
-		return mode
-	}
-	if strings.TrimSpace(sshHost) == "" {
-		return "http"
-	}
-	u, err := url.Parse(strings.TrimSpace(serverURL))
-	if err != nil {
-		return "ssh"
-	}
-	host := strings.ToLower(strings.TrimSpace(u.Hostname()))
-	port := strings.TrimSpace(u.Port())
-	if host == "" || host == "127.0.0.1" || host == "localhost" {
-		return "ssh"
-	}
-	if strings.EqualFold(u.Scheme, "http") && port == "8080" {
-		return "ssh"
-	}
-	return "http"
 }
 
 func validateDistinctGitHubTokens(adminToken, runtimeToken string, enforce bool) error {

--- a/cmd/rascal/main_slot_only_test.go
+++ b/cmd/rascal/main_slot_only_test.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"net/http"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -25,67 +22,4 @@ func TestRascaldJournalctlRemoteCmdUsesSlotUnitsOnly(t *testing.T) {
 	if containsLegacySingleUnitRef(cmd) {
 		t.Fatalf("unexpected legacy single-unit checks in command:\n%s", cmd)
 	}
-}
-
-func TestAPIDoOverSSHUsesSlotPortsWithoutLegacySingleUnitChecks(t *testing.T) {
-	logDir := setupAPISSHFakes(t)
-
-	client := apiClient{
-		transport: "ssh",
-		sshHost:   "example-host",
-		sshUser:   "root",
-		sshPort:   22,
-	}
-	resp, err := client.doOverSSH(http.MethodGet, "/v1/healthz", nil)
-	if err != nil {
-		t.Fatalf("doOverSSH: %v", err)
-	}
-	if err := resp.Body.Close(); err != nil {
-		t.Fatalf("close body: %v", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("status code = %d, want 200", resp.StatusCode)
-	}
-
-	sshLog, err := os.ReadFile(filepath.Join(logDir, "ssh_calls.log"))
-	if err != nil {
-		t.Fatalf("read ssh log: %v", err)
-	}
-	sshCalls := string(sshLog)
-	if !strings.Contains(sshCalls, `systemctl is-active --quiet 'rascal@green'`) {
-		t.Fatalf("expected slot health fallback for green in ssh command, got:\n%s", sshCalls)
-	}
-	if !strings.Contains(sshCalls, `systemctl is-active --quiet 'rascal@blue'`) {
-		t.Fatalf("expected slot health fallback for blue in ssh command, got:\n%s", sshCalls)
-	}
-	if strings.Contains(sshCalls, "127.0.0.1:8080") {
-		t.Fatalf("unexpected proxy-port fallback in ssh API command, got:\n%s", sshCalls)
-	}
-	if containsLegacySingleUnitRef(sshCalls) {
-		t.Fatalf("unexpected legacy single-unit checks in ssh API command, got:\n%s", sshCalls)
-	}
-}
-
-func setupAPISSHFakes(t *testing.T) string {
-	t.Helper()
-
-	binDir := t.TempDir()
-	logDir := t.TempDir()
-	t.Setenv("RASCAL_API_SSH_LOG_DIR", logDir)
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-
-	writeFakeExe(t, filepath.Join(binDir, "ssh"), `#!/usr/bin/env bash
-set -euo pipefail
-log_dir="${RASCAL_API_SSH_LOG_DIR:?}"
-printf '%s\n' "$*" >> "$log_dir/ssh_calls.log"
-cat <<'EOF'
-HTTP/1.1 200 OK
-Content-Type: application/json
-Content-Length: 2
-
-{}
-EOF
-`)
-
-	return logDir
 }

--- a/cmd/rascal/main_test.go
+++ b/cmd/rascal/main_test.go
@@ -123,11 +123,6 @@ func TestRootFlagsDoNotExposeDeadFlags(t *testing.T) {
 	if f := root.PersistentFlags().Lookup("no-color"); f == nil {
 		t.Fatal("expected no-color flag to exist")
 	}
-	for _, name := range []string{"transport", "client-ssh-host", "client-ssh-user", "client-ssh-key", "client-ssh-port"} {
-		if f := root.PersistentFlags().Lookup(name); f == nil {
-			t.Fatalf("expected %s flag to exist", name)
-		}
-	}
 }
 
 func TestRootHasGitHubAndInfraCommands(t *testing.T) {
@@ -604,13 +599,11 @@ func TestPSUsesDefaultLimitQuery(t *testing.T) {
 		cfg: config.ClientConfig{
 			ServerURL: srv.URL,
 			APIToken:  "test-token",
-			Transport: "http",
 		},
 		client: apiClient{
-			baseURL:   srv.URL,
-			token:     "test-token",
-			http:      srv.Client(),
-			transport: "http",
+			baseURL: srv.URL,
+			token:   "test-token",
+			http:    srv.Client(),
 		},
 		output: "json",
 	}
@@ -651,13 +644,11 @@ func TestPSAllUsesAllQuery(t *testing.T) {
 		cfg: config.ClientConfig{
 			ServerURL: srv.URL,
 			APIToken:  "test-token",
-			Transport: "http",
 		},
 		client: apiClient{
-			baseURL:   srv.URL,
-			token:     "test-token",
-			http:      srv.Client(),
-			transport: "http",
+			baseURL: srv.URL,
+			token:   "test-token",
+			http:    srv.Client(),
 		},
 		output: "json",
 	}
@@ -775,13 +766,11 @@ func TestPSRendersIssueColumn(t *testing.T) {
 		cfg: config.ClientConfig{
 			ServerURL: srv.URL,
 			APIToken:  "test-token",
-			Transport: "http",
 		},
 		client: apiClient{
-			baseURL:   srv.URL,
-			token:     "test-token",
-			http:      srv.Client(),
-			transport: "http",
+			baseURL: srv.URL,
+			token:   "test-token",
+			http:    srv.Client(),
 		},
 		output: "table",
 	}
@@ -843,13 +832,11 @@ func TestRunIssueCreatesIssueRunPayload(t *testing.T) {
 		cfg: config.ClientConfig{
 			ServerURL: srv.URL,
 			APIToken:  "test-token",
-			Transport: "http",
 		},
 		client: apiClient{
-			baseURL:   srv.URL,
-			token:     "test-token",
-			http:      srv.Client(),
-			transport: "http",
+			baseURL: srv.URL,
+			token:   "test-token",
+			http:    srv.Client(),
 		},
 		output: "json",
 	}
@@ -902,13 +889,11 @@ func TestRunIssueSendsExplicitDebugOverride(t *testing.T) {
 		cfg: config.ClientConfig{
 			ServerURL: srv.URL,
 			APIToken:  "test-token",
-			Transport: "http",
 		},
 		client: apiClient{
-			baseURL:   srv.URL,
-			token:     "test-token",
-			http:      srv.Client(),
-			transport: "http",
+			baseURL: srv.URL,
+			token:   "test-token",
+			http:    srv.Client(),
 		},
 		output: "json",
 	}
@@ -970,13 +955,11 @@ func TestRetryOmitsDebugByDefault(t *testing.T) {
 		cfg: config.ClientConfig{
 			ServerURL: srv.URL,
 			APIToken:  "test-token",
-			Transport: "http",
 		},
 		client: apiClient{
-			baseURL:   srv.URL,
-			token:     "test-token",
-			http:      srv.Client(),
-			transport: "http",
+			baseURL: srv.URL,
+			token:   "test-token",
+			http:    srv.Client(),
 		},
 		output: "json",
 	}
@@ -1038,13 +1021,11 @@ func TestRetrySendsExplicitDebugOverride(t *testing.T) {
 		cfg: config.ClientConfig{
 			ServerURL: srv.URL,
 			APIToken:  "test-token",
-			Transport: "http",
 		},
 		client: apiClient{
-			baseURL:   srv.URL,
-			token:     "test-token",
-			http:      srv.Client(),
-			transport: "http",
+			baseURL: srv.URL,
+			token:   "test-token",
+			http:    srv.Client(),
 		},
 		output: "json",
 	}
@@ -1107,13 +1088,11 @@ func TestRetryCreatesRunWithRetryTrigger(t *testing.T) {
 		cfg: config.ClientConfig{
 			ServerURL: srv.URL,
 			APIToken:  "test-token",
-			Transport: "http",
 		},
 		client: apiClient{
-			baseURL:   srv.URL,
-			token:     "test-token",
-			http:      srv.Client(),
-			transport: "http",
+			baseURL: srv.URL,
+			token:   "test-token",
+			http:    srv.Client(),
 		},
 		output: "json",
 	}
@@ -1190,7 +1169,6 @@ func TestConfigUnsetRemovesKeyAndReportsEffectiveValue(t *testing.T) {
 		"RASCAL_DEFAULT_REPO",
 		"RASCAL_HOST",
 		"RASCAL_DOMAIN",
-		"RASCAL_TRANSPORT",
 		"RASCAL_SSH_HOST",
 		"RASCAL_SSH_USER",
 		"RASCAL_SSH_KEY",
@@ -1242,7 +1220,6 @@ func TestConfigUnsetIdempotent(t *testing.T) {
 		"RASCAL_DEFAULT_REPO",
 		"RASCAL_HOST",
 		"RASCAL_DOMAIN",
-		"RASCAL_TRANSPORT",
 		"RASCAL_SSH_HOST",
 		"RASCAL_SSH_USER",
 		"RASCAL_SSH_KEY",
@@ -1537,68 +1514,6 @@ func TestRascaldJournalctlRemoteCmd(t *testing.T) {
 		t.Fatalf("expected default line count when lines<=0, got: %q", defaultLinesCmd)
 	}
 }
-func TestResolveTransport(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name       string
-		configured string
-		serverURL  string
-		sshHost    string
-		want       string
-	}{
-		{
-			name:       "explicit http",
-			configured: "http",
-			serverURL:  "http://127.0.0.1:8080",
-			sshHost:    "203.0.113.10",
-			want:       "http",
-		},
-		{
-			name:       "explicit ssh",
-			configured: "ssh",
-			serverURL:  "https://rascal.example.com",
-			sshHost:    "203.0.113.10",
-			want:       "ssh",
-		},
-		{
-			name:       "auto localhost prefers ssh",
-			configured: "auto",
-			serverURL:  "http://127.0.0.1:8080",
-			sshHost:    "203.0.113.10",
-			want:       "ssh",
-		},
-		{
-			name:       "auto remote 8080 prefers ssh",
-			configured: "auto",
-			serverURL:  "http://203.0.113.10:8080",
-			sshHost:    "203.0.113.10",
-			want:       "ssh",
-		},
-		{
-			name:       "auto https prefers http",
-			configured: "auto",
-			serverURL:  "https://rascal.example.com",
-			sshHost:    "203.0.113.10",
-			want:       "http",
-		},
-		{
-			name:       "auto without ssh host is http",
-			configured: "auto",
-			serverURL:  "http://127.0.0.1:8080",
-			sshHost:    "",
-			want:       "http",
-		},
-	}
-
-	for _, tc := range cases {
-		got := resolveTransport(tc.configured, tc.serverURL, tc.sshHost)
-		if got != tc.want {
-			t.Fatalf("%s: resolveTransport(%q, %q, %q) = %q, want %q", tc.name, tc.configured, tc.serverURL, tc.sshHost, got, tc.want)
-		}
-	}
-}
-
 func TestLoadEnvFile(t *testing.T) {
 	path := t.TempDir() + "/.env"
 	content := `
@@ -1782,15 +1697,13 @@ func newFollowLogsTestApp(t *testing.T, responses []map[string]any) (*app, func(
 		cfg: config.ClientConfig{
 			ServerURL:   srv.URL,
 			APIToken:    "test-token",
-			Transport:   "http",
 			SSHPort:     22,
 			DefaultRepo: "owner/repo",
 		},
 		client: apiClient{
-			baseURL:   srv.URL,
-			token:     "test-token",
-			http:      srv.Client(),
-			transport: "http",
+			baseURL: srv.URL,
+			token:   "test-token",
+			http:    srv.Client(),
 		},
 	}
 

--- a/cmd/rascal/testdata/help/auth.golden
+++ b/cmd/rascal/testdata/help/auth.golden
@@ -25,18 +25,13 @@ Flags:
       --write-config                  write generated API token to local config
 
 Global Flags:
-      --api-token string         orchestrator API token
-      --client-ssh-host string   SSH target host for API transport=ssh/auto
-      --client-ssh-key string    SSH private key path for API transport=ssh/auto
-      --client-ssh-port int      SSH target port for API transport=ssh/auto
-      --client-ssh-user string   SSH target user for API transport=ssh/auto
-      --config string            config file path (default "$HOME/.rascal/config.toml")
-      --default-repo string      default repository in OWNER/REPO form
-      --env-file string          env file path (fallback: ./.rascal.env if present)
-      --no-color                 disable ANSI color/style output (also set by NO_COLOR)
-      --output string            output format: table|json|toml (default "table")
-  -q, --quiet                    reduce non-essential output
-      --server-url string        orchestrator URL
-      --transport string         API transport: auto|http|ssh
+      --api-token string      orchestrator API token
+      --config string         config file path (default "$HOME/.rascal/config.toml")
+      --default-repo string   default repository in OWNER/REPO form
+      --env-file string       env file path (fallback: ./.rascal.env if present)
+      --no-color              disable ANSI color/style output (also set by NO_COLOR)
+      --output string         output format: table|json|toml (default "table")
+  -q, --quiet                 reduce non-essential output
+      --server-url string     orchestrator URL
 
 Use "rascal auth [command] --help" for more information about a command.

--- a/cmd/rascal/testdata/help/auth_credentials.golden
+++ b/cmd/rascal/testdata/help/auth_credentials.golden
@@ -24,10 +24,6 @@ Flags:
 
 Global Flags:
       --api-token string              orchestrator API token
-      --client-ssh-host string        SSH target host for API transport=ssh/auto
-      --client-ssh-key string         SSH private key path for API transport=ssh/auto
-      --client-ssh-port int           SSH target port for API transport=ssh/auto
-      --client-ssh-user string        SSH target user for API transport=ssh/auto
       --config string                 config file path (default "$HOME/.rascal/config.toml")
       --default-repo string           default repository in OWNER/REPO form
       --env-file string               env file path (fallback: ./.rascal.env if present)
@@ -42,7 +38,6 @@ Global Flags:
       --ssh-key string                SSH private key path for remote auth sync
       --ssh-port int                  SSH target port for remote auth sync (default 22)
       --ssh-user string               SSH target user for remote auth sync (default "root")
-      --transport string              API transport: auto|http|ssh
       --write-config                  write generated API token to local config
 
 Use "rascal auth credentials [command] --help" for more information about a command.

--- a/cmd/rascal/testdata/help/bootstrap.golden
+++ b/cmd/rascal/testdata/help/bootstrap.golden
@@ -25,14 +25,9 @@ Flags:
       --write-config                  write config file (default true)
 
 Global Flags:
-      --client-ssh-host string   SSH target host for API transport=ssh/auto
-      --client-ssh-key string    SSH private key path for API transport=ssh/auto
-      --client-ssh-port int      SSH target port for API transport=ssh/auto
-      --client-ssh-user string   SSH target user for API transport=ssh/auto
-      --config string            config file path (default "$HOME/.rascal/config.toml")
-      --default-repo string      default repository in OWNER/REPO form
-      --env-file string          env file path (fallback: ./.rascal.env if present)
-      --no-color                 disable ANSI color/style output (also set by NO_COLOR)
-      --output string            output format: table|json|toml (default "table")
-  -q, --quiet                    reduce non-essential output
-      --transport string         API transport: auto|http|ssh
+      --config string         config file path (default "$HOME/.rascal/config.toml")
+      --default-repo string   default repository in OWNER/REPO form
+      --env-file string       env file path (fallback: ./.rascal.env if present)
+      --no-color              disable ANSI color/style output (also set by NO_COLOR)
+      --output string         output format: table|json|toml (default "table")
+  -q, --quiet                 reduce non-essential output

--- a/cmd/rascal/testdata/help/deploy.golden
+++ b/cmd/rascal/testdata/help/deploy.golden
@@ -27,15 +27,10 @@ Flags:
       --webhook-secret string         GitHub webhook secret
 
 Global Flags:
-      --client-ssh-host string   SSH target host for API transport=ssh/auto
-      --client-ssh-key string    SSH private key path for API transport=ssh/auto
-      --client-ssh-port int      SSH target port for API transport=ssh/auto
-      --client-ssh-user string   SSH target user for API transport=ssh/auto
-      --config string            config file path (default "$HOME/.rascal/config.toml")
-      --default-repo string      default repository in OWNER/REPO form
-      --env-file string          env file path (fallback: ./.rascal.env if present)
-      --no-color                 disable ANSI color/style output (also set by NO_COLOR)
-      --output string            output format: table|json|toml (default "table")
-  -q, --quiet                    reduce non-essential output
-      --server-url string        orchestrator URL
-      --transport string         API transport: auto|http|ssh
+      --config string         config file path (default "$HOME/.rascal/config.toml")
+      --default-repo string   default repository in OWNER/REPO form
+      --env-file string       env file path (fallback: ./.rascal.env if present)
+      --no-color              disable ANSI color/style output (also set by NO_COLOR)
+      --output string         output format: table|json|toml (default "table")
+  -q, --quiet                 reduce non-essential output
+      --server-url string     orchestrator URL

--- a/cmd/rascal/testdata/help/github.golden
+++ b/cmd/rascal/testdata/help/github.golden
@@ -18,18 +18,13 @@ Flags:
   -h, --help   help for github
 
 Global Flags:
-      --api-token string         orchestrator API token
-      --client-ssh-host string   SSH target host for API transport=ssh/auto
-      --client-ssh-key string    SSH private key path for API transport=ssh/auto
-      --client-ssh-port int      SSH target port for API transport=ssh/auto
-      --client-ssh-user string   SSH target user for API transport=ssh/auto
-      --config string            config file path (default "$HOME/.rascal/config.toml")
-      --default-repo string      default repository in OWNER/REPO form
-      --env-file string          env file path (fallback: ./.rascal.env if present)
-      --no-color                 disable ANSI color/style output (also set by NO_COLOR)
-      --output string            output format: table|json|toml (default "table")
-  -q, --quiet                    reduce non-essential output
-      --server-url string        orchestrator URL
-      --transport string         API transport: auto|http|ssh
+      --api-token string      orchestrator API token
+      --config string         config file path (default "$HOME/.rascal/config.toml")
+      --default-repo string   default repository in OWNER/REPO form
+      --env-file string       env file path (fallback: ./.rascal.env if present)
+      --no-color              disable ANSI color/style output (also set by NO_COLOR)
+      --output string         output format: table|json|toml (default "table")
+  -q, --quiet                 reduce non-essential output
+      --server-url string     orchestrator URL
 
 Use "rascal github [command] --help" for more information about a command.

--- a/cmd/rascal/testdata/help/infra.golden
+++ b/cmd/rascal/testdata/help/infra.golden
@@ -18,18 +18,13 @@ Flags:
   -h, --help   help for infra
 
 Global Flags:
-      --api-token string         orchestrator API token
-      --client-ssh-host string   SSH target host for API transport=ssh/auto
-      --client-ssh-key string    SSH private key path for API transport=ssh/auto
-      --client-ssh-port int      SSH target port for API transport=ssh/auto
-      --client-ssh-user string   SSH target user for API transport=ssh/auto
-      --config string            config file path (default "$HOME/.rascal/config.toml")
-      --default-repo string      default repository in OWNER/REPO form
-      --env-file string          env file path (fallback: ./.rascal.env if present)
-      --no-color                 disable ANSI color/style output (also set by NO_COLOR)
-      --output string            output format: table|json|toml (default "table")
-  -q, --quiet                    reduce non-essential output
-      --server-url string        orchestrator URL
-      --transport string         API transport: auto|http|ssh
+      --api-token string      orchestrator API token
+      --config string         config file path (default "$HOME/.rascal/config.toml")
+      --default-repo string   default repository in OWNER/REPO form
+      --env-file string       env file path (fallback: ./.rascal.env if present)
+      --no-color              disable ANSI color/style output (also set by NO_COLOR)
+      --output string         output format: table|json|toml (default "table")
+  -q, --quiet                 reduce non-essential output
+      --server-url string     orchestrator URL
 
 Use "rascal infra [command] --help" for more information about a command.

--- a/cmd/rascal/testdata/help/logs.golden
+++ b/cmd/rascal/testdata/help/logs.golden
@@ -27,18 +27,13 @@ Flags:
       --since duration      show logs since duration ago (best effort)
 
 Global Flags:
-      --api-token string         orchestrator API token
-      --client-ssh-host string   SSH target host for API transport=ssh/auto
-      --client-ssh-key string    SSH private key path for API transport=ssh/auto
-      --client-ssh-port int      SSH target port for API transport=ssh/auto
-      --client-ssh-user string   SSH target user for API transport=ssh/auto
-      --config string            config file path (default "$HOME/.rascal/config.toml")
-      --default-repo string      default repository in OWNER/REPO form
-      --env-file string          env file path (fallback: ./.rascal.env if present)
-      --no-color                 disable ANSI color/style output (also set by NO_COLOR)
-      --output string            output format: table|json|toml (default "table")
-  -q, --quiet                    reduce non-essential output
-      --server-url string        orchestrator URL
-      --transport string         API transport: auto|http|ssh
+      --api-token string      orchestrator API token
+      --config string         config file path (default "$HOME/.rascal/config.toml")
+      --default-repo string   default repository in OWNER/REPO form
+      --env-file string       env file path (fallback: ./.rascal.env if present)
+      --no-color              disable ANSI color/style output (also set by NO_COLOR)
+      --output string         output format: table|json|toml (default "table")
+  -q, --quiet                 reduce non-essential output
+      --server-url string     orchestrator URL
 
 Use "rascal logs [command] --help" for more information about a command.

--- a/cmd/rascal/testdata/help/root.golden
+++ b/cmd/rascal/testdata/help/root.golden
@@ -34,19 +34,14 @@ Additional Commands:
   help        Help about any command
 
 Flags:
-      --api-token string         orchestrator API token
-      --client-ssh-host string   SSH target host for API transport=ssh/auto
-      --client-ssh-key string    SSH private key path for API transport=ssh/auto
-      --client-ssh-port int      SSH target port for API transport=ssh/auto
-      --client-ssh-user string   SSH target user for API transport=ssh/auto
-      --config string            config file path (default "$HOME/.rascal/config.toml")
-      --default-repo string      default repository in OWNER/REPO form
-      --env-file string          env file path (fallback: ./.rascal.env if present)
-  -h, --help                     help for rascal
-      --no-color                 disable ANSI color/style output (also set by NO_COLOR)
-      --output string            output format: table|json|toml (default "table")
-  -q, --quiet                    reduce non-essential output
-      --server-url string        orchestrator URL
-      --transport string         API transport: auto|http|ssh
+      --api-token string      orchestrator API token
+      --config string         config file path (default "$HOME/.rascal/config.toml")
+      --default-repo string   default repository in OWNER/REPO form
+      --env-file string       env file path (fallback: ./.rascal.env if present)
+  -h, --help                  help for rascal
+      --no-color              disable ANSI color/style output (also set by NO_COLOR)
+      --output string         output format: table|json|toml (default "table")
+  -q, --quiet                 reduce non-essential output
+      --server-url string     orchestrator URL
 
 Use "rascal [command] --help" for more information about a command.

--- a/cmd/rascal/testdata/help/run.golden
+++ b/cmd/rascal/testdata/help/run.golden
@@ -17,16 +17,11 @@ Flags:
   -t, --task string          task text
 
 Global Flags:
-      --api-token string         orchestrator API token
-      --client-ssh-host string   SSH target host for API transport=ssh/auto
-      --client-ssh-key string    SSH private key path for API transport=ssh/auto
-      --client-ssh-port int      SSH target port for API transport=ssh/auto
-      --client-ssh-user string   SSH target user for API transport=ssh/auto
-      --config string            config file path (default "$HOME/.rascal/config.toml")
-      --default-repo string      default repository in OWNER/REPO form
-      --env-file string          env file path (fallback: ./.rascal.env if present)
-      --no-color                 disable ANSI color/style output (also set by NO_COLOR)
-      --output string            output format: table|json|toml (default "table")
-  -q, --quiet                    reduce non-essential output
-      --server-url string        orchestrator URL
-      --transport string         API transport: auto|http|ssh
+      --api-token string      orchestrator API token
+      --config string         config file path (default "$HOME/.rascal/config.toml")
+      --default-repo string   default repository in OWNER/REPO form
+      --env-file string       env file path (fallback: ./.rascal.env if present)
+      --no-color              disable ANSI color/style output (also set by NO_COLOR)
+      --output string         output format: table|json|toml (default "table")
+  -q, --quiet                 reduce non-essential output
+      --server-url string     orchestrator URL

--- a/docs/config.md
+++ b/docs/config.md
@@ -45,7 +45,6 @@ Rascal-owned auth configuration uses these canonical environment variables:
 - `server_url`
 - `api_token`
 - `default_repo`
-- `transport` (`auto`, `http`, `ssh`)
 - `host`
 - `domain`
 - `ssh_host`
@@ -58,7 +57,6 @@ Set values:
 ```bash
 ./bin/rascal config set server_url https://rascal.example.com
 ./bin/rascal config set default_repo OWNER/REPO
-./bin/rascal config set transport ssh
 ```
 
 Tip: use `doctor` to confirm both local and remote resolution.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -6,8 +6,7 @@
 ./bin/rascal doctor --host YOUR_SERVER_IP
 ```
 
-`doctor` validates local config, server health, transport choice, and remote
-runtime prerequisites.
+`doctor` validates local config, server health, and remote runtime prerequisites.
 
 ## Run Statuses
 
@@ -59,7 +58,7 @@ Operationally this means:
 
 | Symptom | Likely layer | First checks |
 | --- | --- | --- |
-| `rascal` command cannot reach server | Control plane / transport | `./bin/rascal config view`, `./bin/rascal doctor --host YOUR_SERVER_IP` |
+| `rascal` command cannot reach server | Control plane / API path | `./bin/rascal config view`, `./bin/rascal doctor --host YOUR_SERVER_IP` |
 | Webhook arrives but no run is created | Control plane / webhook path | `curl -fsS https://YOUR_DOMAIN/healthz`, `./bin/rascal logs caddy-access --host YOUR_SERVER_IP --follow`, `./bin/rascal logs rascald --host YOUR_SERVER_IP --follow` |
 | Run is stuck in `queued` | Control plane / scheduler | `./bin/rascal ps`, `./bin/rascal logs rascald --host YOUR_SERVER_IP --follow` |
 | Run is `running` but appears idle | Execution plane / backend | `./bin/rascal logs <run_id> --follow`, inspect detached containers on host |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -79,7 +79,7 @@ You can also set a custom env file via `--env-file` or `RASCAL_ENV_FILE`.
 
 You can run Rascal over host IP without a domain.
 
-- CLI-triggered runs work over SSH transport or direct server URL.
+- CLI-triggered runs use the configured Rascal server URL over HTTP(S).
 - GitHub webhooks can also target an IP URL if publicly reachable, but a stable
   domain + TLS is easier to operate.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,7 +50,6 @@ type ClientConfig struct {
 	DefaultRepo string
 	Host        string
 	Domain      string
-	Transport   string
 	SSHHost     string
 	SSHUser     string
 	SSHKey      string
@@ -198,7 +197,6 @@ func LoadClientConfigAtPath(path string) (ClientConfig, error) {
 		DefaultRepo: strings.TrimSpace(v.GetString("default_repo")),
 		Host:        strings.TrimSpace(v.GetString("host")),
 		Domain:      strings.TrimSpace(v.GetString("domain")),
-		Transport:   strings.TrimSpace(v.GetString("transport")),
 		SSHHost:     strings.TrimSpace(v.GetString("ssh_host")),
 		SSHUser:     strings.TrimSpace(v.GetString("ssh_user")),
 		SSHKey:      strings.TrimSpace(v.GetString("ssh_key")),
@@ -207,9 +205,6 @@ func LoadClientConfigAtPath(path string) (ClientConfig, error) {
 	cfg.ServerURL = strings.TrimRight(cfg.ServerURL, "/")
 	if cfg.ServerURL == "" {
 		cfg.ServerURL = "http://127.0.0.1:8080"
-	}
-	if cfg.Transport == "" {
-		cfg.Transport = "auto"
 	}
 	if cfg.SSHUser == "" {
 		cfg.SSHUser = "root"
@@ -235,7 +230,6 @@ func SaveClientConfig(path string, cfg ClientConfig) error {
 	v.Set("default_repo", strings.TrimSpace(cfg.DefaultRepo))
 	v.Set("host", strings.TrimSpace(cfg.Host))
 	v.Set("domain", strings.TrimSpace(cfg.Domain))
-	v.Set("transport", strings.TrimSpace(cfg.Transport))
 	v.Set("ssh_host", strings.TrimSpace(cfg.SSHHost))
 	v.Set("ssh_user", strings.TrimSpace(cfg.SSHUser))
 	v.Set("ssh_key", strings.TrimSpace(cfg.SSHKey))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,7 +20,6 @@ func TestSaveAndLoadClientConfig(t *testing.T) {
 		DefaultRepo: "owner/repo",
 		Host:        "203.0.113.10",
 		Domain:      "rascal.example.com",
-		Transport:   "ssh",
 		SSHHost:     "203.0.113.10",
 		SSHUser:     "root",
 		SSHKey:      "~/.ssh/id_ed25519",
@@ -49,9 +48,6 @@ func TestSaveAndLoadClientConfig(t *testing.T) {
 	if out.Domain != in.Domain {
 		t.Fatalf("domain mismatch: got %s want %s", out.Domain, in.Domain)
 	}
-	if out.Transport != in.Transport {
-		t.Fatalf("transport mismatch: got %s want %s", out.Transport, in.Transport)
-	}
 	if out.SSHHost != in.SSHHost {
 		t.Fatalf("ssh host mismatch: got %s want %s", out.SSHHost, in.SSHHost)
 	}
@@ -76,7 +72,7 @@ func TestSaveAndLoadClientConfig(t *testing.T) {
 
 func TestLoadClientConfigEnvOverride(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.toml")
-	if err := os.WriteFile(path, []byte("server_url = \"https://rascal.example.com\"\napi_token = \"from_file\"\ndefault_repo = \"owner/repo\"\nhost = \"203.0.113.10\"\ndomain = \"rascal.example.com\"\ntransport = \"ssh\"\nssh_host = \"203.0.113.10\"\nssh_user = \"root\"\nssh_key = \"~/.ssh/id_ed25519\"\nssh_port = 22\n"), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte("server_url = \"https://rascal.example.com\"\napi_token = \"from_file\"\ndefault_repo = \"owner/repo\"\nhost = \"203.0.113.10\"\ndomain = \"rascal.example.com\"\nssh_host = \"203.0.113.10\"\nssh_user = \"root\"\nssh_key = \"~/.ssh/id_ed25519\"\nssh_port = 22\n"), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
@@ -97,9 +93,6 @@ func TestLoadClientConfigEnvOverride(t *testing.T) {
 	}
 	if cfg.Domain != "rascal.example.com" {
 		t.Fatalf("expected domain from file, got %s", cfg.Domain)
-	}
-	if cfg.Transport != "ssh" {
-		t.Fatalf("expected transport from file, got %s", cfg.Transport)
 	}
 	if cfg.SSHHost != "203.0.113.10" {
 		t.Fatalf("expected ssh host from file, got %s", cfg.SSHHost)


### PR DESCRIPTION
Drop CLI transport selection and SSH API tunneling in favor of a single direct HTTP(S) control-plane request path.
Keep SSH usage for deployment and remote maintenance commands.

<details><summary>Agent Details</summary>

<pre><code>
    __( O)&gt;  ● new session · codex gpt-5.4
   \____)    20260308_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: &#34;/usr/local/bin/codex&#34;
Model: gpt-5.4
Reasoning effort: high
Skip git check: false
Prompt length: 3713 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Suggestion

The user has 7 extensions with 16 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
Consider asking if they&#39;d like to disable some extensions to improve tool selection accuracy.

# Response Guidelines

Use Markdown formatting for all responses.

Human: &lt;info-msg&gt;
It is currently 2026-03-08 13:42:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

&lt;/info-msg&gt;
# Rascal Run Instructions

Run ID: run_f346a4891b5e9721
Task ID: rtzll/rascal#101
Repository: rtzll/rascal
Issue: #101

## Task

refactor(cli): remove SSH API transport and standardize on one control-plane path

## Summary
Rascal currently supports two client-to-server control-plane paths: direct HTTP and SSH-mediated HTTP via remote `curl`. This duplicates request handling, transport selection, health checks, and operator configuration.

Relevant code:
- `cmd/rascal/main.go` (`apiClient.do`, `doOverHTTP`, `doOverSSH`, `resolveTransport`)
- `cmd/rascal/doctor_remote.go` (`checkServerHealthSSH`, `waitForServerHealthSSH`)
- CLI persistent flags and config fields for `transport`, `client-ssh-host`, `client-ssh-user`, `client-ssh-key`, `client-ssh-port`

## Goal
Standardize the control plane on a single transport path and remove the secondary path if it is no longer required. Make the simplest assumption that keeps the codebase clean: prefer direct HTTP for Rascal API access and remove SSH API tunneling unless a hard product requirement is found in the codebase.

## Scope
- Remove the SSH API transport path from the CLI.
- Remove transport auto-resolution and the extra transport-related client config fields if they are only used for Rascal API access.
- Remove SSH-specific health checks that only exist to support SSH API access.
- Simplify help text, docs, and tests accordingly.
- Keep SSH usage for deployment and remote maintenance commands where it is still the primary mechanism.

## Out Of Scope
- Reworking deployment flows that legitimately use SSH for provisioning or remote file/service management.
- Changing the server HTTP API itself.

## Expected Outcome
- Rascal CLI uses a single control-plane request path.
- Client config surface is smaller and easier to explain.
- Command help and docs no longer mention transport selection for API calls.
- Test coverage reflects the new single-path behavior.

## Acceptance Criteria
- `apiClient` has one request path for Rascal API calls.
- Transport-selection flags/config keys are removed or clearly deprecated in one place with no hidden fallback logic.
- CLI help snapshots are updated.
- Docs are updated to describe the supported control-plane path only.
- No behavior-changing cleanup is submitted until all tests pass.

## Testing Requirements
- Run the full Go test suite with `go test ./...`.
- Update existing tests that assert transport resolution or SSH API behavior.
- Add tests for the final supported request behavior if coverage regresses when transport-specific tests are removed.

## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run tests or explain why tests could not run.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label &#39;rascal&#39; on issue #101


Assistant: 
Image files: 0
============================
{&#34;type&#34;:&#34;message&#34;,&#34;message&#34;:{&#34;id&#34;:null,&#34;role&#34;:&#34;assistant&#34;,&#34;created&#34;:1772978208,&#34;content&#34;:[{&#34;type&#34;:&#34;text&#34;,&#34;text&#34;:&#34;I’m taking issue `rtzll/rascal#101` and will remove SSH API transport while keeping SSH for deployment/maintenance paths. I’ll first map all transport-related code, flags/config, tests, and docs, then implement a minimal refactor and run `go test ./...`.\n\nI located all transport touchpoints across `cmd/rascal`, config/docs, and tests. Next I’m reading the key files (`main.go`, `doctor_remote.go`, config, and related tests) to remove only SSH API transport logic while preserving SSH deploy paths.\n\nI’ve confirmed the API client currently has dual HTTP/SSH paths plus transport resolution in config/init/doctor. I’m now checking `doctor_remote.go`, `infra.go`, and config internals to separate SSH deployment health checks from SSH API transport behavior.\n\nI found transport-related tests in `main_test.go`, `main_slot_only_test.go`, `infra_test.go`, and config tests, plus docs references. Next I’m editing `main.go`/`doctor_remote.go` first, then I’ll update tests and docs to match the single HTTP control-plane path.\n\nI have enough context to implement the refactor safely. Plan:\n1. Remove SSH API transport from `apiClient` and `initConfig` (`doOverSSH`, `resolveTransport`, transport flags/source, and transport validation).\n2. Keep SSH for operational commands by preserving `ssh_host/user/key/port` config and command-specific SSH flags.\n3. Simplify `doctor` to always health-check via direct HTTP (`checkServerHealth`) and remove SSH health helpers in `doctor_remote.go`.\n4. Update config command surface (`supportedConfigKeys`, `config view/get/set`, examples) to drop `transport`.\n5. Update tests and help goldens (remove transport/`client-ssh-*` expectations, remove SSH API tests, adjust infra seeding client expectation).\n6. Update docs (`docs/config.md`, `docs/operations.md`, `docs/setup.md`) and run `go test ./...`.\n7. Write `/rascal-meta/commit_message.txt`.\n\nI’m starting code edits now: removing transport selection and SSH API request plumbing from `main.go`, then wiring deploy credential seeding health checks to direct HTTP. After that I’ll update affected tests and help snapshots.\n\nI’ve removed the core transport logic from `main.go`; next I’m cleaning `doctor_remote.go` and `infra.go` so deployment health waits and credential seeding use direct HTTP as well.\n\nI’ve finished the main refactor and test-file rewrites for removed transport fields. Next step is a compile/test pass to catch remaining references, then I’ll regenerate help snapshots and update docs.\n\nTests are still running after dependency download; I’m waiting on completion and will fix any compile/test failures immediately once results return.\n\nI’m still waiting on the focused test run; it’s taking longer than usual with no intermediate output. I’ll let it finish, then I’ll patch any failures and run the full `go test ./...`.\n\nBuild failed because `net/url` is still needed by unrelated URL parsing helpers in `main.go`. I restored that import and I’m rerunning tests now.\n\nThe code and targeted tests now compile/pass after regenerating help snapshots. I’m updating docs next to remove transport-selection guidance and describe direct HTTP control-plane behavior only.\n\nI’m running the full repository suite (`go test ./...`) now to satisfy the acceptance gate before writing the commit message file.\n\nThe full suite is still in progress; `cmd/rascal` and `cmd/rascal-runner` have already passed. I’m waiting for remaining packages to finish.\n\nAll requested changes are implemented and validated with the full test suite. I’m doing a final diff sanity check and then I’ll summarize exactly what changed.\n\nImplemented `rtzll/rascal#101` with a single direct HTTP(S) control-plane path and removed SSH API tunneling.\n\n### What changed\n- Refactored API client to one request path (`http.Client` only), removed transport resolution and SSH API request code from [main.go](/work/repo/cmd/rascal/main.go).\n- Removed CLI/global API transport flags (`--transport`, `--client-ssh-*`) and related config-source plumbing.\n- Removed `transport` from client config model/load/save in [config.go](/work/repo/internal/config/config.go).\n- Simplified `doctor` health behavior to direct HTTP health checks only; removed SSH-only API health helpers in [doctor_remote.go](/work/repo/cmd/rascal/doctor_remote.go).\n- Kept SSH for deployment/remote ops; updated deploy credential seeding to wait/check via direct HTTP base URL in [infra.go](/work/repo/cmd/rascal/infra.go).\n- Updated tests and removed SSH API transport tests:\n  - [main_test.go](/work/repo/cmd/rascal/main_test.go)\n  - [main_slot_only_test.go](/work/repo/cmd/rascal/main_slot_only_test.go)\n  - [doctor_remote_test.go](/work/repo/cmd/rascal/doctor_remote_test.go)\n  - [infra_test.go](/work/repo/cmd/rascal/infra_test.go)\n  - [config_test.go](/work/repo/internal/config/config_test.go)\n- Regenerated CLI help goldens under `/work/repo/cmd/rascal/testdata/help/*.golden`.\n- Updated docs to remove transport-selection guidance:\n  - [config.md](/work/repo/docs/config.md)\n  - [operations.md](/work/repo/docs/operations.md)\n  - [setup.md](/work/repo/docs/setup.md)\n\n### Validation\n- Ran full suite successfully: `go test ./...`\n\n### Commit message file\n- Wrote: [/rascal-meta/commit_message.txt](/rascal-meta/commit_message.txt)&#34;}],&#34;metadata&#34;:{&#34;userVisible&#34;:true,&#34;agentVisible&#34;:true}}}
{&#34;type&#34;:&#34;complete&#34;,&#34;total_tokens&#34;:9004517}
</code></pre>

</details>

Closes #101

---

Rascal run `run_f346a4891b5e9721` completed in 14m 19s · 9.00M tokens