### PR TITLE
docs: add contributing guide for local development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing
+
+This guide covers the fastest path to make and verify a typical change locally.
+
+## Prerequisites
+
+- Go 1.26 (matches `go.mod`)
+- `make`
+- `curl` (used by `make lint` to install `golangci-lint` into `./bin`)
+
+You do not need a separate `sqlc` install. `make codegen` runs the pinned version with `go run`.
+
+## Local workflow
+
+Run these commands from the repository root:
+
+```bash
+make lint
+make test
+```
+
+- `make lint` runs SQLC code generation first, then runs `golangci-lint`.
+- `make test` runs SQLC code generation first, then runs `go test ./...`.
+- `make test-fast` skips code generation and runs `go test ./...` directly. Use it for faster feedback when you have not changed SQL schema or queries.
+
+## When to run code generation
+
+Run `make codegen` when you change:
+
+- `internal/state/sql/schema.sql`
+- `internal/state/sql/queries.sql`
+
+Commit the generated updates under `internal/state/sqlitegen`. CI runs `git diff --exit-code` after lint and tests, so generated files must be up to date.
+
+## Golden files
+
+Some CLI help output tests use golden files under `cmd/rascal/testdata/help`.
+
+If you intentionally change CLI help text, refresh those fixtures with:
+
+```bash
+UPDATE_GOLDEN=1 go test ./cmd/rascal -run TestHelpGoldenSnapshots
+```
+
+Then run `make test` again before submitting.
+
+## Scope and validation
+
+Keep changes focused on the issue you are solving. When behavior changes, update the relevant tests and any user-facing docs in the same change.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ RASCAL_GITHUB_TOKEN=...
 
 ## Learn More
 
+- Contributing and local verification: [CONTRIBUTING.md](CONTRIBUTING.md)
 - Setup and token details: [docs/setup.md](docs/setup.md)
 - Config and precedence: [docs/config.md](docs/config.md)
 - Command guide: [docs/commands.md](docs/commands.md)


### PR DESCRIPTION
Document the local contributor workflow, including lint/test commands,
code generation, golden file refresh steps, and README linkage.

<details><summary>Agent Details</summary>

<pre><code>
    __( O)&gt;  ● new session · codex gpt-5.4
   \____)    20260310_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: &#34;/usr/local/bin/codex&#34;
Model: gpt-5.4
Reasoning effort: high
Skip git check: false
Prompt length: 2673 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Suggestion

The user has 7 extensions with 16 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
Consider asking if they&#39;d like to disable some extensions to improve tool selection accuracy.

# Response Guidelines

Use Markdown formatting for all responses.

Human: &lt;info-msg&gt;
It is currently 2026-03-10 20:23:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

&lt;/info-msg&gt;
# Rascal Run Instructions

Run ID: run_6413e4ccfd9a746b
Task ID: rtzll/rascal#130
Repository: rtzll/rascal
Issue: #130

## Task

Add a CONTRIBUTING guide for local development and verification

## Summary
The repo has strong operator-facing docs, but it does not have a contributor-focused guide. A new contributor currently has to infer the local development workflow from the Makefile, CI workflow, and scattered docs.

Relevant context:
- `README.md` is primarily product/operator oriented
- CI runs lint, tests, and generated-file checks in `.github/workflows/ci.yml`
- The Makefile contains the main local developer commands

## Goal
Add a concise `CONTRIBUTING.md` that gives a coding agent or human contributor enough context to make and validate a typical change in one pass.

Recommended content:
- prerequisite tooling
- how to run `make lint`, `make test`, and any fast-path target
- when `make codegen` is needed
- any local expectations for updating golden files or generated SQLC output
- a short note on keeping changes scoped and updating docs/tests when behavior changes

## Acceptance Criteria
- A new top-level `CONTRIBUTING.md` exists
- It is linked from `README.md`
- The guide is short, practical, and aligned with the actual commands in the repo
- `make lint` and `make test` still pass

## Notes
Optimize for fast onboarding, not exhaustive project history.

## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run `make lint` and `make test` before finishing if those targets exist.
- If one of those commands does not exist or cannot run, explain exactly why and run the closest equivalent checks instead.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label &#39;rascal&#39; on issue #130


Assistant: 
Image files: 0
============================
{&#34;type&#34;:&#34;message&#34;,&#34;message&#34;:{&#34;id&#34;:null,&#34;role&#34;:&#34;assistant&#34;,&#34;created&#34;:1773175061,&#34;content&#34;:[{&#34;type&#34;:&#34;text&#34;,&#34;text&#34;:&#34;I’m adding a contributor-focused guide, linking it from the README, and then validating the repo’s documented local workflow against the actual Make targets and CI checks.\n\nI’m reading the repo entry points now: `README.md`, `Makefile`, and the CI workflow to make sure the contributor guide matches the project’s real verification path.\n\nThe core workflow is simple: `make lint`, `make test`, and `make codegen`, with CI also enforcing a clean diff after generation. I’m checking for repo-specific details like Go version, generated SQLC output, and any golden-file conventions before writing the guide.\n\nI found both repo-specific generated code and golden test fixtures. I’m reading the relevant test and SQLC config so the guide can say exactly when contributors need to regenerate files or refresh fixtures.\n\nI have enough context to write this cleanly. The guide will stay short and cover: Go toolchain, `make lint` / `make test` / `make test-fast`, when SQLC regeneration is required, how CLI help goldens are refreshed, and the expectation to keep changes scoped and update tests/docs with behavior changes.\n\nI’m editing the docs now: adding a new top-level `CONTRIBUTING.md` and wiring it into the README’s documentation list.\n\nThe docs are in place. I’m running the repo’s actual verification targets now so the guide is backed by commands that still pass in this checkout.\n\nBoth verification targets are still running. The initial work is dependency bootstrapping for the pinned SQLC and linter toolchain, so I’m waiting for the first full pass to finish before checking whether anything in the guide needs tightening.\n\nThe first run is pulling a large transient toolchain because `make` uses pinned `go run` dependencies. Once this cache is warm, the repo’s normal verification path should be much faster.\n\nThe commands have moved past downloads and are in the quiet part of compilation/test execution. I’m polling with a longer interval now so I can get the terminal result instead of partial output.\n\nI haven’t hit a failure yet, but running `make lint` and `make test` in parallel appears to have left both sessions quiet for a while. I’m checking the active processes so I can tell whether they’re still making progress or blocked on shared build state.\n\nThe delay is in `go run ... sqlc generate`, not the docs change itself. Both sessions are still active and consuming CPU, so this looks like slow first-run compilation rather than a hang.\n\nI’m leaving the existing verification sessions in place because they’re still live and compiling the pinned SQLC tool. If they cross from “slow” into “unreasonable,” I’ll stop them and rerun sequentially against the warmed cache so I can still give you a definitive result.\n\nThe parallel run is wasting time on duplicate SQLC compilation. I’m collapsing this to a sequential pass now so one target can finish, then I’ll run the other against the warmed cache.\n\nThe sequentialized `make test` is still in the SQLC build step. This environment did not have that tool cached, so the first pass is materially slower than a normal incremental dev run; I’m continuing until I have an actual exit result.\n\n`make test` has moved through codegen and into module/test resolution. Once this finishes, `make lint` should be much cheaper because the codegen and module caches are now populated.\n\n`make test` passed. I’m running `make lint` again now that the caches are warm; the earlier parallel attempt was abandoned because both targets were redundantly compiling the same SQLC tool at once.\n\nBoth required verification targets now pass. I’m doing one final diff/status check and then writing the requested commit message file.\n\nI only have the intended doc changes in the worktree. Writing the conventional commit message file now.\n\nAdded a short contributor guide at [CONTRIBUTING.md](/work/repo/CONTRIBUTING.md) and linked it from [README.md](/work/repo/README.md#L71). The guide covers the actual local workflow in this repo: prerequisites, `make lint`, `make test`, `make test-fast`, when `make codegen` is required for SQLC output, how to refresh CLI help goldens, and the expectation to keep changes scoped and update tests/docs when behavior changes.\n\nVerification passed with `make test` and `make lint`. I also wrote the requested commit message to [/rascal-meta/commit_message.txt](/rascal-meta/commit_message.txt).&#34;}],&#34;metadata&#34;:{&#34;userVisible&#34;:true,&#34;agentVisible&#34;:true}}}
{&#34;type&#34;:&#34;complete&#34;,&#34;total_tokens&#34;:740739}
</code></pre>

</details>

Closes #130

---

Rascal run `run_6413e4ccfd9a746b` completed in 13m 54s · 740K tokens