### PR TITLE
fix: normalize repository names for task resolution

### DIFF
--- a/cmd/rascald/main.go
+++ b/cmd/rascald/main.go
@@ -588,8 +588,9 @@ func (s *server) handleCreateIssueTask(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "repo and issue_number are required", http.StatusBadRequest)
 		return
 	}
+	req.Repo = state.NormalizeRepo(req.Repo)
 
-	taskID := fmt.Sprintf("%s#%d", req.Repo, req.IssueNumber)
+	taskID := repoIssueTaskID(req.Repo, req.IssueNumber)
 	taskText := fmt.Sprintf("Work on issue #%d in %s", req.IssueNumber, req.Repo)
 	ctxText := ""
 	requestedBy := requesterUserID(r.Context())
@@ -968,7 +969,7 @@ func (s *server) processWebhookEvent(ctx context.Context, eventType string, payl
 			if !strings.EqualFold(ev.Label.Name, "rascal") {
 				return nil
 			}
-			taskID := fmt.Sprintf("%s#%d", ev.Repository.FullName, ev.Issue.Number)
+			taskID := repoIssueTaskID(ev.Repository.FullName, ev.Issue.Number)
 			_, err := s.createAndQueueRun(runRequest{
 				TaskID:      taskID,
 				Repo:        ev.Repository.FullName,
@@ -998,7 +999,7 @@ func (s *server) processWebhookEvent(ctx context.Context, eventType string, payl
 			if !issueHasLabel(ev.Issue.Labels, "rascal") {
 				return nil
 			}
-			taskID := fmt.Sprintf("%s#%d", ev.Repository.FullName, ev.Issue.Number)
+			taskID := repoIssueTaskID(ev.Repository.FullName, ev.Issue.Number)
 			if err := s.store.CancelQueuedRuns(taskID, "issue edited"); err != nil {
 				return fmt.Errorf("cancel queued runs for edited issue: %w", err)
 			}
@@ -1025,7 +1026,7 @@ func (s *server) processWebhookEvent(ctx context.Context, eventType string, payl
 			if !issueHasLabel(ev.Issue.Labels, "rascal") {
 				return nil
 			}
-			taskID := fmt.Sprintf("%s#%d", ev.Repository.FullName, ev.Issue.Number)
+			taskID := repoIssueTaskID(ev.Repository.FullName, ev.Issue.Number)
 			if _, err := s.store.UpsertTask(state.UpsertTaskInput{
 				ID:          taskID,
 				Repo:        ev.Repository.FullName,
@@ -1045,7 +1046,7 @@ func (s *server) processWebhookEvent(ctx context.Context, eventType string, payl
 			if !issueHasLabel(ev.Issue.Labels, "rascal") {
 				return nil
 			}
-			taskID := fmt.Sprintf("%s#%d", ev.Repository.FullName, ev.Issue.Number)
+			taskID := repoIssueTaskID(ev.Repository.FullName, ev.Issue.Number)
 			if _, err := s.store.UpsertTask(state.UpsertTaskInput{
 				ID:          taskID,
 				Repo:        ev.Repository.FullName,
@@ -1419,7 +1420,7 @@ func (s *server) createAndQueueRun(req runRequest) (state.Run, error) {
 	if s.isDraining() {
 		return state.Run{}, errServerDraining
 	}
-	req.Repo = strings.TrimSpace(req.Repo)
+	req.Repo = state.NormalizeRepo(req.Repo)
 	req.Task = strings.TrimSpace(req.Task)
 	req.TaskID = strings.TrimSpace(req.TaskID)
 	req.BaseBranch = strings.TrimSpace(req.BaseBranch)
@@ -2405,13 +2406,13 @@ func (s *server) scheduleRuns(preferredTaskID string) {
 }
 
 func (s *server) reconcileClosedPRRuns(repo string, prNumber int, merged bool) {
-	repo = strings.TrimSpace(repo)
+	repo = state.NormalizeRepo(repo)
 	if repo == "" || prNumber <= 0 {
 		return
 	}
 	runs := s.store.ListRuns(10000)
 	for _, run := range runs {
-		if run.Repo != repo || run.PRNumber != prNumber {
+		if !strings.EqualFold(run.Repo, repo) || run.PRNumber != prNumber {
 			continue
 		}
 		s.updateRunBestEffort(run.ID, func(r *state.Run) error {
@@ -2440,13 +2441,13 @@ func (s *server) reconcileClosedPRRuns(repo string, prNumber int, merged bool) {
 }
 
 func (s *server) reconcileReopenedPRRuns(repo string, prNumber int) {
-	repo = strings.TrimSpace(repo)
+	repo = state.NormalizeRepo(repo)
 	if repo == "" || prNumber <= 0 {
 		return
 	}
 	runs := s.store.ListRuns(10000)
 	for _, run := range runs {
-		if run.Repo != repo || run.PRNumber != prNumber {
+		if !strings.EqualFold(run.Repo, repo) || run.PRNumber != prNumber {
 			continue
 		}
 		s.updateRunBestEffort(run.ID, func(r *state.Run) error {
@@ -2460,10 +2461,18 @@ func (s *server) reconcileReopenedPRRuns(repo string, prNumber int) {
 }
 
 func (s *server) taskForPR(repo string, prNumber int) (state.Task, bool) {
-	if strings.TrimSpace(repo) == "" || prNumber <= 0 {
+	if state.NormalizeRepo(repo) == "" || prNumber <= 0 {
 		return state.Task{}, false
 	}
 	return s.store.FindTaskByPR(repo, prNumber)
+}
+
+func repoIssueTaskID(repo string, issueNumber int) string {
+	repo = state.NormalizeRepo(repo)
+	if repo == "" || issueNumber <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("%s#%d", repo, issueNumber)
 }
 
 func (s *server) activeTaskForPR(repo string, prNumber int) (state.Task, bool) {
@@ -2630,7 +2639,7 @@ Repository: %s
 - Do not ask for interactive input.
 - Do not require MCP tools.
 - Keep changes minimal and scoped to the requested task.
-- Run `+"`make lint`"+` and `+"`make test`"+` before finishing if those targets exist.
+- Run ` + "`make lint`" + ` and ` + "`make test`" + ` before finishing if those targets exist.
 - If one of those commands does not exist or cannot run, explain exactly why and run the closest equivalent checks instead.
 - If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
 - Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

--- a/cmd/rascald/main_test.go
+++ b/cmd/rascald/main_test.go
@@ -1826,6 +1826,45 @@ func TestMergedPRMarksTaskCompleteAndCancelsQueuedRuns(t *testing.T) {
 
 }
 
+func TestMergedPRMatchesRepositoryCaseInsensitively(t *testing.T) {
+	t.Parallel()
+	s := newTestServer(t, &fakeLauncher{})
+	defer waitForServerIdle(t, s)
+
+	taskID := "owner/repo#123"
+	if _, err := s.store.UpsertTask(state.UpsertTaskInput{ID: taskID, Repo: "owner/repo", PRNumber: 55}); err != nil {
+		t.Fatalf("upsert task: %v", err)
+	}
+	run, err := s.store.AddRun(state.CreateRunInput{
+		ID:          "run_case_insensitive_merge",
+		TaskID:      taskID,
+		Repo:        "owner/repo",
+		Task:        "await merge",
+		Trigger:     "pr_comment",
+		RunDir:      t.TempDir(),
+		IssueNumber: 55,
+		PRNumber:    55,
+	})
+	if err != nil {
+		t.Fatalf("add awaiting run: %v", err)
+	}
+	markRunReview(t, s, run.ID)
+
+	payload := []byte(`{"action":"closed","pull_request":{"number":55,"merged":true},"repository":{"full_name":"Owner/Repo"},"sender":{"login":"dev"}}`)
+	req := webhookRequest(t, payload, "pull_request", "delivery-merged-mixed-case", "")
+	rec := httptest.NewRecorder()
+	s.handleWebhook(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202 for mixed-case merged pr event, got %d", rec.Code)
+	}
+
+	waitFor(t, time.Second, func() bool { return s.store.IsTaskCompleted(taskID) }, "task marked completed")
+	waitFor(t, time.Second, func() bool {
+		updated, ok := s.store.GetRun(run.ID)
+		return ok && updated.Status == state.StatusSucceeded
+	}, "awaiting-feedback run marked succeeded on merge")
+}
+
 func TestPullRequestClosedIgnoresUnmanagedPR(t *testing.T) {
 	t.Parallel()
 	s := newTestServer(t, &fakeLauncher{})
@@ -3097,6 +3136,44 @@ func TestHandleCreateTaskAcceptsDebugFalse(t *testing.T) {
 	}
 	if out.Run.Debug {
 		t.Fatal("expected debug=false when explicitly requested")
+	}
+}
+
+func TestHandleCreateIssueTaskNormalizesRepositoryCase(t *testing.T) {
+	t.Parallel()
+	s := newTestServer(t, &fakeLauncher{})
+	defer waitForServerIdle(t, s)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/tasks/issue",
+		strings.NewReader(`{"repo":"Owner/Repo","issue_number":7}`),
+	)
+	rec := httptest.NewRecorder()
+	s.handleCreateIssueTask(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", rec.Code)
+	}
+
+	var out struct {
+		Run state.Run `json:"run"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if out.Run.Repo != "owner/repo" {
+		t.Fatalf("run repo = %q, want owner/repo", out.Run.Repo)
+	}
+	if out.Run.TaskID != "owner/repo#7" {
+		t.Fatalf("run task id = %q, want owner/repo#7", out.Run.TaskID)
+	}
+
+	task, ok := s.store.GetTask("owner/repo#7")
+	if !ok {
+		t.Fatal("expected normalized task to be persisted")
+	}
+	if task.Repo != "owner/repo" {
+		t.Fatalf("task repo = %q, want owner/repo", task.Repo)
 	}
 }
 

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -119,7 +119,7 @@ func NewRunID() (string, error) {
 
 func (s *Store) UpsertTask(in UpsertTaskInput) (Task, error) {
 	in.ID = strings.TrimSpace(in.ID)
-	in.Repo = strings.TrimSpace(in.Repo)
+	in.Repo = NormalizeRepo(in.Repo)
 	in.AgentBackend = agent.NormalizeBackend(string(in.AgentBackend))
 	if in.ID == "" || in.Repo == "" {
 		return Task{}, fmt.Errorf("task id and repo are required")
@@ -158,7 +158,7 @@ func (s *Store) GetTask(taskID string) (Task, bool) {
 
 func (s *Store) FindTaskByPR(repo string, prNumber int) (Task, bool) {
 	row, err := s.q.FindTaskByPR(context.Background(), sqlitegen.FindTaskByPRParams{
-		Repo:     strings.TrimSpace(repo),
+		Repo:     NormalizeRepo(repo),
 		PrNumber: int64(prNumber),
 	})
 	if err != nil {
@@ -293,7 +293,7 @@ func (s *Store) IsTaskCompleted(taskID string) bool {
 func (s *Store) AddRun(in CreateRunInput) (Run, error) {
 	in.ID = strings.TrimSpace(in.ID)
 	in.TaskID = strings.TrimSpace(in.TaskID)
-	in.Repo = strings.TrimSpace(in.Repo)
+	in.Repo = NormalizeRepo(in.Repo)
 	in.AgentBackend = agent.NormalizeBackend(string(in.AgentBackend))
 	if in.ID == "" || in.TaskID == "" || in.Repo == "" {
 		return Run{}, fmt.Errorf("id, task_id and repo are required")

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -98,6 +98,27 @@ func TestStoreRunAndTaskLifecycle(t *testing.T) {
 	}
 }
 
+func TestStoreFindTaskByPRNormalizesRepoCase(t *testing.T) {
+	t.Parallel()
+
+	store, err := New(filepath.Join(t.TempDir(), "state.db"), 200)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	if _, err := store.UpsertTask(UpsertTaskInput{ID: "repo#77", Repo: "owner/repo", PRNumber: 77}); err != nil {
+		t.Fatalf("upsert task: %v", err)
+	}
+
+	task, ok := store.FindTaskByPR("Owner/Repo", 77)
+	if !ok {
+		t.Fatal("expected mixed-case repo lookup by pr to succeed")
+	}
+	if task.Repo != "owner/repo" {
+		t.Fatalf("task repo = %q, want owner/repo", task.Repo)
+	}
+}
+
 func TestStoreAllowsTaskSessionBackendMigration(t *testing.T) {
 	t.Parallel()
 

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/rtzll/rascal/internal/agent"
@@ -73,6 +74,10 @@ func ValidateRunStatusTransition(from, to RunStatus) error {
 		return fmt.Errorf("invalid run status transition %q -> %q", from, to)
 	}
 	return nil
+}
+
+func NormalizeRepo(repo string) string {
+	return strings.ToLower(strings.TrimSpace(repo))
 }
 
 type PRStatus string


### PR DESCRIPTION
Normalize repository names before storing, looking up, and comparing task and
run records so mixed-case GitHub repository identifiers resolve consistently.

<details><summary>Agent Details</summary>

<pre><code>
    __( O)&gt;  ● new session · codex gpt-5.4
   \____)    20260310_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: &#34;/usr/local/bin/codex&#34;
Model: gpt-5.4
Reasoning effort: high
Skip git check: false
Prompt length: 2237 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Suggestion

The user has 7 extensions with 16 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
Consider asking if they&#39;d like to disable some extensions to improve tool selection accuracy.

# Response Guidelines

Use Markdown formatting for all responses.

Human: &lt;info-msg&gt;
It is currently 2026-03-10 21:19:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

&lt;/info-msg&gt;
# Rascal Run Instructions

Run ID: run_1cd9f8fd73e55019
Task ID: rtzll/rascal#136
Repository: rtzll/rascal
Issue: #136

## Task

Normalize repository names before registry resolution

## Problem
Repository resolution currently depends on exact caller-provided casing. GitHub repository identifiers are case-insensitive, so a registry entry created as `owner/repo` should still resolve when a webhook or user supplies `Owner/Repo`.

Today this can cause:
- manual admissions to return `ErrNotFound`
- scoped webhook handling to fail with `repository mismatch`

## Outcome
Repository lookups behave consistently with GitHub and resolve independent of input casing.

## Acceptance Criteria
- Repository names are normalized before registry lookup and comparison.
- A repo registered as `owner/repo` resolves successfully for mixed-case inputs such as `Owner/Repo`.
- Tests cover manual and webhook-driven resolution for mixed-case repository names.

## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run `make lint` and `make test` before finishing if those targets exist.
- If one of those commands does not exist or cannot run, explain exactly why and run the closest equivalent checks instead.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label &#39;rascal&#39; on issue #136


Assistant: 
Image files: 0
============================
{&#34;type&#34;:&#34;message&#34;,&#34;message&#34;:{&#34;id&#34;:null,&#34;role&#34;:&#34;assistant&#34;,&#34;created&#34;:1773178220,&#34;content&#34;:[{&#34;type&#34;:&#34;text&#34;,&#34;text&#34;:&#34;Reviewing the repository path resolution code and tests first. I’m capturing the task requirements in the plan now, then I’ll trace where repository names are resolved for manual admissions and webhook handling.\n\nI’m locating the registry lookup and repository comparison paths now so the change stays narrowly scoped. After that I’ll patch the normalization at the lowest sensible layer and extend the existing tests.\n\nI found two likely choke points: manual task admission in `rascald` and PR/task lookup during webhook processing. I’m reading those handlers plus the state lookup helpers now to decide whether normalization belongs in the store layer or one level above it.\n\nThe `ErrNotFound` and `repository mismatch` strings from the issue text don’t exist verbatim in this tree, so this looks like the same behavior expressed through different code paths here. I’m narrowing it to repo-key generation and PR/task lookups, which are both currently case-sensitive.\n\nI have the minimal shape now: normalize repo names at the store boundary, normalize repo-derived task IDs where they’re generated, and make the PR run reconciliation comparisons case-insensitive for existing rows. Next I’m patching those spots and then I’ll add mixed-case tests.\n\nI’m editing the repo normalization points now. The patch is limited to the state/store boundary, repo-derived task ID construction in `rascald`, and a pair of mixed-case tests covering the manual issue API and webhook PR resolution.\n\nThe code edits are in. I’m formatting and running the focused test set first to catch any compile or behavioral issues before the full `make lint` and `make test` pass.\n\nThe focused test run is still in flight after dependency fetches. Once that is clean I’ll run the repo’s `make` targets and then write the requested commit message file.\n\nThe focused test command is taking longer than expected, likely because `cmd/rascald` has a large test suite. I’m checking whether it’s still actively running before deciding whether to rerun a narrower subset.\n\nThe targeted tests passed, and the repo defines both `make lint` and `make test`. I’m running those full checks now, then I’ll write the conventional commit message file requested by the task.\n\nBoth `make` targets are still building/downloading their toolchain dependencies, so this step is just waiting on the repository’s own checks rather than the code change itself. I’m keeping both sessions open until they settle.\n\nThe full repo checks are still inside `sqlc` codegen startup, which is heavier than the targeted Go tests. I’m verifying they’re making progress rather than silently stuck.\n\n`make test` has moved past codegen into the full Go test run. `make lint` is still finishing its own codegen/tool bootstrap, so I’m letting that complete in parallel before I finalize.\n\nThe full checks are clean: `make lint` finished with `0 issues.` and `make test` passed. I’m doing a final status check now and then writing `/rascal-meta/commit_message.txt` with the requested conventional commit title.\n\nRepository name handling is now case-insensitive across the relevant task-resolution paths.\n\nI added shared repo normalization in [internal/state/types.go](/work/repo/internal/state/types.go), applied it when storing and looking up task/run records in [internal/state/store.go](/work/repo/internal/state/store.go), and normalized repo-derived issue task IDs plus PR reconciliation comparisons in [cmd/rascald/main.go](/work/repo/cmd/rascald/main.go). That makes a registered `owner/repo` resolve correctly for inputs like `Owner/Repo`, including webhook payloads.\n\nCoverage was added in [internal/state/store_test.go](/work/repo/internal/state/store_test.go) and [cmd/rascald/main_test.go](/work/repo/cmd/rascald/main_test.go) for:\n- mixed-case PR task lookup in the store\n- mixed-case manual issue-task admission\n- mixed-case webhook PR handling\n\nVerification:\n- `go test ./internal/state ./cmd/rascald`\n- `make lint`\n- `make test`\n\nI also wrote the requested commit message to [/rascal-meta/commit_message.txt](/rascal-meta/commit_message.txt).&#34;}],&#34;metadata&#34;:{&#34;userVisible&#34;:true,&#34;agentVisible&#34;:true}}}
{&#34;type&#34;:&#34;complete&#34;,&#34;total_tokens&#34;:4423536}
</code></pre>

</details>

Closes #136

---

Rascal run `run_1cd9f8fd73e55019` completed in 11m 2s · 4.42M tokens