### PR TITLE
build: add local verify target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GOLANGCI_LINT_VERSION ?= v2.11.2
 GOLANGCI_LINT := $(CURDIR)/bin/golangci-lint
 GOLANGCI_LINT_CACHE := $(CURDIR)/tmp/golangci-lint-cache
 
-.PHONY: test test-fast build build-cli build-daemon run-daemon run-cli fmt lint codegen
+.PHONY: test test-fast build build-cli build-daemon run-daemon run-cli fmt lint codegen verify
 
 test: codegen
 	go test ./...
@@ -18,6 +18,20 @@ fmt:
 lint: codegen $(GOLANGCI_LINT)
 	mkdir -p "$(GOLANGCI_LINT_CACHE)"
 	GOLANGCI_LINT_CACHE="$(GOLANGCI_LINT_CACHE)" $(GOLANGCI_LINT) run
+
+verify:
+	@before="$$(mktemp)"; \
+	after="$$(mktemp)"; \
+	trap 'rm -f "$$before" "$$after"' EXIT; \
+	git status --porcelain=v1 --untracked-files=all > "$$before"; \
+	$(MAKE) lint; \
+	$(MAKE) test; \
+	git status --porcelain=v1 --untracked-files=all > "$$after"; \
+	if ! cmp -s "$$before" "$$after"; then \
+		echo "working tree changed during verify; commit generated files and re-run"; \
+		diff -u "$$before" "$$after"; \
+		exit 1; \
+	fi
 
 build: build-cli build-daemon
 

--- a/README.md
+++ b/README.md
@@ -77,3 +77,13 @@ RASCAL_GITHUB_TOKEN=...
 - Operator runbook (failure modes + exact commands): [docs/runbook.md](docs/runbook.md)
 - Architecture overview: [docs/architecture.md](docs/architecture.md)
 - Deployment flow (blue/green + drain): [docs/deployment.md](docs/deployment.md)
+
+## Local Verification
+
+Before opening a PR, run:
+
+```bash
+make verify
+```
+
+This mirrors the standard CI checks by running lint, tests, and verifying that the checks do not leave generated-file changes behind.


### PR DESCRIPTION
Mirror the CI verification flow with a single `make verify` command
and document it in the README for contributors.

<details><summary>Agent Details</summary>

<pre><code>
    __( O)&gt;  ● new session · codex gpt-5.4
   \____)    20260310_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: &#34;/usr/local/bin/codex&#34;
Model: gpt-5.4
Reasoning effort: high
Skip git check: false
Prompt length: 2493 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Suggestion

The user has 7 extensions with 16 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
Consider asking if they&#39;d like to disable some extensions to improve tool selection accuracy.

# Response Guidelines

Use Markdown formatting for all responses.

Human: &lt;info-msg&gt;
It is currently 2026-03-10 20:23:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

&lt;/info-msg&gt;
# Rascal Run Instructions

Run ID: run_fe4c481f98280bd7
Task ID: rtzll/rascal#132
Repository: rtzll/rascal
Issue: #132

## Task

Add a single make verify target that matches local CI expectations

## Summary
CI already enforces a clear verification sequence: lint, tests, and generated-file cleanliness. Contributors do not currently have a single local command that mirrors that expectation.

Relevant files:
- `Makefile`
- `.github/workflows/ci.yml`
- potentially `README.md` and/or `CONTRIBUTING.md` if command docs need an update

## Goal
Add a `make verify` target that provides a one-shot local equivalent of the standard repo checks.

Expected behavior:
- run lint
- run tests
- verify generated files are committed or otherwise detect a dirty tree caused by code generation

Use the simplest implementation that is reliable in this repo.

## Acceptance Criteria
- `Makefile` includes a `verify` target
- Running `make verify` performs the main checks contributors are expected to run before opening a PR
- Docs mention `make verify` where appropriate
- CI remains green and no existing workflows regress

## Notes
Keep this tightly scoped to local developer ergonomics and consistency with CI.

## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run `make lint` and `make test` before finishing if those targets exist.
- If one of those commands does not exist or cannot run, explain exactly why and run the closest equivalent checks instead.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label &#39;rascal&#39; on issue #132


Assistant: 
Image files: 0
============================
{&#34;type&#34;:&#34;message&#34;,&#34;message&#34;:{&#34;id&#34;:null,&#34;role&#34;:&#34;assistant&#34;,&#34;created&#34;:1773175064,&#34;content&#34;:[{&#34;type&#34;:&#34;text&#34;,&#34;text&#34;:&#34;Inspecting the repo now to match `make verify` to the existing CI sequence and see whether docs need a small update.\n\nCI already uses `make lint`, `make test`, then `git diff --exit-code`; I’m checking where local developer commands are documented so the new target mirrors that without adding extra behavior.\n\nI have enough context. I’m adding a minimal `verify` target that preserves the current CI sequence exactly, then a short README note so contributors know to use it before opening a PR.\n\nThe code change is in place. I’m running the repo’s real checks now, then I’ll add the requested commit message file and confirm the tree state.\n\nBoth checks are still running through first-time dependency/codegen setup. I’m polling them to completion before I run the one-shot `make verify`.\n\nThe first pass is mostly dependency download time. I’m keeping both jobs running in parallel so I can verify the actual pass/fail state as soon as compilation finishes.\n\nThe commands are still busy without emitting new output, which usually means compilation or the linter install is in progress. I’m giving them a longer wait window before deciding whether anything is stuck.\n\nThe parallel run may be contending on shared Go/codegen state. I’m checking the active processes so I can finish verification reliably instead of waiting on a deadlock.\n\nThe slowdown is from running `sqlc` twice in parallel. I’m collapsing that to a single codegen/test path, then I’ll rerun lint sequentially so the results are still valid and easier to interpret.\n\n`make test` is still inside the `sqlc` codegen prerequisite after several minutes, so I’m checking whether it is actively compiling versus stalled. If it is just slow first-run setup, I’ll let it finish; otherwise I’ll note the repo-specific limitation clearly.\n\n`sqlc` completed and the test target has moved into `go test ./...`. It’s pulling additional module versions now, so I’m waiting for the final exit status before running lint and the new `verify` target.\n\n`make test` passed. I’m running `make lint` cleanly now, then `make verify` once to confirm the new target behaves end-to-end instead of just existing in the `Makefile`.\n\nI accidentally started `make lint` and `make verify` together, which duplicates the `codegen` prerequisite again. I’m stopping the composite run and finishing them sequentially to avoid another slow double-compile.\n\n`make lint` exposed an existing repo/environment issue: the installer reports success, but one invocation immediately failed with `/work/repo/bin/golangci-lint: not found`. I’m checking the installed artifact and the in-flight `make verify` result so I can distinguish a flaky race from a real toolchain problem.\n\n`make verify` is behaving as intended: lint and tests passed, then it failed on `git diff --exit-code` because the working tree contains the new uncommitted changes. I’m doing one clean standalone `make lint` pass as well so the requested individual checks are explicitly covered.\n\nThe check state is now clear: `make test` passed, standalone `make lint` passed, and `make verify` only fails because its final dirty-tree check correctly sees the current uncommitted edits. I’m writing the required commit message file and capturing the final diff context.\n\nThe current `verify` recipe is too literal: `git diff --exit-code` only works on CI’s clean checkout and would fail for any local uncommitted work. I’m adjusting it to compare the tree before and after the checks so it catches codegen-induced dirtiness without requiring a clean branch.\n\nThe `verify` target now preserves a dirty starting branch and only fails if the checks introduce new changes. I’m rerunning `make verify` to confirm that behavior end-to-end on the current working tree.\n\nAdded `make verify` in [Makefile](/work/repo/Makefile#L22) and documented it in [README.md](/work/repo/README.md#L81). The target now runs the same core checks as CI, but it compares `git status --porcelain` before and after the run so contributors can use it on a dirty local branch without getting a false failure from their own in-progress edits.\n\nValidation is complete: `make test`, `make lint`, and `make verify` all passed locally. I also wrote the requested commit message to [/rascal-meta/commit_message.txt](/rascal-meta/commit_message.txt).&#34;}],&#34;metadata&#34;:{&#34;userVisible&#34;:true,&#34;agentVisible&#34;:true}}}
{&#34;type&#34;:&#34;complete&#34;,&#34;total_tokens&#34;:825549}
</code></pre>

</details>

Closes #132

---

Rascal run `run_fe4c481f98280bd7` completed in 13m 56s · 825K tokens