### PR TITLE
build: make test-fast skip slow test packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 GOLANGCI_LINT_VERSION ?= v2.11.2
 GOLANGCI_LINT := $(CURDIR)/bin/golangci-lint
 GOLANGCI_LINT_CACHE := $(CURDIR)/tmp/golangci-lint-cache
+FAST_TEST_PACKAGE_FILTER := ^github.com/rtzll/rascal/(cmd/rascald|internal/deploy)$$
 
 .PHONY: test test-fast build build-cli build-daemon run-daemon run-cli fmt lint codegen
 
@@ -10,7 +11,9 @@ test: codegen
 	go test ./...
 
 test-fast:
-	go test ./...
+	# Fast contributor loop: skip the slower daemon/deploy integration-style suites.
+	# Use `make test` for full verification across every package.
+	go test $$(go list ./... | grep -vE '$(FAST_TEST_PACKAGE_FILTER)')
 
 fmt:
 	gofmt -w cmd internal


### PR DESCRIPTION
Make `test-fast` run a documented smoke subset that excludes the slower
daemon and deploy suites while keeping `make test` as the full verification
path.

<details><summary>Agent Details</summary>

<pre><code>
    __( O)&gt;  ● new session · codex gpt-5.4
   \____)    20260310_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: &#34;/usr/local/bin/codex&#34;
Model: gpt-5.4
Reasoning effort: high
Skip git check: false
Prompt length: 2583 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Suggestion

The user has 7 extensions with 16 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
Consider asking if they&#39;d like to disable some extensions to improve tool selection accuracy.

# Response Guidelines

Use Markdown formatting for all responses.

Human: &lt;info-msg&gt;
It is currently 2026-03-10 20:37:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

&lt;/info-msg&gt;
# Rascal Run Instructions

Run ID: run_025f57ec952deb0f
Task ID: rtzll/rascal#133
Repository: rtzll/rascal
Issue: #133

## Task

Make test-fast meaningfully faster than test

## Summary
The top-level Makefile defines both `test` and `test-fast`, but they currently run the same command: `go test ./...`. The name `test-fast` suggests a quicker contributor loop, but right now it provides no benefit.

Relevant file:
- `Makefile`

## Goal
Give `make test-fast` a distinct, intentionally faster behavior while keeping `make test` as the full verification path.

Possible approaches include:
- use `go test -short ./...` and update tests that should honor short mode
- run a narrower smoke subset if that is a better fit for this repo

Pick the simplest option that preserves confidence without turning this into a broad testing refactor.

## Acceptance Criteria
- `make test-fast` no longer duplicates `make test`
- The chosen semantics are documented in either the Makefile comments, `README.md`, or `CONTRIBUTING.md` if added as part of another change
- Any tests that should be skipped in short mode are updated intentionally
- `make test-fast`, `make test`, and `make lint` pass

## Notes
This issue is about developer ergonomics and CI parity, not about redesigning the entire test suite.

## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run `make lint` and `make test` before finishing if those targets exist.
- If one of those commands does not exist or cannot run, explain exactly why and run the closest equivalent checks instead.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label &#39;rascal&#39; on issue #133


Assistant: 
Image files: 0
============================
{&#34;type&#34;:&#34;message&#34;,&#34;message&#34;:{&#34;id&#34;:null,&#34;role&#34;:&#34;assistant&#34;,&#34;created&#34;:1773175660,&#34;content&#34;:[{&#34;type&#34;:&#34;text&#34;,&#34;text&#34;:&#34;I’m inspecting the repo first to see how `test`, `test-fast`, and `lint` are wired today, then I’ll make the smallest change that creates a real fast path without weakening the full test target.\n\nI found the current duplication in `Makefile`. Next I’m checking whether the repo already has obvious slow tests or existing `testing.Short()` hooks so `test-fast` can become a real contributor loop with a minimal change.\n\nThere’s no existing `testing.Short()` coverage. I’m measuring package-level test time now so I can skip only the expensive cases instead of turning `test-fast` into an arbitrary subset.\n\nDependency download is in progress on the first test run, so the initial timing will be noisier than steady state. I’m waiting for the full package timings, then I’ll target the expensive tests rather than guessing.\n\nThe baseline run is still active after dependency setup, which suggests there are some materially heavier packages here. I’m letting it finish once so the steady-state verification later is more reliable.\n\nI have the slow packages narrowed down. I’m collecting per-test timings from those packages now so the short-mode skips stay surgical rather than broad.\n\nI have two viable paths now. The minimal one is a smoke subset in `test-fast` that excludes the two slow integration-leaning packages (`cmd/rascald` and `internal/deploy`), which cuts runtime materially without refactoring tests; I’m checking the docs to see the cleanest place to document that semantics.\n\nI’m editing the `Makefile` now. The change will keep `make test` as the full repo-wide verification path and turn `make test-fast` into a smoke run that skips the two slower integration-leaning packages, with the semantics documented inline.\n\nThe first timing attempt failed because this environment doesn’t have `/usr/bin/time`. I’m rerunning with the shell builtin so I can confirm the fast path is actually faster, then I’ll do the required full checks.\n\n`make test-fast` completed successfully. It’s already noticeably below the earlier full-path runtime, but `make test` has to warm the codegen dependency first in this environment, so I’m letting that settle before I compare the steady-state numbers.\n\n`make test` is still in the one-time `sqlc` tool bootstrap path. That’s outside the `test-fast` change itself, but I need the command to complete because it’s part of the task’s acceptance checks.\n\nThe required full test run passed. I’m doing one more steady-state `make test` now, after the one-time tool bootstrap, so the final report can distinguish the actual recurring test cost from the initial dependency install.\n\n`make lint` is in the first-run linter install and analysis path. I’m waiting for the full result so I can close this with the actual verification status rather than assumptions.\n\nThe code change is complete and verified. I’m writing the requested conventional commit message file now, then I’ll summarize the exact behavior change and the command results.\n\nUpdated [Makefile](/work/repo/Makefile) so `make test-fast` no longer duplicates `make test`. It now runs a documented smoke subset by excluding `github.com/rtzll/rascal/cmd/rascald` and `github.com/rtzll/rascal/internal/deploy`, while `make test` remains the full repo-wide verification path. I used the smoke-subset approach instead of `go test -short`, so no test files needed changes.\n\nVerification passed:\n- `make test-fast`\n- `make test`\n- `make lint`\n\nOn a warm cache here, `make test-fast` finished in about `5.0s` and steady-state `make test` in about `6.2s`; the first full run was much longer because it had to bootstrap `sqlc`. I also wrote the requested commit message to [commit_message.txt](/rascal-meta/commit_message.txt).&#34;}],&#34;metadata&#34;:{&#34;userVisible&#34;:true,&#34;agentVisible&#34;:true}}}
{&#34;type&#34;:&#34;complete&#34;,&#34;total_tokens&#34;:1374630}
</code></pre>

</details>

Closes #133

---

Rascal run `run_025f57ec952deb0f` completed in 9m 49s · 1.37M tokens