### PR TITLE
test: add coverage for agent and log tail helpers

### DIFF
--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1,0 +1,123 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeBackend(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want Backend
+	}{
+		{name: "default empty", in: "", want: BackendCodex},
+		{name: "default unknown", in: "other", want: BackendCodex},
+		{name: "codex explicit", in: " codex ", want: BackendCodex},
+		{name: "goose explicit", in: "GOOSE", want: BackendGoose},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := NormalizeBackend(tt.in); got != tt.want {
+				t.Fatalf("NormalizeBackend(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeSessionMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want SessionMode
+	}{
+		{name: "default empty", in: "", want: SessionModeOff},
+		{name: "default unknown", in: "sometimes", want: SessionModeOff},
+		{name: "pr only", in: " PR-ONLY ", want: SessionModePROnly},
+		{name: "all", in: "all", want: SessionModeAll},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := NormalizeSessionMode(tt.in); got != tt.want {
+				t.Fatalf("NormalizeSessionMode(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSessionEnabled(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mode    SessionMode
+		trigger string
+		want    bool
+	}{
+		{name: "off mode", mode: SessionModeOff, trigger: "pr_comment", want: false},
+		{name: "all mode", mode: SessionModeAll, trigger: "issue_label", want: true},
+		{name: "pr only supported trigger", mode: SessionModePROnly, trigger: "pr_review_comment", want: true},
+		{name: "pr only retry trigger", mode: SessionModePROnly, trigger: "retry", want: true},
+		{name: "pr only trimmed unsupported trigger", mode: SessionModePROnly, trigger: " issue_label ", want: false},
+		{name: "unknown mode defaults off", mode: SessionMode("custom"), trigger: "pr_comment", want: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := SessionEnabled(tt.mode, tt.trigger); got != tt.want {
+				t.Fatalf("SessionEnabled(%q, %q) = %t, want %t", tt.mode, tt.trigger, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSessionTaskKeyStableAndSanitized(t *testing.T) {
+	t.Parallel()
+
+	keyA := SessionTaskKey(" Owner/Repo ", " issue#123 ")
+	keyB := SessionTaskKey("Owner/Repo", "issue#123")
+	keyC := SessionTaskKey("Owner/Repo", "issue#124")
+
+	if keyA != keyB {
+		t.Fatalf("expected trimmed inputs to produce a stable key, got %q vs %q", keyA, keyB)
+	}
+	if keyA == keyC {
+		t.Fatalf("expected distinct task IDs to produce different keys, got %q", keyA)
+	}
+	if !strings.HasPrefix(keyA, "owner-repo-issue-123-") {
+		t.Fatalf("expected sanitized prefix, got %q", keyA)
+	}
+	if len(keyA) > 56 {
+		t.Fatalf("expected bounded key length <= 56, got %d", len(keyA))
+	}
+	for _, ch := range keyA {
+		if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '-' {
+			continue
+		}
+		t.Fatalf("unexpected key character %q in %q", ch, keyA)
+	}
+}
+
+func TestSessionTaskKeyFallsBackWhenSlugIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	key := SessionTaskKey("!!!", "***")
+	if !strings.HasPrefix(key, "task-") {
+		t.Fatalf("expected empty slug fallback, got %q", key)
+	}
+}

--- a/internal/logs/tail_test.go
+++ b/internal/logs/tail_test.go
@@ -1,0 +1,82 @@
+package logs
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestTail(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		content  string
+		maxLines int
+		want     []string
+	}{
+		{
+			name:     "empty file",
+			content:  "",
+			maxLines: 5,
+			want:     []string{},
+		},
+		{
+			name:     "fewer lines than requested",
+			content:  "one\ntwo\n",
+			maxLines: 5,
+			want:     []string{"one", "two"},
+		},
+		{
+			name:     "more lines than requested",
+			content:  "one\ntwo\nthree\nfour\n",
+			maxLines: 2,
+			want:     []string{"three", "four"},
+		},
+		{
+			name:     "non positive maxLines uses default",
+			content:  "one\ntwo\n",
+			maxLines: 0,
+			want:     []string{"one", "two"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(t.TempDir(), "rascal.log")
+			if err := os.WriteFile(path, []byte(tt.content), 0o600); err != nil {
+				t.Fatalf("write log file: %v", err)
+			}
+
+			got, err := Tail(path, tt.maxLines)
+			if err != nil {
+				t.Fatalf("Tail(%q, %d) error = %v", path, tt.maxLines, err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("Tail(%q, %d) = %#v, want %#v", path, tt.maxLines, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTailInvalidPath(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "missing.log")
+	_, err := Tail(path, 10)
+	if err == nil {
+		t.Fatal("expected error for missing path")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected os.ErrNotExist, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "open log file") {
+		t.Fatalf("expected wrapped open log file error, got %v", err)
+	}
+}


### PR DESCRIPTION
Add focused unit tests for internal/agent normalization and session helper
behavior, plus internal/logs Tail edge cases and invalid path handling.

<details><summary>Agent Details</summary>

<pre><code>
    __( O)&gt;  ● new session · codex gpt-5.4
   \____)    20260310_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: &#34;/usr/local/bin/codex&#34;
Model: gpt-5.4
Reasoning effort: high
Skip git check: false
Prompt length: 2589 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Suggestion

The user has 7 extensions with 16 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
Consider asking if they&#39;d like to disable some extensions to improve tool selection accuracy.

# Response Guidelines

Use Markdown formatting for all responses.

Human: &lt;info-msg&gt;
It is currently 2026-03-10 20:55:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

&lt;/info-msg&gt;
# Rascal Run Instructions

Run ID: run_a0baccfa871851e5
Task ID: rtzll/rascal#131
Repository: rtzll/rascal
Issue: #131

## Task

Add focused unit tests for internal agent and log tail helpers

## Summary
Two small but central utility packages have no direct tests today: `internal/agent` and `internal/logs`. They contain behavior that is easy to lock down cheaply and would improve confidence in core orchestration paths.

Relevant files:
- `internal/agent/agent.go`
- `internal/logs/tail.go`

## Goal
Add targeted unit tests for these helpers without expanding scope into unrelated refactors.

Suggested coverage:
- `NormalizeBackend` default and explicit cases
- `NormalizeSessionMode` behavior
- `SessionEnabled` trigger handling for supported and unsupported triggers
- `SessionTaskKey` stability/sanitization behavior
- `logs.Tail` behavior for empty files, fewer lines than requested, more lines than requested, and invalid paths

## Acceptance Criteria
- New tests exist for `internal/agent`
- New tests exist for `internal/logs`
- The tests are table-driven where that improves readability
- Coverage increases for these packages from zero
- `make test` and `make lint` pass

## Notes
This should stay small. The goal is to protect important helper behavior, not to redesign the packages.

## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run `make lint` and `make test` before finishing if those targets exist.
- If one of those commands does not exist or cannot run, explain exactly why and run the closest equivalent checks instead.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label &#39;rascal&#39; on issue #131


Assistant: 
Image files: 0
============================
{&#34;type&#34;:&#34;message&#34;,&#34;message&#34;:{&#34;id&#34;:null,&#34;role&#34;:&#34;assistant&#34;,&#34;created&#34;:1773176712,&#34;content&#34;:[{&#34;type&#34;:&#34;text&#34;,&#34;text&#34;:&#34;I’m scoping the two helper packages, adding only the requested tests, and I’m recording the concrete requirements first so execution stays tight.\n\nI’m reading the helper implementations and nearby test conventions now so the new coverage matches the repo’s style and stays minimal.\n\nThe helpers are small and isolated. I’m checking a couple of existing tests for style, then I’ll add focused table-driven cases and keep assertions straightforward.\n\nI have the coverage shape. Next I’m adding direct package tests for the agent helpers and the log tail reader, using table-driven cases where they sharpen the intent.\n\nThe agent coverage is in place. I’m adding the log tail cases next, including missing path handling and the line-window behavior at each edge.\n\nThe new tests are written. I’m running focused verification first to catch any mechanical issues before the full lint and test targets.\n\nThe focused tests are still running. If they stay clean, I’ll move directly to the repository-wide `make lint` and `make test` targets next.\n\nThe targeted `go test` invocation is taking longer than expected, likely on first-build/cache population rather than the new cases themselves. I’m waiting it through before widening the checks.\n\nThe focused package tests passed. I’m running the requested repository-wide lint and test targets now, then I’ll write the commit message file and do a final diff check.\n\n`make lint` and `make test` both started with `codegen`, so there’s some initial dependency download/build overhead. I’m monitoring both and will call out any failures precisely if they surface.\n\nThe first full-run pass is still in dependency/bootstrap territory. Once that settles, the actual lint and test execution should be much shorter.\n\n`sqlc` is still building under both targets. I’m keeping the runs live rather than restarting them, since the expensive part appears shared and already underway.\n\nThe full checks are still active with no failures emitted so far. I’m giving them a bit more runway rather than interrupting codegen/build state mid-flight.\n\n`make test` has moved past codegen and into a fresh dependency resolution for the broader repo. I’m waiting for `make lint` to clear the same bootstrap phase and then for both targets to complete.\n\n`make test` passed. I’m waiting on `make lint` to finish the analyzer run, then I’ll capture the final diff and write the conventional commit message file.\n\nThe requested validation is clean. I’m checking the final workspace diff now to confirm only the scoped test additions remain, then I’ll write the commit message artifact.\n\nAdded focused unit tests in [internal/agent/agent_test.go](/work/repo/internal/agent/agent_test.go) and [internal/logs/tail_test.go](/work/repo/internal/logs/tail_test.go). The agent tests cover backend normalization, session mode normalization, supported and unsupported session triggers, stable/sanitized session task keys, and the empty-slug fallback. The logs tests cover empty files, shorter-than-requested tails, longer-than-requested tails, default behavior for non-positive limits, and invalid-path errors.\n\nVerification is clean: `go test ./internal/agent ./internal/logs`, `make test`, and `make lint` all passed. I also wrote the requested commit message to [commit_message.txt](/rascal-meta/commit_message.txt).&#34;}],&#34;metadata&#34;:{&#34;userVisible&#34;:true,&#34;agentVisible&#34;:true}}}
{&#34;type&#34;:&#34;complete&#34;,&#34;total_tokens&#34;:720636}
</code></pre>

</details>

Closes #131

---

Rascal run `run_a0baccfa871851e5` completed in 10m 2s · 720K tokens