### PR TITLE
fix(deploy): forward repository API write methods through caddy

### DIFF
--- a/internal/deploy/assets/Caddyfile.tmpl
+++ b/internal/deploy/assets/Caddyfile.tmpl
@@ -22,6 +22,14 @@
     import /etc/caddy/rascal-upstream.caddy
   }
 
+  @allowed_repository_api {
+    method GET POST PATCH PUT DELETE
+    path /v1/repositories /v1/repositories/*
+  }
+  handle @allowed_repository_api {
+    import /etc/caddy/rascal-upstream.caddy
+  }
+
   @allowed_webhook {
     method POST
     path /v1/webhooks/github

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -80,6 +80,7 @@ func TestRenderCaddyfileVariants(t *testing.T) {
 	for _, want := range []string{
 		"@allowed_health",
 		"@allowed_api",
+		"@allowed_repository_api",
 		"@allowed_webhook",
 		"path /v1/webhooks/github",
 		"header X-GitHub-Event *",
@@ -93,6 +94,25 @@ func TestRenderCaddyfileVariants(t *testing.T) {
 		if !strings.Contains(domain, want) {
 			t.Fatalf("domain caddyfile missing %q:\n%s", want, domain)
 		}
+	}
+}
+
+func TestRenderCaddyfileAllowsRepositoryWriteMethods(t *testing.T) {
+	rendered, err := renderCaddyfile("")
+	if err != nil {
+		t.Fatalf("render caddyfile: %v", err)
+	}
+
+	wantBlock := strings.TrimSpace(`
+@allowed_repository_api {
+    method GET POST PATCH PUT DELETE
+    path /v1/repositories /v1/repositories/*
+  }
+  handle @allowed_repository_api {
+    import /etc/caddy/rascal-upstream.caddy
+  }`)
+	if !strings.Contains(rendered, wantBlock) {
+		t.Fatalf("repository API matcher missing required methods or paths:\n%s", rendered)
 	}
 }
 


### PR DESCRIPTION
Add a dedicated Caddy matcher for `/v1/repositories` so PATCH, PUT, and DELETE
requests reach rascald without widening the existing runs/tasks route policy.
Cover the repository API allowlist in deploy tests to prevent regressions.

<details><summary>Agent Details</summary>

<pre><code>
    __( O)&gt;  ● new session · codex gpt-5.4
   \____)    20260310_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: &#34;/usr/local/bin/codex&#34;
Model: gpt-5.4
Reasoning effort: high
Skip git check: false
Prompt length: 2453 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Suggestion

The user has 7 extensions with 16 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
Consider asking if they&#39;d like to disable some extensions to improve tool selection accuracy.

# Response Guidelines

Use Markdown formatting for all responses.

Human: &lt;info-msg&gt;
It is currently 2026-03-10 21:14:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

&lt;/info-msg&gt;
# Rascal Run Instructions

Run ID: run_bc1841e7d35af339
Task ID: rtzll/rascal#139
Repository: rtzll/rascal
Issue: #139

## Task

Forward repository management verbs through Caddy

## Problem
The shipped Caddy config only forwards `GET` and `POST` API requests to `rascald`. The multirepo registry adds write endpoints that require `PATCH`, `PUT`, and `DELETE`, so repository management commands fail on deployed instances behind Caddy even though the server supports them.

Affected operations:
- `PATCH /v1/repositories/{repo}`
- `DELETE /v1/repositories/{repo}`
- `PUT /v1/repositories/{repo}/roles/{user}`
- `DELETE /v1/repositories/{repo}/roles/{user}`

## Outcome
Repository registry write operations work through the standard deployed HTTP entrypoint, not just via direct localhost access.

## Acceptance Criteria
- `internal/deploy/assets/Caddyfile.tmpl` forwards the HTTP methods needed by repository registry write endpoints.
- `rascal repo update`, `rascal repo remove`, `rascal repo grant`, and `rascal repo revoke` succeed when routed through Caddy.
- A regression test or deploy-level verification covers the allowed-method set for repository APIs.

## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run `make lint` and `make test` before finishing if those targets exist.
- If one of those commands does not exist or cannot run, explain exactly why and run the closest equivalent checks instead.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label &#39;rascal&#39; on issue #139


Assistant: 
Image files: 0
============================
{&#34;type&#34;:&#34;message&#34;,&#34;message&#34;:{&#34;id&#34;:null,&#34;role&#34;:&#34;assistant&#34;,&#34;created&#34;:1773177765,&#34;content&#34;:[{&#34;type&#34;:&#34;text&#34;,&#34;text&#34;:&#34;I’m inspecting the deploy config and test surface first so I can make the smallest change that forwards the missing repository-management verbs and add coverage for the allowed method set.\n\nI found the Caddy template restriction: `/v1/*` only allows `GET POST`, so the repository write routes are definitely blocked at the proxy layer. I’m checking existing deploy tests now to add coverage in the same layer instead of inventing a new harness.\n\nI’m not finding repository-registry client code yet, which suggests the CLI tests for those verbs may not exist in this checkout. The deploy-side acceptance still points cleanly at the Caddy method gate, so I’m tracing the embedded routing tests and server handlers to confirm the exact path shape before patching.\n\nI have enough context to patch this cleanly. The repo checkout doesn’t appear to include the newer repository-registry CLI/server code the issue text references, so I’m constraining the change to the deploy layer and adding deploy-level regression coverage that proves Caddy will pass the required verbs for `/v1/repositories...` without widening the existing run/task routes.\n\nI’m editing the Caddy template now to add a dedicated repository API matcher, then I’ll tighten `deploy_test.go` around that specific block so the allowed verb set can’t regress silently.\n\nThe patch is in. I’ve kicked off a focused `go test ./internal/deploy` first to catch any template/test issues before running the full `make lint` and `make test` required by the task.\n\nThe focused deploy tests pass. Next I’m running the required repo-wide checks from the issue constraints: `make lint` and `make test`, then I’ll write the conventional commit message file.\n\n`make lint` is still in progress; it’s pulling toolchain dependencies and generating code before linting. Once that clears, I’ll run the full test suite and only then close out with the exact verification status.\n\nThe slow part is `sqlc generate`, not the Caddy change. It’s still active under `make lint`, so I’m letting the required check finish rather than short-circuiting it and guessing at status.\n\n`golangci-lint` is now the active step. There’s no failure output so far, just a long first run against a cold cache. After that finishes I’ll run `make test` and write the commit message file.\n\nThe full required checks passed. I’m writing the conventional commit message file now, then I’ll do a quick diff/status pass and close with the exact files changed and what the regression test covers.\n\nAdded a dedicated repository API matcher in [internal/deploy/assets/Caddyfile.tmpl](/work/repo/internal/deploy/assets/Caddyfile.tmpl#L25) so Caddy now forwards `GET`, `POST`, `PATCH`, `PUT`, and `DELETE` for `/v1/repositories` and `/v1/repositories/*` without widening the existing runs/tasks policy. I also added deploy-level regression coverage in [internal/deploy/deploy_test.go](/work/repo/internal/deploy/deploy_test.go#L100) that asserts the repository allowlist block and method set are present in the rendered config.\n\nVerification passed with `go test ./internal/deploy`, `make lint`, and `make test`. The conventional commit message is in [/rascal-meta/commit_message.txt](/rascal-meta/commit_message.txt#L1).\n\nOne note: this checkout doesn’t appear to include the newer repository-registry CLI/server paths mentioned in the issue text, so the regression coverage is at the deploy/Caddy layer rather than an end-to-end `rascal repo ...` command test.&#34;}],&#34;metadata&#34;:{&#34;userVisible&#34;:true,&#34;agentVisible&#34;:true}}}
{&#34;type&#34;:&#34;complete&#34;,&#34;total_tokens&#34;:1894141}
</code></pre>

</details>

Closes #139

---

Rascal run `run_bc1841e7d35af339` completed in 8m 28s · 1.89M tokens