### PR TITLE
fix(runner): run real lightweight verify targets

### DIFF
--- a/cmd/rascal-runner/main.go
+++ b/cmd/rascal-runner/main.go
@@ -37,8 +37,9 @@ const (
 )
 
 var (
-	convCommitPattern = regexp.MustCompile(`^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9._/-]+\))?(!)?:[[:space:]].+`)
-	prURLPattern      = regexp.MustCompile(`https://github\.com/[^[:space:]]+/pull/[0-9]+`)
+	convCommitPattern       = regexp.MustCompile(`^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9._/-]+\))?(!)?:[[:space:]].+`)
+	makeSimpleTargetPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
+	prURLPattern            = regexp.MustCompile(`https://github\.com/[^[:space:]]+/pull/[0-9]+`)
 
 	buildVersion = "dev"
 	buildCommit  = "unknown"
@@ -89,6 +90,12 @@ type prView struct {
 
 type gooseSessionInfo struct {
 	Name string `json:"name"`
+}
+
+type verifyPlan struct {
+	Command []string
+	Message string
+	Status  string
 }
 
 type commandExecutor interface {
@@ -250,16 +257,10 @@ func runWithExecutor(ex commandExecutor) error {
 		return fail(err)
 	}
 
-	if _, statErr := os.Stat(filepath.Join(cfg.RepoDir, "Makefile")); statErr == nil {
-		if err := runStage("verify", func() error {
-			log.Printf("[%s] running lightweight verify: make -n test", nowUTC())
-			if _, err := runCommand(ex, cfg.RepoDir, nil, "make", "-n", "test"); err != nil {
-				return fmt.Errorf("preview make test target: %w", err)
-			}
-			return nil
-		}); err != nil {
-			log.Printf("[%s] lightweight verify warning: %v", nowUTC(), err)
-		}
+	if err := runStage("verify", func() error {
+		return runLightweightVerify(ex, cfg)
+	}); err != nil {
+		log.Printf("[%s] lightweight verify warning: %v", nowUTC(), err)
 	}
 
 	commitTitle := fmt.Sprintf("chore(rascal): %s", taskSubject(cfg.Task, cfg.TaskID))
@@ -682,6 +683,111 @@ func checkoutRepo(ex commandExecutor, cfg config) error {
 		return fmt.Errorf("create head branch %s: %w", cfg.HeadBranch, err)
 	}
 	return nil
+}
+
+func runLightweightVerify(ex commandExecutor, cfg config) error {
+	plan, err := planLightweightVerify(cfg.RepoDir)
+	if err != nil {
+		return fmt.Errorf("plan lightweight verify: %w", err)
+	}
+
+	switch plan.Status {
+	case "execute":
+		log.Printf("[%s] lightweight verify executing command=%s", nowUTC(), strings.Join(plan.Command, " "))
+		if len(plan.Command) == 0 {
+			return fmt.Errorf("lightweight verify plan missing command")
+		}
+		if _, err := runCommand(ex, cfg.RepoDir, nil, plan.Command[0], plan.Command[1:]...); err != nil {
+			return fmt.Errorf("run lightweight verify command: %w", err)
+		}
+	case "fallback":
+		log.Printf("[%s] lightweight verify fallback command=%s reason=%s", nowUTC(), strings.Join(plan.Command, " "), plan.Message)
+		if len(plan.Command) == 0 {
+			return fmt.Errorf("lightweight verify fallback plan missing command")
+		}
+		if _, err := runCommand(ex, cfg.RepoDir, nil, plan.Command[0], plan.Command[1:]...); err != nil {
+			return fmt.Errorf("run lightweight verify fallback: %w", err)
+		}
+	default:
+		log.Printf("[%s] lightweight verify skipped: %s", nowUTC(), plan.Message)
+	}
+
+	return nil
+}
+
+func planLightweightVerify(repoDir string) (verifyPlan, error) {
+	makefilePath := filepath.Join(repoDir, "Makefile")
+	if _, err := os.Stat(makefilePath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return verifyPlan{
+				Message: "Makefile not found",
+				Status:  "skip",
+			}, nil
+		}
+		return verifyPlan{}, fmt.Errorf("stat Makefile: %w", err)
+	}
+
+	targets, err := loadMakeTargets(makefilePath)
+	if err != nil {
+		return verifyPlan{}, fmt.Errorf("load Makefile targets: %w", err)
+	}
+
+	if targets["test-fast"] {
+		return verifyPlan{
+			Command: []string{"make", "test-fast"},
+			Message: "executing lightweight verify target test-fast",
+			Status:  "execute",
+		}, nil
+	}
+	if targets["test"] {
+		return verifyPlan{
+			Message: "Makefile defines test but not test-fast; skipping lightweight verify fallback",
+			Status:  "skip",
+		}, nil
+	}
+
+	return verifyPlan{
+		Message: "Makefile has no test-fast or test target",
+		Status:  "skip",
+	}, nil
+}
+
+func loadMakeTargets(path string) (_ map[string]bool, err error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open Makefile: %w", err)
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close Makefile: %w", closeErr)
+		}
+	}()
+
+	targets := make(map[string]bool)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimSpace(line) == "" || strings.HasPrefix(line, "\t") || strings.HasPrefix(line, " ") {
+			continue
+		}
+		colon := strings.IndexByte(line, ':')
+		if colon <= 0 {
+			continue
+		}
+		suffix := line[colon+1:]
+		if strings.HasPrefix(suffix, "=") || strings.HasPrefix(suffix, ":=") {
+			continue
+		}
+		for _, target := range strings.Fields(strings.TrimSpace(line[:colon])) {
+			if makeSimpleTargetPattern.MatchString(target) {
+				targets[target] = true
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan Makefile: %w", err)
+	}
+	return targets, nil
 }
 
 func runAgent(ex commandExecutor, cfg config) (string, string, error) {

--- a/cmd/rascal-runner/main_test.go
+++ b/cmd/rascal-runner/main_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -145,6 +147,106 @@ func TestLoadAgentCommitMessage(t *testing.T) {
 		wantBody := "- move entrypoint logic\n- add tests"
 		if body != wantBody {
 			t.Fatalf("unexpected body: got %q want %q", body, wantBody)
+		}
+	})
+}
+
+func TestPlanLightweightVerify(t *testing.T) {
+	t.Run("executes test-fast when available", func(t *testing.T) {
+		repoDir := t.TempDir()
+		writeMakefile(t, repoDir, ".PHONY: test-fast test\n\ntest-fast:\n\t@echo fast\n\ntest:\n\t@echo full\n")
+
+		plan, err := planLightweightVerify(repoDir)
+		if err != nil {
+			t.Fatalf("planLightweightVerify returned error: %v", err)
+		}
+		if plan.Status != "execute" {
+			t.Fatalf("status = %q, want execute", plan.Status)
+		}
+		if got := strings.Join(plan.Command, " "); got != "make test-fast" {
+			t.Fatalf("command = %q, want %q", got, "make test-fast")
+		}
+	})
+
+	t.Run("skips when Makefile only has test target", func(t *testing.T) {
+		repoDir := t.TempDir()
+		writeMakefile(t, repoDir, ".PHONY: test\n\ntest:\n\t@echo full\n")
+
+		plan, err := planLightweightVerify(repoDir)
+		if err != nil {
+			t.Fatalf("planLightweightVerify returned error: %v", err)
+		}
+		if plan.Status != "skip" {
+			t.Fatalf("status = %q, want skip", plan.Status)
+		}
+		if !strings.Contains(plan.Message, "defines test but not test-fast") {
+			t.Fatalf("unexpected message: %q", plan.Message)
+		}
+	})
+
+	t.Run("skips when Makefile is missing", func(t *testing.T) {
+		plan, err := planLightweightVerify(t.TempDir())
+		if err != nil {
+			t.Fatalf("planLightweightVerify returned error: %v", err)
+		}
+		if plan.Status != "skip" {
+			t.Fatalf("status = %q, want skip", plan.Status)
+		}
+		if plan.Message != "Makefile not found" {
+			t.Fatalf("message = %q, want %q", plan.Message, "Makefile not found")
+		}
+	})
+}
+
+func TestRunLightweightVerify(t *testing.T) {
+	t.Run("runs make test-fast", func(t *testing.T) {
+		repoDir := t.TempDir()
+		writeMakefile(t, repoDir, ".PHONY: test-fast\n\ntest-fast:\n\t@echo fast\n")
+
+		var calls []string
+		ex := fakeExecutor{
+			combinedFn: func(dir string, _ []string, name string, args ...string) (string, error) {
+				calls = append(calls, strings.Join(append([]string{name}, args...), " "))
+				if dir != repoDir {
+					t.Fatalf("dir = %q, want %q", dir, repoDir)
+				}
+				return "ok", nil
+			},
+		}
+
+		logs := captureLogs(t, func() {
+			if err := runLightweightVerify(ex, config{RepoDir: repoDir}); err != nil {
+				t.Fatalf("runLightweightVerify returned error: %v", err)
+			}
+		})
+
+		if len(calls) != 1 || calls[0] != "make test-fast" {
+			t.Fatalf("calls = %#v, want [make test-fast]", calls)
+		}
+		if !strings.Contains(logs, "lightweight verify executing command=make test-fast") {
+			t.Fatalf("expected execute log, got %q", logs)
+		}
+	})
+
+	t.Run("skips when only test target exists", func(t *testing.T) {
+		repoDir := t.TempDir()
+		writeMakefile(t, repoDir, ".PHONY: test\n\ntest:\n\t@echo full\n")
+
+		ex := fakeExecutor{
+			combinedFn: func(_ string, _ []string, name string, args ...string) (string, error) {
+				t.Fatalf("did not expect command execution: %s %v", name, args)
+				return "", nil
+			},
+		}
+
+		logs := captureLogs(t, func() {
+			if err := runLightweightVerify(ex, config{RepoDir: repoDir}); err != nil {
+				t.Fatalf("runLightweightVerify returned error: %v", err)
+			}
+		})
+
+		if !strings.Contains(logs, "lightweight verify skipped: Makefile defines test but not test-fast; skipping lightweight verify fallback") {
+			t.Fatalf("expected skip log, got %q", logs)
 		}
 	})
 }
@@ -1263,4 +1365,26 @@ func writeExe(t *testing.T, path, content string) {
 	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
 		t.Fatalf("write executable %s: %v", path, err)
 	}
+}
+
+func writeMakefile(t *testing.T, repoDir, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(repoDir, "Makefile"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write Makefile: %v", err)
+	}
+}
+
+func captureLogs(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	originalWriter := log.Writer()
+	originalFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(originalWriter)
+		log.SetFlags(originalFlags)
+	})
+	fn()
+	return buf.String()
 }


### PR DESCRIPTION
Switch rascal-runner verify from `make -n test` to real target selection.
Run `make test-fast` when available, otherwise skip with explicit logs instead
of implying verification ran when only previewed.

<details><summary>Agent Details</summary>

<pre><code>
    __( O)&gt;  ● new session · codex gpt-5.4
   \____)    20260310_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: &#34;/usr/local/bin/codex&#34;
Model: gpt-5.4
Reasoning effort: high
Skip git check: false
Prompt length: 2883 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Suggestion

The user has 7 extensions with 16 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
Consider asking if they&#39;d like to disable some extensions to improve tool selection accuracy.

# Response Guidelines

Use Markdown formatting for all responses.

Human: &lt;info-msg&gt;
It is currently 2026-03-10 20:38:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

&lt;/info-msg&gt;
# Rascal Run Instructions

Run ID: run_d5c9036e6c988446
Task ID: rtzll/rascal#135
Repository: rtzll/rascal
Issue: #135

## Task

Make rascal-runner verify stage execute a real fast verification

## Summary
The runner currently records a `verify` stage, but it only previews the repo test target with `make -n test` instead of executing any verification. That gives a false sense of safety for Rascal-generated PRs.

Current implementation:
- `cmd/rascal-runner/main.go` around the existing `runStage(&#34;verify&#34;, ...)` block
- It logs `running lightweight verify: make -n test` and then runs `make -n test`

## Goal
Change the runner so the verify stage performs a real lightweight verification when the target repo supports it.

Preferred behavior:
- If the repo has a `Makefile` and a `test-fast` target, run `make test-fast`
- Otherwise, if the repo has a `test` target and there is no `test-fast`, either run a clearly intentional lightweight fallback or skip with an explicit log message
- Do not fail the whole run just because the lightweight verify step is unavailable; keep the current warning-only posture unless there is a strong reason to tighten it

## Acceptance Criteria
- The verify stage no longer uses `make -n test` as its primary behavior
- Runner logs make it obvious whether verification was executed, skipped, or downgraded to a fallback
- Existing tests are updated or expanded to cover the new behavior
- `make lint` and `make test` pass in this repo

## Notes
Keep the implementation scoped to the runner behavior and its tests. This should be a single focused change.

## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run `make lint` and `make test` before finishing if those targets exist.
- If one of those commands does not exist or cannot run, explain exactly why and run the closest equivalent checks instead.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label &#39;rascal&#39; on issue #135


Assistant: 
Image files: 0
============================
{&#34;type&#34;:&#34;message&#34;,&#34;message&#34;:{&#34;id&#34;:null,&#34;role&#34;:&#34;assistant&#34;,&#34;created&#34;:1773176099,&#34;content&#34;:[{&#34;type&#34;:&#34;text&#34;,&#34;text&#34;:&#34;Inspecting the runner and its tests first, then I’ll patch the verify-stage behavior, add coverage for the new branch logic, and finish by running the repo’s lint and test targets.\n\nThe current verify path is exactly the preview-only `make -n test` branch in `cmd/rascal-runner/main.go`. I’m reading that code and the existing runner tests now to keep the change scoped and align with the current stage/logging patterns.\n\nI found an end-to-end runner test with fake `git`, `gh`, and `goose` binaries. I’m using that pattern rather than inventing new seams, so the verify-stage change stays in the existing test style and validates the actual command selection/logging behavior.\n\nI’ve narrowed the decision point: `test-fast` should be the only automatic real verify target, and the non-`test-fast` paths need to stay warning-only. I’m checking repo instructions and test affordances before editing so the fallback/skip behavior is deliberate rather than implicit.\n\nI have the change scoped: introduce a small verify planner/helper, wire the `verify` stage through it, and cover the execution and skip branches directly in runner tests. I’m patching `cmd/rascal-runner/main.go` and `cmd/rascal-runner/main_test.go` now.\n\nThe edit is in place. I’m checking the new helper/test code for any parser or logging edge cases, then I’ll run `gofmt`, targeted tests, and finally the repo-wide `make lint` / `make test`.\n\nThe helper and tests look coherent. I’m formatting the runner files and running the runner test package first so any failures stay local before I spend time on the repo-wide targets.\n\nThe runner package test process is still active, so I’m polling it rather than assuming success. If it stalls, I’ll isolate the failing test subset next.\n\nThe failure is a Go `regexp` issue: I used a negative lookahead, which RE2 doesn’t support. I’m replacing that with simpler Makefile parsing logic now and rerunning the same test package immediately after.\n\nThe runner package now passes. I’m running the repo-level `make lint` and `make test` next, because those are explicit acceptance checks and may surface unrelated integration issues beyond the runner package.\n\nBoth repo-wide targets are running and downloading their toolchain dependencies. I’m letting them complete, then I’ll inspect any lint/test failures before writing the commit message file.\n\nThe repo-wide targets are still active but quiet now, which usually means they’re in compilation/test execution rather than download/setup. I’m continuing to poll them rather than restarting and losing the state.\n\n`make lint` and `make test` are both still sitting in the `sqlc` codegen bootstrap, not hung idle; the child `go run ... sqlc generate` processes are still consuming CPU. I’m giving that setup step more time rather than forcing a retry that would just restart the same download/build work.\n\nThe validation step is taking materially longer than the code change itself because both make targets start with `sqlc` generation and are still compiling that toolchain. I’m staying on it until they either finish or produce a concrete failure to report.\n\nThe two repo-wide validations are not making useful forward progress in parallel; they’re both pinned in the same `sqlc` bootstrap path. I’m stopping those duplicate runs and rerunning the checks sequentially so the module/tool download path only happens once.\n\n`make lint` got past codegen and installed `golangci-lint`; it’s now in the actual lint pass. I’m waiting for that to return before starting `make test` so the validation signal is clean and attributable.\n\nLint surfaced one real issue in the new helper: `errcheck` requires the Makefile close path to be handled. I’m fixing that directly, then I’ll rerun lint and continue to `make test`.\n\n`make lint` is clean now. `make test` has moved past codegen and is in the full `go test ./...` pass; I’m waiting on that final repo-wide result before closing out.\n\nRepo-wide validation is complete: `make lint` passed and `make test` passed. I’m writing the requested conventional commit message file and then I’ll summarize the behavioral change and validation results.\n\nChanged the verify stage so it always goes through a real lightweight verify decision instead of `make -n test`. In [main.go](/work/repo/cmd/rascal-runner/main.go#L260), the runner now enters `verify` unconditionally, uses [runLightweightVerify](/work/repo/cmd/rascal-runner/main.go#L688) and [planLightweightVerify](/work/repo/cmd/rascal-runner/main.go#L718), runs `make test-fast` when that target exists, and otherwise logs an explicit skip reason. The old preview-only behavior is gone.\n\nAdded runner tests in [main_test.go](/work/repo/cmd/rascal-runner/main_test.go#L154) covering the planner and execution/logging paths for `test-fast`, `test`-only, and missing-`Makefile` repos. Wrote the requested commit message to [commit_message.txt](/rascal-meta/commit_message.txt#L1).\n\nValidation passed: `go test ./cmd/rascal-runner`, `make lint`, and `make test`.&#34;}],&#34;metadata&#34;:{&#34;userVisible&#34;:true,&#34;agentVisible&#34;:true}}}
{&#34;type&#34;:&#34;complete&#34;,&#34;total_tokens&#34;:2781319}
</code></pre>

</details>

Closes #135

---

Rascal run `run_d5c9036e6c988446` completed in 17m 5s · 2.78M tokens