### PR TITLE
fix: harden run supervision under memory pressure

### DIFF
--- a/cmd/rascald/main.go
+++ b/cmd/rascald/main.go
@@ -41,6 +41,7 @@ var errServerDraining = errors.New("orchestrator is draining")
 
 const runLeaseTTL = 90 * time.Second
 const runSupervisorTick = 1 * time.Second
+const defaultSupervisorInspectTimeout = 5 * time.Second
 const runResponseTargetFile = "response_target.json"
 const runStartCommentMarkerFile = "start_comment_posted.json"
 const runCompletionCommentMarkerFile = "completion_comment_posted.json"
@@ -89,11 +90,12 @@ type server struct {
 	resumeTimer   *time.Timer
 	resumeAt      time.Time
 
-	supervisorInterval time.Duration
-	retryBackoff       func(attempt int) time.Duration
-	stopSupervisors    bool
-	beforeSupervise    func(runID string)
-	afterRunCleanup    func(runID string)
+	supervisorInterval       time.Duration
+	supervisorInspectTimeout time.Duration
+	retryBackoff             func(attempt int) time.Duration
+	stopSupervisors          bool
+	beforeSupervise          func(runID string)
+	afterRunCleanup          func(runID string)
 }
 
 type runRequest struct {
@@ -199,7 +201,7 @@ func main() {
 	s := &server{
 		cfg:           cfg,
 		store:         store,
-		launcher:      runner.NewLauncher(cfg.RunnerMode, cfg.RunnerImageForBackend(cfg.AgentBackend), cfg.GitHubToken),
+		launcher:      runner.NewLauncher(cfg.RunnerMode, cfg.RunnerImageForBackend(cfg.AgentBackend), cfg.GitHubToken, cfg.RunnerMemory, cfg.RunnerMemorySwap),
 		gh:            ghapi.NewAPIClient(cfg.GitHubToken),
 		broker:        credentials.NewBroker(store, allocStrategy, cipher, cfg.CredentialLeaseTTL),
 		cipher:        cipher,
@@ -318,6 +320,7 @@ func (s *server) recoverRunningRuns() {
 
 func (s *server) recoverDetachedRun(run state.Run, execRec state.RunExecution) {
 	handle := runExecutionHandle(execRec)
+	log.Printf("recover run %s adopting detached execution backend=%s container=%s", run.ID, execRec.Backend, firstNonEmpty(execRec.ContainerID, execRec.ContainerName))
 	inspectCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	execState, err := s.launcher.Inspect(inspectCtx, handle)
@@ -354,7 +357,7 @@ func (s *server) recoverDetachedRun(run state.Run, execRec state.RunExecution) {
 	if _, err := s.store.UpdateRunExecutionState(run.ID, "exited", exitCode, time.Now().UTC()); err != nil {
 		log.Printf("recover run %s update execution exited state failed: %v", run.ID, err)
 	}
-	s.finalizeDetachedRun(run.ID, execRec, exitCode)
+	s.finalizeDetachedRun(run.ID, execRec, execState)
 }
 
 func (s *server) failRunForMissingExecution(run state.Run, reason string) {
@@ -1849,6 +1852,8 @@ func (s *server) executeRun(runID string) {
 		Task:         run.Task,
 		AgentBackend: run.AgentBackend,
 		RunnerImage:  s.cfg.RunnerImageForBackend(run.AgentBackend),
+		MemoryLimit:  s.cfg.RunnerMemory,
+		MemorySwap:   s.cfg.RunnerMemorySwap,
 		BaseBranch:   run.BaseBranch,
 		HeadBranch:   run.HeadBranch,
 		Trigger:      run.Trigger,
@@ -1984,6 +1989,7 @@ func (s *server) superviseRun(ctx context.Context, runID string, execRec state.R
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			now := time.Now().UTC()
 			if time.Now().UTC().Before(nextRenewAt) {
 				// Continue with inspect/cancel handling on every tick.
 			} else {
@@ -1999,7 +2005,10 @@ func (s *server) superviseRun(ctx context.Context, runID string, execRec state.R
 				}
 				nextRenewAt = time.Now().UTC().Add(renewEvery)
 			}
-			if credentialLeaseID != "" && !time.Now().UTC().Before(nextCredentialRenewAt) {
+			if credentialLeaseID != "" && !now.Before(nextCredentialRenewAt) {
+				if stall := now.Sub(nextCredentialRenewAt); stall > credentialRenewEvery {
+					log.Printf("run %s credential lease renewal delayed by %s (interval %s)", runID, stall.Round(time.Millisecond), credentialRenewEvery)
+				}
 				if err := s.broker.Renew(ctx, credentialLeaseID); err != nil {
 					log.Printf("run %s credential lease renew failed: %v", runID, err)
 					if cancelErr := s.store.RequestRunCancel(runID, "credential lease lost", "broker"); cancelErr != nil {
@@ -2018,8 +2027,7 @@ func (s *server) superviseRun(ctx context.Context, runID string, execRec state.R
 				nextCredentialRenewAt = time.Now().UTC().Add(credentialRenewEvery)
 			}
 
-			now := time.Now().UTC()
-			execState, err := s.launcher.Inspect(ctx, handle)
+			execState, err := s.inspectExecution(ctx, runID, handle, "supervision")
 			if errors.Is(err, runner.ErrExecutionNotFound) {
 				run, ok := s.store.GetRun(runID)
 				if ok {
@@ -2028,7 +2036,7 @@ func (s *server) superviseRun(ctx context.Context, runID string, execRec state.R
 				return
 			}
 			if err != nil {
-				if !errors.Is(err, context.Canceled) {
+				if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 					log.Printf("run %s inspect failed: %v", runID, err)
 				}
 				continue
@@ -2062,13 +2070,13 @@ func (s *server) superviseRun(ctx context.Context, runID string, execRec state.R
 			if _, err := s.store.UpdateRunExecutionState(runID, "exited", exitCode, now); err != nil {
 				log.Printf("run %s update execution exited state failed: %v", runID, err)
 			}
-			s.finalizeDetachedRun(runID, execRec, exitCode)
+			s.finalizeDetachedRun(runID, execRec, execState)
 			return
 		}
 	}
 }
 
-func (s *server) finalizeDetachedRun(runID string, execRec state.RunExecution, observedExitCode int) {
+func (s *server) finalizeDetachedRun(runID string, execRec state.RunExecution, execState runner.ExecutionState) {
 	run, ok := s.store.GetRun(runID)
 	if !ok {
 		s.cleanupDetachedExecution(runID, execRec)
@@ -2083,6 +2091,10 @@ func (s *server) finalizeDetachedRun(runID string, execRec state.RunExecution, o
 
 	metaPath := filepath.Join(run.RunDir, "meta.json")
 	meta, metaErr := runner.ReadMeta(metaPath)
+	observedExitCode := 0
+	if execState.ExitCode != nil {
+		observedExitCode = *execState.ExitCode
+	}
 	if metaErr != nil {
 		meta = runner.Meta{
 			RunID:      run.ID,
@@ -2101,6 +2113,11 @@ func (s *server) finalizeDetachedRun(runID string, execRec state.RunExecution, o
 	}
 	if meta.ExitCode == 0 && observedExitCode != 0 {
 		meta.ExitCode = observedExitCode
+	}
+	if execState.OOMKilled {
+		meta.Error = formatExecutionFailure(execState, meta.ExitCode)
+	} else if strings.TrimSpace(meta.Error) == "" && observedExitCode != 0 {
+		meta.Error = formatExecutionFailure(execState, meta.ExitCode)
 	}
 	if strings.TrimSpace(meta.AgentSessionID) != "" {
 		existing, _ := s.store.GetTaskAgentSession(run.TaskID)
@@ -2162,8 +2179,12 @@ func (s *server) finalizeDetachedRun(runID string, execRec state.RunExecution, o
 	if reason, canceled := s.pendingRunCancelReason(runID); canceled && status == state.StatusFailed {
 		// Cancellation should explain a stopped execution, but it should not
 		// overwrite a successful terminal result that raced with the request.
-		status = state.StatusCanceled
-		errText = reason
+		if shouldPreserveFailureStatus(reason, errText, execState) {
+			log.Printf("run %s preserving failed status despite cancel request %q", runID, reason)
+		} else {
+			status = state.StatusCanceled
+			errText = reason
+		}
 	}
 	tokenUsage, hasTokenUsage, tokenUsageErr := loadRunTokenUsage(run)
 	if tokenUsageErr != nil {
@@ -2212,6 +2233,38 @@ func (s *server) finalizeDetachedRun(runID string, execRec state.RunExecution, o
 	}
 	s.cleanupDetachedExecution(runID, execRec)
 	s.finishRun(updated)
+}
+
+func (s *server) inspectExecution(ctx context.Context, runID string, handle runner.ExecutionHandle, purpose string) (runner.ExecutionState, error) {
+	inspectCtx, cancel := context.WithTimeout(ctx, s.supervisorInspectDeadline())
+	defer cancel()
+	execState, err := s.launcher.Inspect(inspectCtx, handle)
+	if errors.Is(err, context.DeadlineExceeded) {
+		log.Printf("run %s %s inspect timed out after %s", runID, purpose, s.supervisorInspectDeadline())
+	}
+	if err != nil {
+		return execState, fmt.Errorf("%s inspect for run %s: %w", purpose, runID, err)
+	}
+	return execState, nil
+}
+
+func formatExecutionFailure(execState runner.ExecutionState, exitCode int) string {
+	exitText := fmt.Sprintf("docker runner failed with exit code %d", exitCode)
+	if execState.OOMKilled {
+		exitText = fmt.Sprintf("runner container OOM-killed (exit code %d)", exitCode)
+	}
+	if detail := strings.TrimSpace(execState.Error); detail != "" {
+		return exitText + ": " + detail
+	}
+	return exitText
+}
+
+func shouldPreserveFailureStatus(cancelReason, errText string, execState runner.ExecutionState) bool {
+	if execState.OOMKilled {
+		return true
+	}
+	text := strings.ToLower(strings.TrimSpace(cancelReason + " " + errText + " " + execState.Error))
+	return strings.Contains(text, "oom")
 }
 
 func (s *server) cleanupDetachedExecution(runID string, execRec state.RunExecution) {
@@ -2425,7 +2478,7 @@ func (s *server) scheduleRuns(preferredTaskID string) {
 			log.Printf("run scheduling paused until %s: %s", pauseUntil.Format(time.RFC3339), pauseReason)
 			return
 		}
-		atCapacity := s.activeRunCount() >= s.concurrencyLimit()
+		atCapacity := s.globalActiveRunCount() >= s.concurrencyLimit()
 		draining := s.isDraining()
 		if draining || atCapacity {
 			return
@@ -2925,6 +2978,13 @@ func (s *server) supervisorTick() time.Duration {
 	return runSupervisorTick
 }
 
+func (s *server) supervisorInspectDeadline() time.Duration {
+	if s != nil && s.supervisorInspectTimeout > 0 {
+		return s.supervisorInspectTimeout
+	}
+	return defaultSupervisorInspectTimeout
+}
+
 func (s *server) startRetryBackoff(attempt int) time.Duration {
 	if s != nil && s.retryBackoff != nil {
 		if backoff := s.retryBackoff(attempt); backoff > 0 {
@@ -2983,6 +3043,10 @@ func (s *server) waitForNoActiveRuns(timeout time.Duration) error {
 
 func (s *server) activeRunCount() int {
 	return s.store.CountRunLeasesByOwner(s.instanceID)
+}
+
+func (s *server) globalActiveRunCount() int {
+	return s.store.CountRunLeases()
 }
 
 func (s *server) cancelRunningTaskRuns(taskID, reason string) {

--- a/cmd/rascald/main_test.go
+++ b/cmd/rascald/main_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rtzll/rascal/internal/agent"
 	"github.com/rtzll/rascal/internal/config"
 	"github.com/rtzll/rascal/internal/credentials"
+	credentialstrategies "github.com/rtzll/rascal/internal/credentials/strategies"
 	ghapi "github.com/rtzll/rascal/internal/github"
 	"github.com/rtzll/rascal/internal/runner"
 	"github.com/rtzll/rascal/internal/state"
@@ -107,12 +108,20 @@ type stubbornLauncher struct {
 	stopped  bool
 }
 
+type blockingInspectLauncher struct {
+	mu       sync.Mutex
+	nextExec int
+	specs    map[string]runner.Spec
+}
+
 type fakeRunResult struct {
-	PRNumber int
-	PRURL    string
-	HeadSHA  string
-	ExitCode int
-	Error    string
+	PRNumber   int
+	PRURL      string
+	HeadSHA    string
+	ExitCode   int
+	Error      string
+	OOMKilled  bool
+	StateError string
 }
 
 type fakeExecution struct {
@@ -254,7 +263,12 @@ func (f *fakeLauncher) Inspect(_ context.Context, handle runner.ExecutionHandle)
 		execRec.finalized = true
 	}
 	exitCode := execRec.result.ExitCode
-	return runner.ExecutionState{Running: false, ExitCode: &exitCode}, nil
+	return runner.ExecutionState{
+		Running:   false,
+		ExitCode:  &exitCode,
+		OOMKilled: execRec.result.OOMKilled,
+		Error:     strings.TrimSpace(execRec.result.StateError),
+	}, nil
 }
 
 func (f *fakeLauncher) Stop(_ context.Context, handle runner.ExecutionHandle, _ time.Duration) error {
@@ -340,7 +354,12 @@ func (l *stubbornLauncher) Inspect(_ context.Context, _ runner.ExecutionHandle) 
 		return runner.ExecutionState{}, err
 	}
 	exitCode := res.ExitCode
-	return runner.ExecutionState{Running: false, ExitCode: &exitCode}, nil
+	return runner.ExecutionState{
+		Running:   false,
+		ExitCode:  &exitCode,
+		OOMKilled: res.OOMKilled,
+		Error:     strings.TrimSpace(res.StateError),
+	}, nil
 }
 
 func (l *stubbornLauncher) Stop(_ context.Context, _ runner.ExecutionHandle, _ time.Duration) error {
@@ -359,6 +378,36 @@ func (l *stubbornLauncher) Stop(_ context.Context, _ runner.ExecutionHandle, _ t
 }
 
 func (l *stubbornLauncher) Remove(_ context.Context, _ runner.ExecutionHandle) error {
+	return nil
+}
+
+func (l *blockingInspectLauncher) StartDetached(_ context.Context, spec runner.Spec) (runner.ExecutionHandle, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.specs == nil {
+		l.specs = make(map[string]runner.Spec)
+	}
+	l.nextExec++
+	handle := runner.ExecutionHandle{
+		Backend: "fake",
+		ID:      fmt.Sprintf("blocking-exec-%d", l.nextExec),
+		Name:    "blocking-" + spec.RunID,
+	}
+	l.specs[handle.ID] = spec
+	l.specs[handle.Name] = spec
+	return handle, nil
+}
+
+func (l *blockingInspectLauncher) Inspect(ctx context.Context, _ runner.ExecutionHandle) (runner.ExecutionState, error) {
+	<-ctx.Done()
+	return runner.ExecutionState{}, fmt.Errorf("blocking inspect: %w", ctx.Err())
+}
+
+func (l *blockingInspectLauncher) Stop(_ context.Context, _ runner.ExecutionHandle, _ time.Duration) error {
+	return nil
+}
+
+func (l *blockingInspectLauncher) Remove(_ context.Context, _ runner.ExecutionHandle) error {
 	return nil
 }
 
@@ -2129,6 +2178,128 @@ func TestCreateAndQueueRunRespectsGlobalConcurrencyLimit(t *testing.T) {
 	}, "second run to complete")
 }
 
+func TestCreateAndQueueRunRespectsGlobalConcurrencyAcrossInstances(t *testing.T) {
+	t.Parallel()
+	waitCh := make(chan struct{})
+	dataDir := t.TempDir()
+	statePath := filepath.Join(dataDir, "state.db")
+	launcherA := &fakeLauncher{waitCh: waitCh}
+	launcherB := &fakeLauncher{waitCh: waitCh}
+	s1 := newTestServerWithPaths(t, launcherA, dataDir, statePath, "instance-a")
+	s2 := newTestServerWithPaths(t, launcherB, dataDir, statePath, "instance-b")
+	s1.maxConcurrent = 1
+	s2.maxConcurrent = 1
+	defer waitForServerIdle(t, s1)
+	defer waitForServerIdle(t, s2)
+
+	_, err := s1.createAndQueueRun(runRequest{TaskID: "task-a", Repo: "owner/repo", Task: "first"})
+	if err != nil {
+		t.Fatalf("create first run: %v", err)
+	}
+	second, err := s2.createAndQueueRun(runRequest{TaskID: "task-b", Repo: "owner/repo", Task: "second"})
+	if err != nil {
+		t.Fatalf("create second run: %v", err)
+	}
+
+	waitFor(t, time.Second, func() bool {
+		return launcherA.Calls()+launcherB.Calls() == 1
+	}, "only one run starts across instances while global slot is full")
+	if calls := launcherA.Calls() + launcherB.Calls(); calls != 1 {
+		t.Fatalf("launcher calls = %d, want 1", calls)
+	}
+
+	r2, ok := s2.store.GetRun(second.ID)
+	if !ok {
+		t.Fatalf("missing second run %s", second.ID)
+	}
+	if r2.Status != state.StatusQueued {
+		t.Fatalf("expected second run queued, got %s", r2.Status)
+	}
+
+	close(waitCh)
+	waitFor(t, 2*time.Second, func() bool {
+		return launcherA.Calls()+launcherB.Calls() == 2
+	}, "second run to start after first completes")
+	waitFor(t, 2*time.Second, func() bool {
+		r, ok := s1.store.GetRun(second.ID)
+		return ok && r.Status == state.StatusSucceeded
+	}, "second run to complete across instances")
+}
+
+func TestSupervisionInspectTimeoutStillRenewsCredentialLease(t *testing.T) {
+	t.Parallel()
+	launcher := &blockingInspectLauncher{}
+	s := newTestServer(t, launcher)
+	s.supervisorInterval = 5 * time.Millisecond
+	s.supervisorInspectTimeout = 10 * time.Millisecond
+	s.cfg.CredentialRenewEvery = 10 * time.Millisecond
+	defer func() {
+		s.beginDrain()
+		s.stopRunSupervisors()
+		waitForServerIdle(t, s)
+	}()
+
+	cipher, err := credentials.NewAESCipher("test-secret")
+	if err != nil {
+		t.Fatalf("new cipher: %v", err)
+	}
+	strategy, err := credentialstrategies.ByName("requester_own_then_shared")
+	if err != nil {
+		t.Fatalf("strategy: %v", err)
+	}
+	s.cipher = cipher
+	s.broker = credentials.NewBroker(s.store, strategy, cipher, 40*time.Millisecond)
+
+	if _, err := s.store.UpsertUser(state.UpsertUserInput{ID: "owner", ExternalLogin: "owner", Role: state.UserRoleUser}); err != nil {
+		t.Fatalf("upsert owner: %v", err)
+	}
+	blob, err := cipher.Encrypt([]byte(`{"token":"run-token"}`))
+	if err != nil {
+		t.Fatalf("encrypt auth blob: %v", err)
+	}
+	if _, err := s.store.CreateCodexCredential(state.CreateCodexCredentialInput{
+		ID:                "cred-owner",
+		OwnerUserID:       "owner",
+		Scope:             "personal",
+		EncryptedAuthBlob: blob,
+		Weight:            1,
+		Status:            "active",
+	}); err != nil {
+		t.Fatalf("create credential: %v", err)
+	}
+
+	run, err := s.createAndQueueRun(runRequest{
+		Repo:            "owner/repo",
+		Task:            "inspect timeout keeps renewing credential lease",
+		CreatedByUserID: "owner",
+	})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	_ = waitForRunExecution(t, s, run.ID)
+
+	time.Sleep(120 * time.Millisecond)
+
+	lease, ok, err := s.store.GetActiveCredentialLeaseByRunID(run.ID)
+	if err != nil {
+		t.Fatalf("get active credential lease: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected active credential lease for %s", run.ID)
+	}
+	if !lease.ExpiresAt.After(time.Now().UTC()) {
+		t.Fatalf("expected credential lease expiry to advance past now, got %s", lease.ExpiresAt.Format(time.RFC3339Nano))
+	}
+
+	updated, ok := s.store.GetRun(run.ID)
+	if !ok {
+		t.Fatalf("missing run %s", run.ID)
+	}
+	if updated.Status != state.StatusRunning {
+		t.Fatalf("run status = %s, want running", updated.Status)
+	}
+}
+
 func TestMergedPRMarksTaskCompleteAndCancelsQueuedRuns(t *testing.T) {
 	t.Parallel()
 	waitCh := make(chan struct{})
@@ -3727,6 +3898,59 @@ func TestCanceledRunDoesNotTransitionToSuccess(t *testing.T) {
 			return false
 		}
 	}, "run cleanup after canceled run")
+}
+
+func TestFinalizeDetachedRunPreservesOOMFailureOverCredentialLeaseLoss(t *testing.T) {
+	t.Parallel()
+	s := newTestServer(t, &fakeLauncher{})
+	defer waitForServerIdle(t, s)
+
+	run, err := s.store.AddRun(state.CreateRunInput{
+		ID:         "run_oom_preserved",
+		TaskID:     "task_oom_preserved",
+		Repo:       "owner/repo",
+		Task:       "preserve oom failure",
+		BaseBranch: "main",
+		RunDir:     t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("add run: %v", err)
+	}
+	if _, err := s.store.SetRunStatus(run.ID, state.StatusRunning, ""); err != nil {
+		t.Fatalf("set run running: %v", err)
+	}
+	execRec, err := s.store.UpsertRunExecution(state.RunExecution{
+		RunID:         run.ID,
+		Backend:       "fake",
+		ContainerName: "rascal-run_oom_preserved",
+		ContainerID:   "oom-exec",
+		Status:        "exited",
+		ExitCode:      137,
+	})
+	if err != nil {
+		t.Fatalf("upsert run execution: %v", err)
+	}
+	if err := s.store.RequestRunCancel(run.ID, "credential lease lost", "broker"); err != nil {
+		t.Fatalf("request run cancel: %v", err)
+	}
+
+	exitCode := 137
+	s.finalizeDetachedRun(run.ID, execRec, runner.ExecutionState{
+		Running:   false,
+		ExitCode:  &exitCode,
+		OOMKilled: true,
+	})
+
+	updated, ok := s.store.GetRun(run.ID)
+	if !ok {
+		t.Fatalf("missing run %s", run.ID)
+	}
+	if updated.Status != state.StatusFailed {
+		t.Fatalf("status = %s, want failed", updated.Status)
+	}
+	if !strings.Contains(updated.Error, "OOM-killed") {
+		t.Fatalf("expected OOM failure, got %q", updated.Error)
+	}
 }
 
 func TestCancelActiveRunsUsesDrainReason(t *testing.T) {

--- a/docs/config.md
+++ b/docs/config.md
@@ -91,3 +91,18 @@ Rascal uses encrypted stored credentials for Codex runs.
 Operators can manage stored credentials with `rascal auth credentials ...`.
 Bootstrap and deploy flows can seed an initial shared credential with
 `--codex-auth ~/.codex/auth.json`.
+
+## Runner Memory Settings
+
+- `RASCAL_RUNNER_DOCKER_MEMORY`
+  Optional Docker `--memory` limit applied to each run container.
+  Example: `2g`
+
+- `RASCAL_RUNNER_DOCKER_MEMORY_SWAP`
+  Optional Docker `--memory-swap` limit applied to each run container.
+  Example: `3g`
+
+On small hosts, set both values explicitly so a single run cannot consume all
+available RAM. A practical starting point is `RASCAL_RUNNER_DOCKER_MEMORY=2g`
+and `RASCAL_RUNNER_DOCKER_MEMORY_SWAP=3g` on a 4 GB host, then adjust after
+observing steady-state headroom.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -44,6 +44,17 @@ default):
 - `RASCAL_AGENT_SESSION_TTL_DAYS=14`
 - `RASCAL_RUNNER_IMAGE_GOOSE` and `RASCAL_RUNNER_IMAGE_CODEX` set the backend-specific runner images
 - `RASCAL_AGENT_BACKEND` selects which of those configured runner images is used by default
+- `RASCAL_RUNNER_DOCKER_MEMORY` and `RASCAL_RUNNER_DOCKER_MEMORY_SWAP` can cap per-run container memory on smaller hosts
+
+For low-memory hosts, configure Docker memory limits before allowing multiple
+runs. On 4 GB machines, start with `RASCAL_RUNNER_DOCKER_MEMORY=2g` and
+`RASCAL_RUNNER_DOCKER_MEMORY_SWAP=3g`, then leave at least 1 GB for
+`rascald`, Docker, Caddy, and the kernel page cache.
+
+If the host has no swap configured, add a small swapfile so short-lived spikes
+do not immediately escalate into OOM kills. Swap is not a substitute for
+container memory limits, but it gives the host more room to recover under
+pressure.
 
 ## Blue/Green Sequence
 
@@ -104,6 +115,8 @@ Additional safeguards:
 - Webhook delivery dedupe is atomic claim/finalize (no check-then-insert race).
 - Run start is DB-atomic (`queued -> running`) with task-level exclusivity, so
   two instances cannot both start work for the same queued run/task.
+- Scheduler capacity is enforced against the global run-lease count, so
+  blue/green overlap does not double effective worker capacity.
 - Detached execution handles are persisted, so startup recovery can adopt
   active runs immediately after slot rotation.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,8 @@ type ServerConfig struct {
 	RunnerImage             string
 	RunnerImageGoose        string
 	RunnerImageCodex        string
+	RunnerMemory            string
+	RunnerMemorySwap        string
 	RunnerMaxAttempts       int
 	CredentialStrategy      string
 	CredentialLeaseTTL      time.Duration
@@ -75,6 +77,8 @@ func LoadServerConfig() ServerConfig {
 		AgentBackend:            loadAgentBackend(),
 		RunnerImageGoose:        envOrDefault("RASCAL_RUNNER_IMAGE_GOOSE", defaults.GooseRunnerImageTag),
 		RunnerImageCodex:        envOrDefault("RASCAL_RUNNER_IMAGE_CODEX", defaults.CodexRunnerImageTag),
+		RunnerMemory:            strings.TrimSpace(os.Getenv("RASCAL_RUNNER_DOCKER_MEMORY")),
+		RunnerMemorySwap:        strings.TrimSpace(os.Getenv("RASCAL_RUNNER_DOCKER_MEMORY_SWAP")),
 		RunnerMaxAttempts:       envIntOrDefault("RASCAL_RUNNER_MAX_ATTEMPTS", 1),
 		CredentialStrategy:      envOrDefault("RASCAL_CREDENTIAL_STRATEGY", "requester_own_then_shared"),
 		CredentialLeaseTTL:      envDurationOrDefault("RASCAL_CREDENTIAL_LEASE_TTL", 90*time.Second),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -179,3 +179,16 @@ func TestLoadServerConfigCredentialEncryptionKeyFallback(t *testing.T) {
 		t.Fatalf("CredentialEncryptionKey = %q, want explicit-key", cfg.CredentialEncryptionKey)
 	}
 }
+
+func TestLoadServerConfigRunnerMemoryLimits(t *testing.T) {
+	t.Setenv("RASCAL_RUNNER_DOCKER_MEMORY", "2g")
+	t.Setenv("RASCAL_RUNNER_DOCKER_MEMORY_SWAP", "3g")
+
+	cfg := LoadServerConfig()
+	if cfg.RunnerMemory != "2g" {
+		t.Fatalf("RunnerMemory = %q, want 2g", cfg.RunnerMemory)
+	}
+	if cfg.RunnerMemorySwap != "3g" {
+		t.Fatalf("RunnerMemorySwap = %q, want 3g", cfg.RunnerMemorySwap)
+	}
+}

--- a/internal/runner/docker.go
+++ b/internal/runner/docker.go
@@ -1,7 +1,9 @@
 package runner
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -19,9 +21,11 @@ import (
 
 // DockerLauncher runs a task inside a Docker container.
 type DockerLauncher struct {
-	DefaultImage string
-	Image        string
-	GitHubToken  string
+	DefaultImage      string
+	Image             string
+	GitHubToken       string
+	DefaultMemory     string
+	DefaultMemorySwap string
 }
 
 const (
@@ -158,6 +162,16 @@ func (l DockerLauncher) StartDetached(ctx context.Context, spec Spec) (handle Ex
 		"--label", fmt.Sprintf("rascal.task_id=%s", spec.TaskID),
 		"--label", fmt.Sprintf("rascal.repo=%s", spec.Repo),
 	}
+	if memory := strings.TrimSpace(spec.MemoryLimit); memory != "" {
+		args = append(args, "--memory", memory)
+	} else if memory := strings.TrimSpace(l.DefaultMemory); memory != "" {
+		args = append(args, "--memory", memory)
+	}
+	if memorySwap := strings.TrimSpace(spec.MemorySwap); memorySwap != "" {
+		args = append(args, "--memory-swap", memorySwap)
+	} else if memorySwap := strings.TrimSpace(l.DefaultMemorySwap); memorySwap != "" {
+		args = append(args, "--memory-swap", memorySwap)
+	}
 	envKeys := make([]string, 0, len(envPairs))
 	for k := range envPairs {
 		envKeys = append(envKeys, k)
@@ -217,30 +231,44 @@ func (l DockerLauncher) Inspect(ctx context.Context, handle ExecutionHandle) (Ex
 	if target == "" {
 		return ExecutionState{}, fmt.Errorf("execution target is required")
 	}
-	cmd := exec.CommandContext(ctx, "docker", "inspect", "--type", "container", "--format", "{{.State.Running}} {{.State.ExitCode}}", target)
+	cmd := exec.CommandContext(ctx,
+		"docker",
+		"inspect",
+		"--type",
+		"container",
+		"--format",
+		`{{json .State}}`,
+		target,
+	)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		if dockerNotFoundOutput(err, out) {
 			return ExecutionState{}, ErrExecutionNotFound
 		}
-		if errors.Is(ctx.Err(), context.Canceled) {
-			return ExecutionState{}, context.Canceled
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ExecutionState{}, fmt.Errorf("inspect docker container %s: %w", target, ctxErr)
 		}
 		return ExecutionState{}, fmt.Errorf("inspect docker container %s: %w", target, unwrapSyscallError(err))
 	}
-	parts := strings.Fields(strings.TrimSpace(string(out)))
-	if len(parts) < 2 {
-		return ExecutionState{}, fmt.Errorf("unexpected docker inspect output for %s: %q", target, strings.TrimSpace(string(out)))
+	var raw struct {
+		Running   bool   `json:"Running"`
+		ExitCode  int    `json:"ExitCode"`
+		OOMKilled bool   `json:"OOMKilled"`
+		Error     string `json:"Error"`
 	}
-	running := parts[0] == "true"
-	if running {
+	if err := json.Unmarshal(bytes.TrimSpace(out), &raw); err != nil {
+		return ExecutionState{}, fmt.Errorf("parse docker inspect output for %s: %w", target, err)
+	}
+	if raw.Running {
 		return ExecutionState{Running: true}, nil
 	}
-	exitCode, convErr := strconv.Atoi(parts[1])
-	if convErr != nil {
-		return ExecutionState{}, fmt.Errorf("parse docker exit code %q: %w", parts[1], convErr)
-	}
-	return ExecutionState{Running: false, ExitCode: &exitCode}, nil
+	exitCode := raw.ExitCode
+	return ExecutionState{
+		Running:   false,
+		ExitCode:  &exitCode,
+		OOMKilled: raw.OOMKilled,
+		Error:     strings.TrimSpace(raw.Error),
+	}, nil
 }
 
 func firstNonEmptySessionPath(values ...string) string {
@@ -270,8 +298,8 @@ func (l DockerLauncher) Stop(ctx context.Context, handle ExecutionHandle, timeou
 		if dockerNotFoundOutput(err, out) {
 			return ErrExecutionNotFound
 		}
-		if errors.Is(ctx.Err(), context.Canceled) {
-			return context.Canceled
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return fmt.Errorf("stop docker container %s: %w", target, ctxErr)
 		}
 		return fmt.Errorf("stop docker container %s: %w", target, unwrapSyscallError(err))
 	}
@@ -289,8 +317,8 @@ func (l DockerLauncher) Remove(ctx context.Context, handle ExecutionHandle) erro
 		if dockerNotFoundOutput(err, out) {
 			return nil
 		}
-		if errors.Is(ctx.Err(), context.Canceled) {
-			return context.Canceled
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return fmt.Errorf("remove docker container %s: %w", target, ctxErr)
 		}
 		return fmt.Errorf("remove docker container %s: %w", target, unwrapSyscallError(err))
 	}

--- a/internal/runner/docker_test.go
+++ b/internal/runner/docker_test.go
@@ -97,6 +97,58 @@ exit 0
 	}
 }
 
+func TestDockerLauncherStartDetachedAppliesMemoryLimits(t *testing.T) {
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "docker_calls.log")
+	fakeDocker := filepath.Join(tmp, "docker")
+	script := `#!/bin/sh
+set -eu
+echo "$@" >> "` + logPath + `"
+if [ "${1:-}" = "run" ]; then
+  echo "container-memory"
+fi
+exit 0
+`
+	if err := os.WriteFile(fakeDocker, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake docker: %v", err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	t.Setenv("PATH", tmp+string(os.PathListSeparator)+oldPath)
+
+	runDir := filepath.Join(tmp, "run")
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatalf("create run dir: %v", err)
+	}
+
+	launcher := DockerLauncher{
+		Image:             "rascal-runner:latest",
+		DefaultMemory:     "2g",
+		DefaultMemorySwap: "3g",
+	}
+	if _, err := launcher.StartDetached(context.Background(), Spec{
+		RunID:      "run_memory",
+		TaskID:     "task_memory",
+		Repo:       "owner/repo",
+		Task:       "memory limits",
+		BaseBranch: "main",
+		RunDir:     runDir,
+	}); err != nil {
+		t.Fatalf("start detached: %v", err)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read docker call log: %v", err)
+	}
+	logText := string(data)
+	for _, want := range []string{"--memory 2g", "--memory-swap 3g"} {
+		if !strings.Contains(logText, want) {
+			t.Fatalf("expected %q in docker call log:\n%s", want, logText)
+		}
+	}
+}
+
 func TestDockerLauncherInspectStopAndRemove(t *testing.T) {
 	tmp := t.TempDir()
 	logPath := filepath.Join(tmp, "docker_calls.log")
@@ -108,11 +160,15 @@ cmd="${1:-}"
 target="${6:-}"
 if [ "$cmd" = "inspect" ]; then
   if [ "$target" = "running-id" ]; then
-    echo "true 0"
+    echo '{"Running":true,"ExitCode":0,"OOMKilled":false,"Error":""}'
     exit 0
   fi
   if [ "$target" = "exited-id" ]; then
-    echo "false 17"
+    echo '{"Running":false,"ExitCode":17,"OOMKilled":false,"Error":""}'
+    exit 0
+  fi
+  if [ "$target" = "oom-id" ]; then
+    echo '{"Running":false,"ExitCode":137,"OOMKilled":true,"Error":"container killed by kernel"}'
     exit 0
   fi
   echo "Error: No such object: $target" >&2
@@ -149,6 +205,16 @@ exit 0
 	if exitedState.Running || exitedState.ExitCode == nil || *exitedState.ExitCode != 17 {
 		t.Fatalf("unexpected exited state: %+v", exitedState)
 	}
+	oomState, err := launcher.Inspect(context.Background(), ExecutionHandle{ID: "oom-id"})
+	if err != nil {
+		t.Fatalf("inspect oom container: %v", err)
+	}
+	if oomState.Running || oomState.ExitCode == nil || *oomState.ExitCode != 137 || !oomState.OOMKilled {
+		t.Fatalf("unexpected oom state: %+v", oomState)
+	}
+	if oomState.Error != "container killed by kernel" {
+		t.Fatalf("state error = %q, want container killed by kernel", oomState.Error)
+	}
 
 	if _, err := launcher.Inspect(context.Background(), ExecutionHandle{ID: "missing-id"}); !errors.Is(err, ErrExecutionNotFound) {
 		t.Fatalf("expected ErrExecutionNotFound for missing container, got %v", err)
@@ -167,7 +233,7 @@ exit 0
 	}
 	logText := string(data)
 	for _, want := range []string{
-		"inspect --type container --format {{.State.Running}} {{.State.ExitCode}} running-id",
+		"inspect --type container --format {{json .State}} running-id",
 		"stop --time 3 running-id",
 		"rm -f running-id",
 	} {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -17,6 +17,8 @@ type Spec struct {
 	Task         string
 	AgentBackend agent.Backend
 	RunnerImage  string
+	MemoryLimit  string
+	MemorySwap   string
 	BaseBranch   string
 	HeadBranch   string
 	Trigger      string
@@ -43,8 +45,10 @@ type ExecutionHandle struct {
 }
 
 type ExecutionState struct {
-	Running  bool
-	ExitCode *int
+	Running   bool
+	ExitCode  *int
+	OOMKilled bool
+	Error     string
 }
 
 func ExecutionHandleForRun(runID string) ExecutionHandle {
@@ -72,10 +76,15 @@ type Launcher interface {
 	Remove(ctx context.Context, handle ExecutionHandle) error
 }
 
-func NewLauncher(mode, image, githubToken string) Launcher {
+func NewLauncher(mode, image, githubToken, memoryLimit, memorySwap string) Launcher {
 	switch mode {
 	case "docker":
-		return DockerLauncher{DefaultImage: image, GitHubToken: githubToken}
+		return DockerLauncher{
+			DefaultImage:      image,
+			GitHubToken:       githubToken,
+			DefaultMemory:     memoryLimit,
+			DefaultMemorySwap: memorySwap,
+		}
 	default:
 		return NoopLauncher{}
 	}

--- a/internal/state/sql/queries.sql
+++ b/internal/state/sql/queries.sql
@@ -341,6 +341,10 @@ SELECT COUNT(*)
 FROM run_leases
 WHERE owner_id = ?;
 
+-- name: CountRunLeases :one
+SELECT COUNT(*)
+FROM run_leases;
+
 -- name: UpsertRunExecution :exec
 INSERT INTO run_executions (
   run_id,

--- a/internal/state/sqlitegen/queries.sql.go
+++ b/internal/state/sqlitegen/queries.sql.go
@@ -483,6 +483,18 @@ func (q *Queries) CountDeliveries(ctx context.Context) (int64, error) {
 	return count, err
 }
 
+const countRunLeases = `-- name: CountRunLeases :one
+SELECT COUNT(*)
+FROM run_leases
+`
+
+func (q *Queries) CountRunLeases(ctx context.Context) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countRunLeases)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const countRunLeasesByOwner = `-- name: CountRunLeasesByOwner :one
 SELECT COUNT(*)
 FROM run_leases

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -677,6 +677,14 @@ func (s *Store) CountRunLeasesByOwner(ownerID string) int {
 	return int(count)
 }
 
+func (s *Store) CountRunLeases() int {
+	count, err := s.q.CountRunLeases(context.Background())
+	if err != nil {
+		return 0
+	}
+	return int(count)
+}
+
 func (s *Store) UpsertRunExecution(exec RunExecution) (RunExecution, error) {
 	exec.RunID = strings.TrimSpace(exec.RunID)
 	exec.Backend = strings.TrimSpace(exec.Backend)

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -573,6 +573,9 @@ func TestStoreRunLeaseLifecycle(t *testing.T) {
 	if got := store.CountRunLeasesByOwner("instance-a"); got != 1 {
 		t.Fatalf("expected owner lease count 1, got %d", got)
 	}
+	if got := store.CountRunLeases(); got != 1 {
+		t.Fatalf("expected total lease count 1, got %d", got)
+	}
 	lease, ok := store.GetRunLease("run_lease_1")
 	if !ok {
 		t.Fatal("expected run lease to exist")
@@ -598,6 +601,9 @@ func TestStoreRunLeaseLifecycle(t *testing.T) {
 	}
 	if got := store.CountRunLeasesByOwner("instance-a"); got != 0 {
 		t.Fatalf("expected owner lease count 0 after delete, got %d", got)
+	}
+	if got := store.CountRunLeases(); got != 0 {
+		t.Fatalf("expected total lease count 0 after delete, got %d", got)
 	}
 	if _, ok := store.GetRunLease("run_lease_1"); ok {
 		t.Fatal("expected run lease to be deleted")


### PR DESCRIPTION
Add a bounded supervision inspect timeout so lease renewal keeps progressing
under Docker stalls, surface container OOM kills in terminal run state, and
enforce global worker capacity across blue/green overlap.

Also add configurable Docker memory limits with low-memory deployment guidance
and regression coverage for delayed inspect handling.

<details><summary>Agent Details</summary>

<pre><code>
    __( O)&gt;  ● new session · codex gpt-5.4
   \____)    20260313_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: &#34;/usr/local/bin/codex&#34;
Model: gpt-5.4
Reasoning effort: high
Skip git check: false
Prompt length: 4442 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Suggestion

The user has 7 extensions with 16 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
Consider asking if they&#39;d like to disable some extensions to improve tool selection accuracy.

# Response Guidelines

Use Markdown formatting for all responses.

Human: &lt;info-msg&gt;
It is currently 2026-03-13 07:38:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

&lt;/info-msg&gt;
# Rascal Run Instructions

Run ID: run_bb76835df54893b7
Task ID: rtzll/rascal#158
Repository: rtzll/rascal
Issue: #158

## Task

Harden run supervision against credential lease loss under host memory pressure

## Summary
A Goose run for issue #153 (`run_d54d430dc9761cfb`) did not fail because of the task itself. It started normally, posted the start comment, and then was eventually canceled with `credential lease lost` while the host was under sustained memory pressure.

A second run (`run_528aade03ff0df76`) failed the same way at the same second, which suggests an orchestrator/runtime problem rather than a task-specific issue.

## Incident Evidence
- Run `run_d54d430dc9761cfb` started at `2026-03-12T21:16:28Z`
- Persisted final state was `status=canceled`, `error=credential lease lost`
- The credential lease expiry for that run stopped advancing at `2026-03-12T21:37:15Z`
- `rascald` only noticed the expired lease at `2026-03-12T22:23:11Z` and canceled the run
- Host journals show sustained memory pressure before failure
- Docker events show the runner container was also OOM-impacted at failure time
- Kernel log shows OOM killed a `vet` process inside the run container

## Likely Failure Mode
There appear to be two problems:

1. The supervision loop can stop renewing credential leases for too long.
2. The runner containers have no memory guardrails, so host pressure can escalate into OOM and destabilize multiple runs.

A likely code path is that the steady-state supervisor loop blocks too long in `launcher.Inspect(...)`, which currently uses `docker inspect` without a dedicated timeout in the normal supervision path. If that call wedges under host pressure, credential renewal can stop long enough for the lease to expire, after which the broker cancels the run.

## Relevant Code Areas
- `cmd/rascald/main.go` supervision loop
- `internal/runner/docker.go` inspect path
- runner container resource configuration
- slot overlap / concurrency accounting during blue-green handoff

## Requested Changes
- Add a bounded timeout around the steady-state inspect path used by run supervision.
- Distinguish container OOM / host pressure failures from generic `credential lease lost` cancellations where possible.
- Add configurable per-run Docker memory limits, and document sane defaults for small hosts.
- Consider adding swap guidance in deployment docs for low-memory hosts.
- Review concurrency accounting during blue/green overlap so capacity is global, not effectively per-slot.
- Add incident-oriented logging around lease renewal stalls and detached-run adoption.

## Acceptance Criteria
- A stalled `docker inspect` cannot block credential lease renewal indefinitely.
- Runs that die due to OOM are surfaced as such in terminal state/logs.
- Operators can configure runner memory limits.
- Blue/green overlap cannot unintentionally double effective worker capacity on a small host.
- A regression test covers supervision recovery / lease renewal under delayed inspect conditions.

## Notes
This issue was created from investigation of:
- issue #153
- run `run_d54d430dc9761cfb`
- concurrent run `run_528aade03ff0df76`


## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run `make lint` and `make test` before finishing if those targets exist.
- If one of those commands does not exist or cannot run, explain exactly why and run the closest equivalent checks instead.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label &#39;rascal&#39; on issue #158


Assistant: 
Image files: 0
============================
{&#34;type&#34;:&#34;message&#34;,&#34;message&#34;:{&#34;id&#34;:null,&#34;role&#34;:&#34;assistant&#34;,&#34;created&#34;:1773388632,&#34;content&#34;:[{&#34;type&#34;:&#34;text&#34;,&#34;text&#34;:&#34;I’m mapping the issue to the relevant code paths first: supervision loop, Docker inspect/termination handling, memory-limit config, and blue/green slot accounting. I’ll build a minimal plan from the repo state, then make targeted changes and run the requested checks.\n\nI’m gathering the current implementation details before editing so the fix stays scoped. Next I’m reading the supervision loop, Docker runner paths, config/docs, and any existing tests around blue/green or detached-run adoption.\n\nThe current supervision loop confirms the likely failure path: lease renewal and `docker inspect` are serialized on the same tick, and the steady-state inspect uses the parent context with no per-call timeout. I’m checking scheduler/capacity logic now to see whether blue/green overlap is counted per process instead of globally, then I’ll patch both areas together.\n\nI’ve confirmed there’s already a timeout during recovery adoption, but not in the steady-state loop, and the cancellation path currently overwrites real execution failures with a generic canceled state. I’m reading the launcher fakes and existing supervisor tests now so I can extend the existing test harness instead of adding new scaffolding.\n\nI have enough context to start patching. The edits will be: add a timed inspect wrapper in supervision, carry OOM details through Docker inspect/finalization, wire Docker memory limit config into launcher startup, switch scheduling to a global lease count while keeping shutdown local, then add focused tests and docs.\n\nI’m editing the core behavior first: timeout and result handling in `rascald`, then the Docker launcher and config surface, then I’ll regenerate SQL code and add tests. After that I’ll run `make lint` and `make test`, and write the requested commit message file.\n\nI hit a small patch mismatch in the test import block, so I’m re-reading that section and continuing with the test additions. The implementation edits are in place; this is just aligning the test file cleanly before I add the new cases.\n\nI’m in the test phase now. I’ve added the new supervisor and terminal-state cases in `rascald`; next I’m aligning the Docker launcher tests and config tests with the new memory-limit and inspect-state behavior, then I’ll run codegen/formatting and the requested checks.\n\nI’ve finished the source edits and test additions. Next step is mechanical validation: regenerate `sqlc`, run `gofmt`, then `make lint` and `make test`, fix anything that shakes out, and finally write the commit message file.\n\n`sqlc` generation is taking longer than expected, likely on first-run module/toolchain setup, so I’m checking whether it completed cleanly or is hung before moving on to lint/tests. If it’s stuck, I’ll diagnose and run the nearest working equivalent without leaving the generated code stale.\n\n`gofmt` touched one unrelated CLI file with spacing-only changes. I’m reverting that incidental formatting so the diff stays scoped to the issue.\n\nLint surfaced only wrapcheck issues around the new timeout path. I’m patching those error returns now so `errors.Is` still works but the linter is satisfied, then I’ll rerun lint and tests.\n\nThe full check pass is clean: `make lint` and `make test` both succeeded. I’m doing one final diff review now, then I’ll write `/rascal-meta/commit_message.txt` and close with the concise outcome summary.\n\nImplemented the hardening in [cmd/rascald/main.go](/work/repo/cmd/rascald/main.go#L42): steady-state supervision now uses a bounded inspect timeout, logs credential-renew stalls, preserves real OOM failures instead of collapsing them into generic `credential lease lost` cancellations, and enforces scheduling capacity from the global run-lease count rather than per-slot ownership. The regression coverage is in [cmd/rascald/main_test.go](/work/repo/cmd/rascald/main_test.go).\n\nDocker runner memory guardrails and OOM surfacing are wired through [internal/config/config.go](/work/repo/internal/config/config.go#L27), [internal/runner/docker.go](/work/repo/internal/runner/docker.go#L23), and the generated/state query updates in [internal/state/store.go](/work/repo/internal/state/store.go#L668). Operator guidance was added to [docs/config.md](/work/repo/docs/config.md#L95) and [docs/deployment.md](/work/repo/docs/deployment.md#L39). The commit message was written to [commit_message.txt](/rascal-meta/commit_message.txt).\n\nVerification: `make lint` and `make test` both passed.&#34;}],&#34;metadata&#34;:{&#34;userVisible&#34;:true,&#34;agentVisible&#34;:true}}}
{&#34;type&#34;:&#34;complete&#34;,&#34;total_tokens&#34;:9210886}
</code></pre>

</details>

Closes #158

---

Rascal run `run_bb76835df54893b7` completed in 18m 20s · 9.21M tokens