### PR TITLE
refactor(cmd): extract shared task payload builder for run/retry/issue

### DIFF
--- a/cmd/rascal/main.go
+++ b/cmd/rascal/main.go
@@ -918,14 +918,13 @@ rascal run --issue OWNER/REPO#123
 				if err != nil {
 					return &cliError{Code: exitInput, Message: err.Error()}
 				}
-				payload := map[string]any{
-					"repo":         repo,
-					"issue_number": issueNumber,
-				}
-				if cmd.Flags().Changed("debug") {
-					payload["debug"] = debug
-				}
-				resp, err := a.client.doJSON(http.MethodPost, "/v1/tasks/issue", payload)
+				debugValue := optionalBoolFlagValue(cmd, "debug", debug)
+				path, payload := buildCreateTaskPayload(createTaskPayloadInput{
+					Repo:        repo,
+					IssueNumber: issueNumber,
+					Debug:       debugValue,
+				})
+				resp, err := a.client.doJSON(http.MethodPost, path, payload)
 				if err != nil {
 					return &cliError{Code: exitServer, Message: "request failed", Cause: err}
 				}
@@ -952,15 +951,14 @@ rascal run --issue OWNER/REPO#123
 				return &cliError{Code: exitInput, Message: "both --repo/-R and --task/-t are required"}
 			}
 
-			payload := map[string]any{
-				"repo":        repo,
-				"task":        task,
-				"base_branch": baseBranch,
-			}
-			if cmd.Flags().Changed("debug") {
-				payload["debug"] = debug
-			}
-			resp, err := a.client.doJSON(http.MethodPost, "/v1/tasks", payload)
+			debugValue := optionalBoolFlagValue(cmd, "debug", debug)
+			path, payload := buildCreateTaskPayload(createTaskPayloadInput{
+				Repo:       repo,
+				Task:       task,
+				BaseBranch: baseBranch,
+				Debug:      debugValue,
+			})
+			resp, err := a.client.doJSON(http.MethodPost, path, payload)
 			if err != nil {
 				return &cliError{Code: exitServer, Message: "request failed", Hint: "verify server URL and network access", Cause: err}
 			}
@@ -1748,17 +1746,16 @@ rascal retry run_abc123 --debug=false
 			if run.Status != state.StatusFailed && run.Status != state.StatusCanceled {
 				return &cliError{Code: exitInput, Message: "retry only supports failed or canceled runs"}
 			}
-			payload := map[string]any{
-				"task_id":     run.TaskID,
-				"repo":        run.Repo,
-				"task":        run.Task,
-				"base_branch": run.BaseBranch,
-				"trigger":     "retry",
-			}
-			if cmd.Flags().Changed("debug") {
-				payload["debug"] = debug
-			}
-			resp, err := a.client.doJSON(http.MethodPost, "/v1/tasks", payload)
+			debugValue := optionalBoolFlagValue(cmd, "debug", debug)
+			path, payload := buildCreateTaskPayload(createTaskPayloadInput{
+				TaskID:     run.TaskID,
+				Repo:       run.Repo,
+				Task:       run.Task,
+				BaseBranch: run.BaseBranch,
+				Trigger:    "retry",
+				Debug:      debugValue,
+			})
+			resp, err := a.client.doJSON(http.MethodPost, path, payload)
 			if err != nil {
 				return &cliError{Code: exitServer, Message: "request failed", Cause: err}
 			}
@@ -2775,6 +2772,53 @@ func parseIssueRef(input string) (string, int, error) {
 		return "", 0, fmt.Errorf("invalid repo in %q", input)
 	}
 	return repo, issue, nil
+}
+
+type createTaskPayloadInput struct {
+	TaskID      string
+	Repo        string
+	Task        string
+	BaseBranch  string
+	Trigger     string
+	IssueNumber int
+	Debug       *bool
+}
+
+func optionalBoolFlagValue(cmd *cobra.Command, name string, value bool) *bool {
+	if !cmd.Flags().Changed(name) {
+		return nil
+	}
+	v := value
+	return &v
+}
+
+func buildCreateTaskPayload(input createTaskPayloadInput) (string, map[string]any) {
+	if input.IssueNumber > 0 {
+		payload := map[string]any{
+			"repo":         input.Repo,
+			"issue_number": input.IssueNumber,
+		}
+		if input.Debug != nil {
+			payload["debug"] = *input.Debug
+		}
+		return "/v1/tasks/issue", payload
+	}
+
+	payload := map[string]any{
+		"repo":        input.Repo,
+		"task":        input.Task,
+		"base_branch": input.BaseBranch,
+	}
+	if strings.TrimSpace(input.TaskID) != "" {
+		payload["task_id"] = input.TaskID
+	}
+	if strings.TrimSpace(input.Trigger) != "" {
+		payload["trigger"] = input.Trigger
+	}
+	if input.Debug != nil {
+		payload["debug"] = *input.Debug
+	}
+	return "/v1/tasks", payload
 }
 
 func (c apiClient) doJSON(method, path string, payload any) (*http.Response, error) {

--- a/cmd/rascal/main_test.go
+++ b/cmd/rascal/main_test.go
@@ -49,6 +49,107 @@ func TestFirstNonEmpty(t *testing.T) {
 	}
 }
 
+func TestBuildCreateTaskPayloadForRun(t *testing.T) {
+	t.Parallel()
+
+	path, payload := buildCreateTaskPayload(createTaskPayloadInput{
+		Repo:       "owner/repo",
+		Task:       "Fix flaky tests",
+		BaseBranch: "main",
+	})
+
+	if path != "/v1/tasks" {
+		t.Fatalf("path = %q, want /v1/tasks", path)
+	}
+	if payload["repo"] != "owner/repo" {
+		t.Fatalf("repo = %v, want owner/repo", payload["repo"])
+	}
+	if payload["task"] != "Fix flaky tests" {
+		t.Fatalf("task = %v, want Fix flaky tests", payload["task"])
+	}
+	if payload["base_branch"] != "main" {
+		t.Fatalf("base_branch = %v, want main", payload["base_branch"])
+	}
+	if _, ok := payload["task_id"]; ok {
+		t.Fatalf("did not expect task_id in run payload")
+	}
+	if _, ok := payload["trigger"]; ok {
+		t.Fatalf("did not expect trigger in run payload")
+	}
+	if _, ok := payload["issue_number"]; ok {
+		t.Fatalf("did not expect issue_number in run payload")
+	}
+	if _, ok := payload["debug"]; ok {
+		t.Fatalf("did not expect debug in run payload when unset")
+	}
+}
+
+func TestBuildCreateTaskPayloadForRetry(t *testing.T) {
+	t.Parallel()
+
+	debug := false
+	path, payload := buildCreateTaskPayload(createTaskPayloadInput{
+		TaskID:     "task_1",
+		Repo:       "owner/repo",
+		Task:       "Retry task",
+		BaseBranch: "main",
+		Trigger:    "retry",
+		Debug:      &debug,
+	})
+
+	if path != "/v1/tasks" {
+		t.Fatalf("path = %q, want /v1/tasks", path)
+	}
+	if payload["task_id"] != "task_1" {
+		t.Fatalf("task_id = %v, want task_1", payload["task_id"])
+	}
+	if payload["trigger"] != "retry" {
+		t.Fatalf("trigger = %v, want retry", payload["trigger"])
+	}
+	if payload["debug"] != false {
+		t.Fatalf("debug = %v, want false", payload["debug"])
+	}
+}
+
+func TestBuildCreateTaskPayloadForIssue(t *testing.T) {
+	t.Parallel()
+
+	debug := true
+	path, payload := buildCreateTaskPayload(createTaskPayloadInput{
+		Repo:        "owner/repo",
+		IssueNumber: 42,
+		Task:        "ignored",
+		BaseBranch:  "ignored",
+		Trigger:     "ignored",
+		Debug:       &debug,
+	})
+
+	if path != "/v1/tasks/issue" {
+		t.Fatalf("path = %q, want /v1/tasks/issue", path)
+	}
+	if payload["repo"] != "owner/repo" {
+		t.Fatalf("repo = %v, want owner/repo", payload["repo"])
+	}
+	if payload["issue_number"] != 42 {
+		t.Fatalf("issue_number = %v, want 42", payload["issue_number"])
+	}
+	if payload["debug"] != true {
+		t.Fatalf("debug = %v, want true", payload["debug"])
+	}
+	if _, ok := payload["task_id"]; ok {
+		t.Fatalf("did not expect task_id in issue payload")
+	}
+	if _, ok := payload["task"]; ok {
+		t.Fatalf("did not expect task in issue payload")
+	}
+	if _, ok := payload["base_branch"]; ok {
+		t.Fatalf("did not expect base_branch in issue payload")
+	}
+	if _, ok := payload["trigger"]; ok {
+		t.Fatalf("did not expect trigger in issue payload")
+	}
+}
+
 func TestDecodeServerErrorIncludesRequestID(t *testing.T) {
 	t.Parallel()
 
@@ -808,6 +909,68 @@ func TestPSRendersIssueColumn(t *testing.T) {
 	}
 	if strings.Contains(lines[2], "#") {
 		t.Fatalf("expected blank issue column for non-issue run, got:\n%s", lines[2])
+	}
+}
+
+func TestRunCreatesTaskPayload(t *testing.T) {
+	var payload map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/v1/tasks" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"run": map[string]any{"id": "run_new", "status": "queued"},
+		}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	a := &app{
+		cfg: config.ClientConfig{
+			ServerURL: srv.URL,
+			APIToken:  "test-token",
+			Transport: "http",
+		},
+		client: apiClient{
+			baseURL:   srv.URL,
+			token:     "test-token",
+			http:      srv.Client(),
+			transport: "http",
+		},
+		output: "json",
+	}
+
+	cmd := a.newRunCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"--repo", "owner/repo", "--task", "Fix flaky tests"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("run --repo --task: %v", err)
+	}
+
+	if payload["repo"] != "owner/repo" {
+		t.Fatalf("unexpected repo payload: %v", payload["repo"])
+	}
+	if payload["task"] != "Fix flaky tests" {
+		t.Fatalf("unexpected task payload: %v", payload["task"])
+	}
+	if payload["base_branch"] != "main" {
+		t.Fatalf("expected default base_branch main, got: %v", payload["base_branch"])
+	}
+	if _, ok := payload["debug"]; ok {
+		t.Fatalf("did not expect debug payload unless flag is set, got: %v", payload["debug"])
 	}
 }
 


### PR DESCRIPTION
Centralize create-task payload assembly behind a shared helper and reuse it
across run, retry, and issue-based run entrypoints.

Add unit coverage for helper modes and run command payload parity.

<details><summary>Agent Details</summary>

<pre><code>
    __( O)&gt;  ● new session · codex gpt-5.4
   \____)    20260308_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: &#34;/usr/local/bin/codex&#34;
Model: gpt-5.4
Reasoning effort: high
Skip git check: false
Prompt length: 1878 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Suggestion

The user has 7 extensions with 16 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
Consider asking if they&#39;d like to disable some extensions to improve tool selection accuracy.

# Response Guidelines

Use Markdown formatting for all responses.

Human: &lt;info-msg&gt;
It is currently 2026-03-08 19:45:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

&lt;/info-msg&gt;
# Rascal Run Instructions

Run ID: run_aa25d7b0e6bf9403
Task ID: rtzll/rascal#13
Repository: rtzll/rascal
Issue: #13

## Task

refactor(cmd): extract shared run payload builder for run/retry/issue flows

## Goal
Reduce duplication in CLI run creation by centralizing payload assembly for `run`, `retry`, and issue-based entrypoints.

## Scope
- Extract shared helper to build `/v1/tasks` payloads.
- Reuse for `run`, `retry`, and any issue-run path that posts create-task requests.
- Preserve current behavior and defaults.

## Acceptance Criteria
- No behavior changes in existing commands.
- Duplicate payload-building logic removed from command handlers.
- Unit tests cover helper behavior and command parity.
- `go test ./...` passes.

## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run tests or explain why tests could not run.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label &#39;rascal&#39; on issue #13


Assistant: 
Image files: 0
============================
{&#34;type&#34;:&#34;message&#34;,&#34;message&#34;:{&#34;id&#34;:null,&#34;role&#34;:&#34;assistant&#34;,&#34;created&#34;:1772999515,&#34;content&#34;:[{&#34;type&#34;:&#34;text&#34;,&#34;text&#34;:&#34;I’ll implement a minimal refactor to centralize create-task payload assembly for `run`, `retry`, and issue-based run paths, then add/adjust tests to prove behavior parity and run `go test ./...`. I’m starting by scanning the CLI command handlers for duplicated `/v1/tasks` payload construction.\n\nI found likely duplication in `cmd/rascal/main.go` around `run`, `retry`, and issue task creation endpoints. Next I’m opening those command implementations and their tests to isolate the payload-building overlap before editing.\n\nI’ve identified three payload builders in `cmd/rascal/main.go` (`run`, `run --issue`, and `retry`) that all target `/v1/tasks*`. I’m now setting a concrete todo and then implementing one shared builder used by all three paths while keeping request bodies and debug/default behavior unchanged.\n\nI’ve confirmed only three command paths construct these create-task payloads, so a single helper can cover all duplication without touching server behavior. Next I’m adding a small payload-builder API in `cmd/rascal/main.go` and then updating tests in `cmd/rascal/main_test.go` to validate helper output plus unchanged command payloads.\n\nI’m ready to edit: I’ll introduce one `buildCreateTaskPayload(...)` helper that returns both endpoint and payload (`/v1/tasks` vs `/v1/tasks/issue`), then replace all three call sites and add focused tests for helper modes (run/retry/issue) plus a standard `run --repo/--task` parity test.\n\nI’ve applied the refactor and test updates in both `main.go` and `main_test.go`. Next I’m running `gofmt` and then `go test ./...` to confirm behavior parity and full suite pass.\n\n`go test ./...` completed but failed in `cmd/rascald` on `TestSchedulerAllowsConcurrentRunsToReuseSharedCredential`, which looks unrelated to this CLI refactor and appears timing-sensitive. I’m rerunning the full suite once to verify whether this is a transient failure before reporting final status.\n\nThe full suite is failing in unrelated `cmd/rascald` integration tests with idle-timeout flakes, not in the CLI package I changed. I’m running targeted tests for `cmd/rascal` now to verify the refactor and new coverage are green.\n\nImplemented the refactor with minimal scope and no CLI behavior changes.\n\n- Centralized `/v1/tasks` payload construction in a shared helper: [cmd/rascal/main.go:2777](/work/repo/cmd/rascal/main.go:2777)\n- Reused helper in all relevant entrypoints:\n  - `run --issue` path: [cmd/rascal/main.go:921](/work/repo/cmd/rascal/main.go:921)\n  - standard `run` path: [cmd/rascal/main.go:954](/work/repo/cmd/rascal/main.go:954)\n  - `retry` path: [cmd/rascal/main.go:1749](/work/repo/cmd/rascal/main.go:1749)\n- Added unit coverage for helper behavior and run command parity:\n  - helper tests: [cmd/rascal/main_test.go:52](/work/repo/cmd/rascal/main_test.go:52)\n  - run payload parity test: [cmd/rascal/main_test.go:915](/work/repo/cmd/rascal/main_test.go:915)\n\nTests run:\n- `go test ./cmd/rascal -count=1` ✅\n- `go test ./...` ❌ (unrelated `cmd/rascald` integration timeouts/flakes, e.g. `TestSchedulerAllowsConcurrentRunsToReuseSharedCredential`, `TestCanceledRunDoesNotTransitionToSuccess`)\n\nCommit message file written:\n- [/rascal-meta/commit_message.txt](/rascal-meta/commit_message.txt)&#34;}],&#34;metadata&#34;:{&#34;userVisible&#34;:true,&#34;agentVisible&#34;:true}}}
{&#34;type&#34;:&#34;complete&#34;,&#34;total_tokens&#34;:1450541}
</code></pre>

</details>

Closes #13

---

Rascal run `run_aa25d7b0e6bf9403` completed in 6m 8s · 1.45M tokens