### PR TITLE
feat(campaigns): add multi-run campaign orchestration

### DIFF
--- a/cmd/rascal/campaign.go
+++ b/cmd/rascal/campaign.go
@@ -1,0 +1,458 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/rtzll/rascal/internal/api"
+	"github.com/rtzll/rascal/internal/state"
+	"github.com/spf13/cobra"
+	"go.yaml.in/yaml/v3"
+)
+
+type campaignManifest struct {
+	ID          string                 `json:"id,omitempty" yaml:"id"`
+	Name        string                 `json:"name" yaml:"name"`
+	Description string                 `json:"description,omitempty" yaml:"description"`
+	Policy      campaignManifestPolicy `json:"policy" yaml:"policy"`
+	Items       []campaignManifestItem `json:"items" yaml:"items"`
+}
+
+type campaignManifestPolicy struct {
+	MaxConcurrent     int   `json:"max_concurrent" yaml:"max_concurrent"`
+	StopAfterFailures int   `json:"stop_after_failures" yaml:"stop_after_failures"`
+	ContinueOnFailure bool  `json:"continue_on_failure" yaml:"continue_on_failure"`
+	SkipIfOpenPR      *bool `json:"skip_if_open_pr,omitempty" yaml:"skip_if_open_pr"`
+}
+
+type campaignManifestItem struct {
+	Repo       string `json:"repo" yaml:"repo"`
+	Task       string `json:"task" yaml:"task"`
+	TaskID     string `json:"task_id,omitempty" yaml:"task_id"`
+	BaseBranch string `json:"base_branch,omitempty" yaml:"base_branch"`
+	Backend    string `json:"backend,omitempty" yaml:"backend"`
+}
+
+func (a *app) newCampaignCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "campaign",
+		Short: "Manage multi-run maintenance campaigns",
+		Long:  "Create, inspect, and control bounded batches of Rascal runs.",
+		Example: strings.TrimSpace(`
+rascal campaign create --name "Deps rollout" --manifest ./campaign.yaml
+rascal campaign list
+rascal campaign view camp_abc123
+rascal campaign start camp_abc123
+`),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(a.newCampaignCreateCmd())
+	cmd.AddCommand(a.newCampaignListCmd())
+	cmd.AddCommand(a.newCampaignViewCmd())
+	cmd.AddCommand(a.newCampaignActionCmd("start", "Start a draft campaign"))
+	cmd.AddCommand(a.newCampaignActionCmd("pause", "Pause a running campaign"))
+	cmd.AddCommand(a.newCampaignActionCmd("resume", "Resume a paused or failed campaign"))
+	cmd.AddCommand(a.newCampaignActionCmd("cancel", "Cancel a campaign and request cancellation for active items"))
+	cmd.AddCommand(a.newCampaignActionCmd("retry-failed", "Reset failed items and requeue the campaign"))
+	return cmd
+}
+
+func (a *app) newCampaignCreateCmd() *cobra.Command {
+	var (
+		manifestPath      string
+		inlineItems       []string
+		campaignID        string
+		name              string
+		description       string
+		maxConcurrent     int
+		stopAfterFailures int
+		continueOnFailure bool
+		skipIfOpenPR      bool
+		skipIfOpenPRSet   bool
+	)
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a draft campaign",
+		Long:  "Create a draft campaign from a manifest file and/or inline item definitions. Creation validates the batch without enqueueing runs.",
+		Example: strings.TrimSpace(`
+rascal campaign create --name "Deps rollout" --manifest ./campaign.yaml
+rascal campaign create --name "Hygiene" --item '{"repo":"owner/repo","task":"Run formatter"}'
+`),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := a.requireServerAuth(); err != nil {
+				return err
+			}
+			req, skipSpecifiedByManifest, err := a.loadCampaignCreateRequest(manifestPath, inlineItems)
+			if err != nil {
+				return err
+			}
+			maxConcurrentSet := cmd.Flags().Changed("max-concurrent")
+			stopAfterFailuresSet := cmd.Flags().Changed("stop-after-failures")
+			skipIfOpenPRSet = cmd.Flags().Changed("skip-if-open-pr")
+			if strings.TrimSpace(campaignID) != "" {
+				req.ID = strings.TrimSpace(campaignID)
+			}
+			if strings.TrimSpace(name) != "" {
+				req.Name = strings.TrimSpace(name)
+			}
+			if strings.TrimSpace(description) != "" {
+				req.Description = strings.TrimSpace(description)
+			}
+			if maxConcurrentSet && maxConcurrent > 0 {
+				req.Policy.MaxConcurrent = maxConcurrent
+			}
+			if stopAfterFailuresSet {
+				req.Policy.StopAfterFailures = stopAfterFailures
+			}
+			if continueOnFailure {
+				req.Policy.ContinueOnFailure = true
+			}
+			if skipIfOpenPRSet {
+				req.Policy.SkipIfOpenPR = skipIfOpenPR
+			} else if !skipSpecifiedByManifest {
+				req.Policy.SkipIfOpenPR = true
+			}
+			if strings.TrimSpace(req.Name) == "" {
+				return &cliError{Code: exitInput, Message: "campaign name is required", Hint: "set --name or include name in the manifest"}
+			}
+			if len(req.Items) == 0 {
+				return &cliError{Code: exitInput, Message: "campaign items are required", Hint: "set --manifest and/or --item"}
+			}
+			if err := a.applyCampaignDefaults(&req); err != nil {
+				return err
+			}
+			resp, err := doJSON(a.client, http.MethodPost, "/v1/campaigns", req)
+			if err != nil {
+				return &cliError{Code: exitServer, Message: "request failed", Cause: err}
+			}
+			defer closeWithLog("close create campaign response body", resp.Body)
+			if resp.StatusCode >= 300 {
+				return decodeServerError(resp)
+			}
+			var out api.CampaignResponse
+			if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+				return &cliError{Code: exitServer, Message: "failed to decode server response", Cause: err}
+			}
+			return emit(a, out, func() error {
+				return renderCampaignViewTable(out.Campaign)
+			})
+		},
+	}
+	cmd.Flags().StringVar(&campaignID, "id", "", "campaign identifier override")
+	cmd.Flags().StringVar(&name, "name", "", "campaign name")
+	cmd.Flags().StringVar(&description, "description", "", "campaign description")
+	cmd.Flags().StringVar(&manifestPath, "manifest", "", "path to a YAML or JSON campaign manifest")
+	cmd.Flags().StringArrayVar(&inlineItems, "item", nil, "inline item definition as JSON or YAML object")
+	cmd.Flags().IntVar(&maxConcurrent, "max-concurrent", 0, "max items to enqueue at once")
+	cmd.Flags().IntVar(&stopAfterFailures, "stop-after-failures", 1, "stop enqueueing after this many failed items (0 disables)")
+	cmd.Flags().BoolVar(&continueOnFailure, "continue-on-failure", false, "keep enqueueing items after failures")
+	cmd.Flags().BoolVar(&skipIfOpenPR, "skip-if-open-pr", true, "skip items when an open Rascal PR already exists")
+	return cmd
+}
+
+func (a *app) newCampaignListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List campaigns",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if err := a.requireServerAuth(); err != nil {
+				return err
+			}
+			out, err := a.fetchCampaigns()
+			if err != nil {
+				return err
+			}
+			return emit(a, out, func() error {
+				tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+				if _, err := fmt.Fprintln(tw, "ID\tSTATE\tTOTAL\tACTIVE\tSUCCEEDED\tFAILED\tSKIPPED\tCREATED\tNAME"); err != nil {
+					return fmt.Errorf("write campaign table header: %w", err)
+				}
+				for _, entry := range out.Campaigns {
+					if _, err := fmt.Fprintf(
+						tw,
+						"%s\t%s\t%d\t%d\t%d\t%d\t%d\t%s\t%s\n",
+						entry.Campaign.ID,
+						entry.Campaign.State,
+						entry.Summary.TotalItems,
+						entry.Summary.ActiveItems,
+						entry.Summary.Succeeded,
+						entry.Summary.Failed,
+						entry.Summary.Skipped,
+						entry.Campaign.CreatedAt.Format(time.RFC3339),
+						entry.Campaign.Name,
+					); err != nil {
+						return fmt.Errorf("write campaign table row: %w", err)
+					}
+				}
+				return tw.Flush()
+			})
+		},
+	}
+	return cmd
+}
+
+func (a *app) newCampaignViewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "view <campaign_id>",
+		Short: "Show campaign progress and item details",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if err := a.requireServerAuth(); err != nil {
+				return err
+			}
+			out, err := a.fetchCampaign(args[0])
+			if err != nil {
+				return err
+			}
+			return emit(a, out, func() error {
+				return renderCampaignViewTable(out.Campaign)
+			})
+		},
+	}
+	return cmd
+}
+
+func (a *app) newCampaignActionCmd(action, short string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   action + " <campaign_id>",
+		Short: short,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if err := a.requireServerAuth(); err != nil {
+				return err
+			}
+			out, err := a.campaignAction(args[0], action)
+			if err != nil {
+				return err
+			}
+			return emit(a, out, func() error {
+				return renderCampaignViewTable(out.Campaign)
+			})
+		},
+	}
+	return cmd
+}
+
+func (a *app) loadCampaignCreateRequest(manifestPath string, inlineItems []string) (api.CreateCampaignRequest, bool, error) {
+	req := api.CreateCampaignRequest{}
+	skipSpecified := false
+	if strings.TrimSpace(manifestPath) != "" {
+		data, err := os.ReadFile(strings.TrimSpace(manifestPath))
+		if err != nil {
+			return req, false, &cliError{Code: exitInput, Message: "failed to read campaign manifest", Cause: err}
+		}
+		manifest, err := parseCampaignManifest(data)
+		if err != nil {
+			return req, false, err
+		}
+		req, skipSpecified = manifestToCreateCampaignRequest(manifest)
+	}
+	for _, raw := range inlineItems {
+		manifestItem, err := parseCampaignManifestItem([]byte(raw))
+		if err != nil {
+			return req, false, err
+		}
+		req.Items = append(req.Items, state.CampaignItemInput{
+			Repo:            manifestItem.Repo,
+			Task:            manifestItem.Task,
+			TaskID:          manifestItem.TaskID,
+			BaseBranch:      manifestItem.BaseBranch,
+			BackendOverride: manifestItem.Backend,
+		})
+	}
+	return req, skipSpecified, nil
+}
+
+func (a *app) applyCampaignDefaults(req *api.CreateCampaignRequest) error {
+	req.Policy = state.NormalizeCampaignExecutionPolicy(req.Policy)
+	if req.Policy.MaxConcurrent == 0 {
+		req.Policy.MaxConcurrent = 1
+	}
+	if req.Policy.StopAfterFailures == 0 && !req.Policy.ContinueOnFailure {
+		req.Policy.StopAfterFailures = 1
+	}
+	for i := range req.Items {
+		req.Items[i] = state.NormalizeCampaignItemInput(req.Items[i])
+		if req.Items[i].Repo == "" {
+			req.Items[i].Repo = state.NormalizeRepo(a.cfg.DefaultRepo)
+		}
+		if req.Items[i].Repo == "" || req.Items[i].Task == "" {
+			return &cliError{Code: exitInput, Message: fmt.Sprintf("campaign item %d requires repo and task", i+1)}
+		}
+	}
+	return nil
+}
+
+func parseCampaignManifest(data []byte) (campaignManifest, error) {
+	var manifest campaignManifest
+	if err := json.Unmarshal(data, &manifest); err == nil {
+		return manifest, nil
+	}
+	if err := yaml.Unmarshal(data, &manifest); err != nil {
+		return campaignManifest{}, &cliError{Code: exitInput, Message: "failed to parse campaign manifest", Cause: err}
+	}
+	return manifest, nil
+}
+
+func parseCampaignManifestItem(data []byte) (campaignManifestItem, error) {
+	var item campaignManifestItem
+	if err := json.Unmarshal(data, &item); err == nil {
+		return item, nil
+	}
+	if err := yaml.Unmarshal(data, &item); err != nil {
+		return campaignManifestItem{}, &cliError{Code: exitInput, Message: "failed to parse inline campaign item", Cause: err}
+	}
+	return item, nil
+}
+
+func manifestToCreateCampaignRequest(manifest campaignManifest) (api.CreateCampaignRequest, bool) {
+	req := api.CreateCampaignRequest{
+		ID:          manifest.ID,
+		Name:        manifest.Name,
+		Description: manifest.Description,
+		Policy: state.CampaignExecutionPolicy{
+			MaxConcurrent:     manifest.Policy.MaxConcurrent,
+			StopAfterFailures: manifest.Policy.StopAfterFailures,
+			ContinueOnFailure: manifest.Policy.ContinueOnFailure,
+			SkipIfOpenPR:      true,
+		},
+	}
+	skipSpecified := false
+	if manifest.Policy.SkipIfOpenPR != nil {
+		req.Policy.SkipIfOpenPR = *manifest.Policy.SkipIfOpenPR
+		skipSpecified = true
+	}
+	for _, item := range manifest.Items {
+		req.Items = append(req.Items, state.CampaignItemInput{
+			Repo:            item.Repo,
+			Task:            item.Task,
+			TaskID:          item.TaskID,
+			BaseBranch:      item.BaseBranch,
+			BackendOverride: item.Backend,
+		})
+	}
+	return req, skipSpecified
+}
+
+func (a *app) fetchCampaigns() (api.CampaignListResponse, error) {
+	resp, err := a.client.do(http.MethodGet, "/v1/campaigns", nil)
+	if err != nil {
+		return api.CampaignListResponse{}, &cliError{Code: exitServer, Message: "request failed", Cause: err}
+	}
+	defer closeWithLog("close list campaigns response body", resp.Body)
+	if resp.StatusCode >= 300 {
+		return api.CampaignListResponse{}, decodeServerError(resp)
+	}
+	var out api.CampaignListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return api.CampaignListResponse{}, &cliError{Code: exitServer, Message: "failed to decode server response", Cause: err}
+	}
+	return out, nil
+}
+
+func (a *app) fetchCampaign(campaignID string) (api.CampaignResponse, error) {
+	resp, err := a.client.do(http.MethodGet, "/v1/campaigns/"+campaignID, nil)
+	if err != nil {
+		return api.CampaignResponse{}, &cliError{Code: exitServer, Message: "request failed", Cause: err}
+	}
+	defer closeWithLog("close get campaign response body", resp.Body)
+	if resp.StatusCode >= 300 {
+		return api.CampaignResponse{}, decodeServerError(resp)
+	}
+	var out api.CampaignResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return api.CampaignResponse{}, &cliError{Code: exitServer, Message: "failed to decode server response", Cause: err}
+	}
+	return out, nil
+}
+
+func (a *app) campaignAction(campaignID, action string) (api.CampaignResponse, error) {
+	resp, err := a.client.do(http.MethodPost, "/v1/campaigns/"+campaignID+"/"+action, nil)
+	if err != nil {
+		return api.CampaignResponse{}, &cliError{Code: exitServer, Message: "request failed", Cause: err}
+	}
+	defer closeWithLog("close campaign action response body", resp.Body)
+	if resp.StatusCode >= 300 {
+		return api.CampaignResponse{}, decodeServerError(resp)
+	}
+	var out api.CampaignResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return api.CampaignResponse{}, &cliError{Code: exitServer, Message: "failed to decode server response", Cause: err}
+	}
+	return out, nil
+}
+
+func renderCampaignViewTable(view api.CampaignView) error {
+	fmt.Printf("Campaign: %s\n", view.Campaign.ID)
+	fmt.Printf("Name: %s\n", view.Campaign.Name)
+	fmt.Printf("State: %s\n", view.Campaign.State)
+	if strings.TrimSpace(view.Campaign.Description) != "" {
+		fmt.Printf("Description: %s\n", view.Campaign.Description)
+	}
+	fmt.Printf(
+		"Policy: max_concurrent=%d stop_after_failures=%d continue_on_failure=%t skip_if_open_pr=%t\n",
+		view.Campaign.Policy.MaxConcurrent,
+		view.Campaign.Policy.StopAfterFailures,
+		view.Campaign.Policy.ContinueOnFailure,
+		view.Campaign.Policy.SkipIfOpenPR,
+	)
+	fmt.Printf(
+		"Summary: total=%d active=%d succeeded=%d failed=%d skipped=%d canceled=%d review=%d pending=%d queued=%d running=%d\n",
+		view.Summary.TotalItems,
+		view.Summary.ActiveItems,
+		view.Summary.Succeeded,
+		view.Summary.Failed,
+		view.Summary.Skipped,
+		view.Summary.Canceled,
+		view.Summary.Review,
+		view.Summary.Pending,
+		view.Summary.Queued,
+		view.Summary.Running,
+	)
+
+	tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "ORDER\tSTATE\tREPO\tRUN\tPR\tREASON\tTASK"); err != nil {
+		return fmt.Errorf("write campaign view header: %w", err)
+	}
+	for _, item := range view.Items {
+		reason := strings.TrimSpace(item.Item.SkipReason)
+		if reason == "" {
+			reason = strings.TrimSpace(item.Item.FailureReason)
+		}
+		prLabel := "-"
+		runID := strings.TrimSpace(item.Item.RunID)
+		if item.Run != nil {
+			runID = item.Run.ID
+			if item.Run.PRNumber > 0 {
+				prLabel = fmt.Sprintf("#%d", item.Run.PRNumber)
+			}
+		}
+		if runID == "" {
+			runID = "-"
+		}
+		if _, err := fmt.Fprintf(
+			tw,
+			"%d\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			item.Item.Order,
+			item.Item.State,
+			item.Item.Repo,
+			runID,
+			prLabel,
+			reason,
+			item.Item.Task,
+		); err != nil {
+			return fmt.Errorf("write campaign view row: %w", err)
+		}
+	}
+	if err := tw.Flush(); err != nil {
+		return fmt.Errorf("flush campaign view table: %w", err)
+	}
+	return nil
+}

--- a/cmd/rascal/campaign_test.go
+++ b/cmd/rascal/campaign_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rtzll/rascal/internal/api"
+	"github.com/rtzll/rascal/internal/config"
+	"github.com/rtzll/rascal/internal/state"
+)
+
+func TestLoadCampaignCreateRequestFromManifestAndInlineItems(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	manifestPath := filepath.Join(tmp, "campaign.yaml")
+	if err := os.WriteFile(manifestPath, []byte(`
+name: deps rollout
+description: batch dependency updates
+policy:
+  max_concurrent: 2
+  stop_after_failures: 3
+  continue_on_failure: true
+  skip_if_open_pr: false
+items:
+  - repo: owner/repo
+    task: Update dependencies
+    task_id: deps-owner-repo
+    base_branch: main
+    backend: goose
+`), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	a := &app{}
+	req, skipSpecified, err := a.loadCampaignCreateRequest(manifestPath, []string{
+		`{"repo":"owner/other","task":"Run formatter","base_branch":"develop"}`,
+	})
+	if err != nil {
+		t.Fatalf("load campaign create request: %v", err)
+	}
+	if !skipSpecified {
+		t.Fatal("expected skip_if_open_pr to be marked as explicitly set")
+	}
+	if req.Name != "deps rollout" {
+		t.Fatalf("name = %q, want deps rollout", req.Name)
+	}
+	if req.Policy.MaxConcurrent != 2 {
+		t.Fatalf("max_concurrent = %d, want 2", req.Policy.MaxConcurrent)
+	}
+	if req.Policy.StopAfterFailures != 3 {
+		t.Fatalf("stop_after_failures = %d, want 3", req.Policy.StopAfterFailures)
+	}
+	if !req.Policy.ContinueOnFailure {
+		t.Fatal("expected continue_on_failure to be true")
+	}
+	if req.Policy.SkipIfOpenPR {
+		t.Fatal("expected skip_if_open_pr to remain false from manifest")
+	}
+	if len(req.Items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(req.Items))
+	}
+	if req.Items[0].BackendOverride != "goose" {
+		t.Fatalf("backend override = %q, want goose", req.Items[0].BackendOverride)
+	}
+	if req.Items[1].Repo != "owner/other" {
+		t.Fatalf("second item repo = %q, want owner/other", req.Items[1].Repo)
+	}
+}
+
+func TestApplyCampaignDefaultsUsesDefaultRepo(t *testing.T) {
+	t.Parallel()
+
+	a := &app{
+		cfg: config.ClientConfig{
+			DefaultRepo: "Owner/Repo",
+		},
+	}
+	req := apiCreateCampaignRequestForTest()
+	if err := a.applyCampaignDefaults(&req); err != nil {
+		t.Fatalf("apply campaign defaults: %v", err)
+	}
+	if req.Policy.MaxConcurrent != 1 {
+		t.Fatalf("max concurrent = %d, want 1", req.Policy.MaxConcurrent)
+	}
+	if req.Policy.StopAfterFailures != 1 {
+		t.Fatalf("stop after failures = %d, want 1", req.Policy.StopAfterFailures)
+	}
+	if req.Items[0].Repo != "owner/repo" {
+		t.Fatalf("repo = %q, want owner/repo", req.Items[0].Repo)
+	}
+}
+
+func apiCreateCampaignRequestForTest() api.CreateCampaignRequest {
+	return api.CreateCampaignRequest{
+		Name: "defaults",
+		Items: []state.CampaignItemInput{
+			{Task: "Run formatter"},
+		},
+	}
+}

--- a/cmd/rascal/main.go
+++ b/cmd/rascal/main.go
@@ -341,6 +341,8 @@ func newRootCmd() *cobra.Command {
 	cancelCmd.GroupID = "runs"
 	taskCmd := a.newTaskCmd()
 	taskCmd.GroupID = "runs"
+	campaignCmd := a.newCampaignCmd()
+	campaignCmd.GroupID = "runs"
 
 	logsCmd := a.newLogsCmd()
 	logsCmd.GroupID = "logs"
@@ -366,6 +368,7 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(retryCmd)
 	root.AddCommand(cancelCmd)
 	root.AddCommand(taskCmd)
+	root.AddCommand(campaignCmd)
 	root.AddCommand(logsCmd)
 	root.AddCommand(githubCmd)
 	root.AddCommand(infraCmd)

--- a/cmd/rascal/testdata/help/root.golden
+++ b/cmd/rascal/testdata/help/root.golden
@@ -12,6 +12,7 @@ Setup:
   init        Initialize local Rascal CLI config
 
 Runs:
+  campaign    Manage multi-run maintenance campaigns
   cancel      Cancel a queued or running run
   open        Open PR URL for a run in your browser
   ps          List recent runs

--- a/cmd/rascald/campaigns.go
+++ b/cmd/rascald/campaigns.go
@@ -1,0 +1,662 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/rtzll/rascal/internal/agent"
+	"github.com/rtzll/rascal/internal/api"
+	"github.com/rtzll/rascal/internal/state"
+)
+
+func (s *server) handleCampaigns(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		entries, err := s.listCampaignEntries()
+		if err != nil {
+			http.Error(w, "failed to list campaigns", http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, http.StatusOK, api.CampaignListResponse{Campaigns: entries})
+	case http.MethodPost:
+		if s.isDraining() {
+			http.Error(w, "server is draining", http.StatusServiceUnavailable)
+			return
+		}
+		var req api.CreateCampaignRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid JSON body", http.StatusBadRequest)
+			return
+		}
+		campaign, _, err := s.store.CreateCampaign(state.CreateCampaignInput{
+			ID:          req.ID,
+			Name:        req.Name,
+			Description: req.Description,
+			Policy:      req.Policy,
+			Items:       req.Items,
+		})
+		if err != nil {
+			http.Error(w, "failed to create campaign: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		view, err := s.buildCampaignView(campaign.ID, false)
+		if err != nil {
+			http.Error(w, "failed to load campaign", http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, http.StatusCreated, api.CampaignResponse{Campaign: view})
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *server) handleCampaignSubresources(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/v1/campaigns/")
+	path = strings.Trim(path, "/")
+	if path == "" {
+		http.Error(w, "campaign id is required", http.StatusBadRequest)
+		return
+	}
+	parts := strings.Split(path, "/")
+	campaignID := strings.TrimSpace(parts[0])
+	if campaignID == "" {
+		http.Error(w, "campaign id is required", http.StatusBadRequest)
+		return
+	}
+
+	if len(parts) == 1 {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		view, err := s.buildCampaignView(campaignID, true)
+		if err != nil {
+			if errors.Is(err, errNotFound) {
+				http.Error(w, "campaign not found", http.StatusNotFound)
+				return
+			}
+			http.Error(w, "failed to load campaign", http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, http.StatusOK, api.CampaignResponse{Campaign: view})
+		return
+	}
+
+	if len(parts) != 2 || r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var (
+		view api.CampaignView
+		err  error
+	)
+	switch parts[1] {
+	case "start":
+		view, err = s.startCampaign(campaignID)
+	case "pause":
+		view, err = s.pauseCampaign(campaignID)
+	case "resume":
+		view, err = s.resumeCampaign(campaignID)
+	case "cancel":
+		view, err = s.cancelCampaign(campaignID)
+	case "retry-failed":
+		view, err = s.retryFailedCampaignItems(campaignID)
+	default:
+		http.Error(w, "unknown campaign action", http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		if errors.Is(err, errNotFound) {
+			http.Error(w, "campaign not found", http.StatusNotFound)
+			return
+		}
+		var cliErr *campaignActionError
+		if errors.As(err, &cliErr) {
+			http.Error(w, cliErr.Error(), http.StatusBadRequest)
+			return
+		}
+		http.Error(w, "campaign action failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, api.CampaignResponse{Campaign: view})
+}
+
+var errNotFound = errors.New("not found")
+
+type campaignActionError struct {
+	message string
+}
+
+func (e *campaignActionError) Error() string {
+	return e.message
+}
+
+func wrapCampaignErr(action string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", action, err)
+}
+
+func (s *server) listCampaignEntries() ([]api.CampaignListEntry, error) {
+	if err := s.scheduleCampaigns(); err != nil {
+		return nil, wrapCampaignErr("schedule campaigns before list", err)
+	}
+	campaigns, err := s.store.ListCampaigns()
+	if err != nil {
+		return nil, wrapCampaignErr("list campaigns", err)
+	}
+	out := make([]api.CampaignListEntry, 0, len(campaigns))
+	for _, campaign := range campaigns {
+		items, err := s.store.ListCampaignItems(campaign.ID)
+		if err != nil {
+			return nil, wrapCampaignErr("list campaign items", err)
+		}
+		out = append(out, api.CampaignListEntry{
+			Campaign: campaign,
+			Summary:  state.SummarizeCampaignItems(items),
+		})
+	}
+	return out, nil
+}
+
+func (s *server) buildCampaignView(campaignID string, sync bool) (api.CampaignView, error) {
+	if sync {
+		if err := s.syncCampaign(campaignID); err != nil {
+			return api.CampaignView{}, err
+		}
+	}
+	campaign, ok, err := s.store.GetCampaign(campaignID)
+	if err != nil {
+		return api.CampaignView{}, wrapCampaignErr("get campaign", err)
+	}
+	if !ok {
+		return api.CampaignView{}, errNotFound
+	}
+	items, err := s.store.ListCampaignItems(campaignID)
+	if err != nil {
+		return api.CampaignView{}, wrapCampaignErr("list campaign items", err)
+	}
+	viewItems := make([]api.CampaignItemView, 0, len(items))
+	for _, item := range items {
+		itemView := api.CampaignItemView{Item: item}
+		if strings.TrimSpace(item.RunID) != "" {
+			if run, ok := s.store.GetRun(item.RunID); ok {
+				runCopy := run
+				itemView.Run = &runCopy
+			}
+		}
+		viewItems = append(viewItems, itemView)
+	}
+	return api.CampaignView{
+		Campaign: campaign,
+		Summary:  state.SummarizeCampaignItems(items),
+		Items:    viewItems,
+	}, nil
+}
+
+func (s *server) startCampaign(campaignID string) (api.CampaignView, error) {
+	campaign, ok, err := s.store.GetCampaign(campaignID)
+	if err != nil {
+		return api.CampaignView{}, wrapCampaignErr("get campaign", err)
+	}
+	if !ok {
+		return api.CampaignView{}, errNotFound
+	}
+	if campaign.State != state.CampaignStateDraft {
+		return api.CampaignView{}, &campaignActionError{message: "campaign start only supports draft campaigns"}
+	}
+	if _, err := s.store.UpdateCampaign(campaign.ID, func(c *state.Campaign) error {
+		now := time.Now().UTC()
+		c.State = state.CampaignStateRunning
+		if c.StartedAt == nil {
+			c.StartedAt = &now
+		}
+		c.CompletedAt = nil
+		return nil
+	}); err != nil {
+		return api.CampaignView{}, wrapCampaignErr("start campaign", err)
+	}
+	if err := s.scheduleCampaigns(); err != nil {
+		return api.CampaignView{}, wrapCampaignErr("schedule campaign start", err)
+	}
+	return s.buildCampaignView(campaignID, true)
+}
+
+func (s *server) pauseCampaign(campaignID string) (api.CampaignView, error) {
+	campaign, ok, err := s.store.GetCampaign(campaignID)
+	if err != nil {
+		return api.CampaignView{}, wrapCampaignErr("get campaign", err)
+	}
+	if !ok {
+		return api.CampaignView{}, errNotFound
+	}
+	if campaign.State != state.CampaignStateRunning {
+		return api.CampaignView{}, &campaignActionError{message: "campaign pause only supports running campaigns"}
+	}
+	if _, err := s.store.UpdateCampaign(campaign.ID, func(c *state.Campaign) error {
+		c.State = state.CampaignStatePaused
+		return nil
+	}); err != nil {
+		return api.CampaignView{}, wrapCampaignErr("pause campaign", err)
+	}
+	return s.buildCampaignView(campaignID, true)
+}
+
+func (s *server) resumeCampaign(campaignID string) (api.CampaignView, error) {
+	campaign, ok, err := s.store.GetCampaign(campaignID)
+	if err != nil {
+		return api.CampaignView{}, wrapCampaignErr("get campaign", err)
+	}
+	if !ok {
+		return api.CampaignView{}, errNotFound
+	}
+	if campaign.State != state.CampaignStatePaused && campaign.State != state.CampaignStateFailed {
+		return api.CampaignView{}, &campaignActionError{message: "campaign resume only supports paused or failed campaigns"}
+	}
+	if _, err := s.store.UpdateCampaign(campaign.ID, func(c *state.Campaign) error {
+		now := time.Now().UTC()
+		c.State = state.CampaignStateRunning
+		if c.StartedAt == nil {
+			c.StartedAt = &now
+		}
+		c.CompletedAt = nil
+		return nil
+	}); err != nil {
+		return api.CampaignView{}, wrapCampaignErr("resume campaign", err)
+	}
+	if err := s.scheduleCampaigns(); err != nil {
+		return api.CampaignView{}, wrapCampaignErr("schedule campaign resume", err)
+	}
+	return s.buildCampaignView(campaignID, true)
+}
+
+func (s *server) cancelCampaign(campaignID string) (api.CampaignView, error) {
+	campaign, ok, err := s.store.GetCampaign(campaignID)
+	if err != nil {
+		return api.CampaignView{}, wrapCampaignErr("get campaign", err)
+	}
+	if !ok {
+		return api.CampaignView{}, errNotFound
+	}
+	if campaign.State == state.CampaignStateCompleted || campaign.State == state.CampaignStateCanceled {
+		return api.CampaignView{}, &campaignActionError{message: "campaign cancel does not support completed or canceled campaigns"}
+	}
+	items, err := s.store.ListCampaignItems(campaign.ID)
+	if err != nil {
+		return api.CampaignView{}, wrapCampaignErr("list campaign items", err)
+	}
+	for _, item := range items {
+		switch item.State {
+		case state.CampaignItemStatePending:
+			if _, err := s.store.UpdateCampaignItem(item.ID, func(ci *state.CampaignItem) error {
+				ci.State = state.CampaignItemStateCanceled
+				ci.SkipReason = "campaign canceled"
+				ci.FailureReason = ""
+				return nil
+			}); err != nil {
+				return api.CampaignView{}, wrapCampaignErr("mark pending campaign item canceled", err)
+			}
+		case state.CampaignItemStateQueued, state.CampaignItemStateRunning:
+			if err := s.store.RequestRunCancel(item.RunID, "campaign canceled", "campaign"); err != nil {
+				return api.CampaignView{}, wrapCampaignErr("request run cancel", err)
+			}
+			if run, ok := s.store.GetRun(item.RunID); ok && run.Status == state.StatusQueued {
+				if _, err := s.store.SetRunStatus(item.RunID, state.StatusCanceled, "campaign canceled"); err != nil {
+					return api.CampaignView{}, wrapCampaignErr("cancel queued run", err)
+				}
+			} else {
+				s.stopRunExecutionBestEffort(item.RunID, "campaign cancellation")
+			}
+		}
+	}
+	if _, err := s.store.UpdateCampaign(campaign.ID, func(c *state.Campaign) error {
+		now := time.Now().UTC()
+		c.State = state.CampaignStateCanceled
+		c.CompletedAt = &now
+		return nil
+	}); err != nil {
+		return api.CampaignView{}, wrapCampaignErr("cancel campaign", err)
+	}
+	return s.buildCampaignView(campaignID, true)
+}
+
+func (s *server) retryFailedCampaignItems(campaignID string) (api.CampaignView, error) {
+	campaign, ok, err := s.store.GetCampaign(campaignID)
+	if err != nil {
+		return api.CampaignView{}, wrapCampaignErr("get campaign", err)
+	}
+	if !ok {
+		return api.CampaignView{}, errNotFound
+	}
+	if campaign.State == state.CampaignStateCanceled {
+		return api.CampaignView{}, &campaignActionError{message: "campaign retry-failed does not support canceled campaigns"}
+	}
+	items, err := s.store.ListCampaignItems(campaign.ID)
+	if err != nil {
+		return api.CampaignView{}, wrapCampaignErr("list campaign items", err)
+	}
+	resetCount := 0
+	for _, item := range items {
+		if item.State != state.CampaignItemStateFailed {
+			continue
+		}
+		if _, err := s.store.UpdateCampaignItem(item.ID, func(ci *state.CampaignItem) error {
+			ci.State = state.CampaignItemStatePending
+			ci.RunID = ""
+			ci.SkipReason = ""
+			ci.FailureReason = ""
+			return nil
+		}); err != nil {
+			return api.CampaignView{}, wrapCampaignErr("reset failed campaign item", err)
+		}
+		resetCount++
+	}
+	if resetCount == 0 {
+		return api.CampaignView{}, &campaignActionError{message: "campaign has no failed items to retry"}
+	}
+	if _, err := s.store.UpdateCampaign(campaign.ID, func(c *state.Campaign) error {
+		now := time.Now().UTC()
+		c.State = state.CampaignStateRunning
+		if c.StartedAt == nil {
+			c.StartedAt = &now
+		}
+		c.CompletedAt = nil
+		return nil
+	}); err != nil {
+		return api.CampaignView{}, wrapCampaignErr("retry failed campaign items", err)
+	}
+	if err := s.scheduleCampaigns(); err != nil {
+		return api.CampaignView{}, wrapCampaignErr("schedule campaign retry", err)
+	}
+	return s.buildCampaignView(campaignID, true)
+}
+
+func (s *server) scheduleCampaigns() error {
+	campaigns, err := s.store.ListCampaigns()
+	if err != nil {
+		return wrapCampaignErr("list campaigns for scheduler", err)
+	}
+	for _, campaign := range campaigns {
+		if err := s.syncCampaign(campaign.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *server) syncCampaign(campaignID string) error {
+	campaign, ok, err := s.store.GetCampaign(campaignID)
+	if err != nil {
+		return wrapCampaignErr("get campaign for sync", err)
+	}
+	if !ok {
+		return errNotFound
+	}
+	items, err := s.store.ListCampaignItems(campaignID)
+	if err != nil {
+		return wrapCampaignErr("list campaign items for sync", err)
+	}
+
+	changed := false
+	for _, item := range items {
+		_, itemChanged, err := s.syncCampaignItem(item)
+		if err != nil {
+			return wrapCampaignErr("sync campaign item", err)
+		}
+		if itemChanged {
+			changed = true
+		}
+	}
+	if changed {
+		campaign, ok, err = s.store.GetCampaign(campaignID)
+		if err != nil {
+			return wrapCampaignErr("reload campaign", err)
+		}
+		if !ok {
+			return errNotFound
+		}
+		items, err = s.store.ListCampaignItems(campaignID)
+		if err != nil {
+			return wrapCampaignErr("reload campaign items", err)
+		}
+	}
+
+	summary := state.SummarizeCampaignItems(items)
+	if campaign.State == state.CampaignStateRunning && campaignFailureThresholdReached(campaign, summary) {
+		if _, err := s.store.UpdateCampaign(campaign.ID, func(c *state.Campaign) error {
+			now := time.Now().UTC()
+			c.State = state.CampaignStateFailed
+			c.CompletedAt = &now
+			return nil
+		}); err != nil {
+			return wrapCampaignErr("mark campaign failed", err)
+		}
+		campaign.State = state.CampaignStateFailed
+	}
+
+	if campaign.State == state.CampaignStateRunning {
+		enqueued, err := s.enqueueCampaignItems(campaign, items)
+		if err != nil {
+			return wrapCampaignErr("enqueue campaign items", err)
+		}
+		if enqueued {
+			campaign, ok, err = s.store.GetCampaign(campaignID)
+			if err != nil {
+				return wrapCampaignErr("reload campaign after enqueue", err)
+			}
+			if !ok {
+				return errNotFound
+			}
+			items, err = s.store.ListCampaignItems(campaignID)
+			if err != nil {
+				return wrapCampaignErr("reload campaign items after enqueue", err)
+			}
+			summary = state.SummarizeCampaignItems(items)
+			if campaignFailureThresholdReached(campaign, summary) {
+				if _, err := s.store.UpdateCampaign(campaign.ID, func(c *state.Campaign) error {
+					now := time.Now().UTC()
+					c.State = state.CampaignStateFailed
+					c.CompletedAt = &now
+					return nil
+				}); err != nil {
+					return wrapCampaignErr("mark campaign failed after enqueue", err)
+				}
+				campaign.State = state.CampaignStateFailed
+			}
+		}
+	}
+
+	if campaign.State == state.CampaignStateRunning || campaign.State == state.CampaignStateFailed {
+		if summary.Pending == 0 && summary.ActiveItems == 0 {
+			nextState := state.CampaignStateCompleted
+			if summary.Failed > 0 && !campaign.Policy.ContinueOnFailure {
+				nextState = state.CampaignStateFailed
+			}
+			if _, err := s.store.UpdateCampaign(campaign.ID, func(c *state.Campaign) error {
+				now := time.Now().UTC()
+				c.State = nextState
+				c.CompletedAt = &now
+				return nil
+			}); err != nil {
+				return wrapCampaignErr("finalize campaign state", err)
+			}
+		}
+	}
+	return nil
+}
+
+func (s *server) syncCampaignItem(item state.CampaignItem) (state.CampaignItem, bool, error) {
+	if item.State == state.CampaignItemStateSkipped {
+		return item, false, nil
+	}
+	if strings.TrimSpace(item.RunID) == "" {
+		return item, false, nil
+	}
+	run, ok := s.store.GetRun(item.RunID)
+	if !ok {
+		if item.State == state.CampaignItemStateQueued || item.State == state.CampaignItemStateRunning {
+			updated, err := s.store.UpdateCampaignItem(item.ID, func(ci *state.CampaignItem) error {
+				ci.State = state.CampaignItemStateFailed
+				ci.FailureReason = "linked run not found"
+				return nil
+			})
+			return updated, true, wrapCampaignErr("mark missing linked run as failed", err)
+		}
+		return item, false, nil
+	}
+	nextState := state.CampaignItemStateFromRunStatus(run.Status)
+	nextSkipReason := item.SkipReason
+	nextFailureReason := item.FailureReason
+	switch nextState {
+	case state.CampaignItemStateQueued, state.CampaignItemStateRunning, state.CampaignItemStateReview, state.CampaignItemStateSucceeded:
+		nextSkipReason = ""
+		nextFailureReason = ""
+	case state.CampaignItemStateFailed, state.CampaignItemStateCanceled:
+		nextFailureReason = strings.TrimSpace(run.Error)
+	}
+	if item.State == nextState && item.TaskID == run.TaskID && item.RunID == run.ID && item.SkipReason == nextSkipReason && item.FailureReason == nextFailureReason {
+		return item, false, nil
+	}
+	updated, err := s.store.UpdateCampaignItem(item.ID, func(ci *state.CampaignItem) error {
+		ci.State = nextState
+		ci.TaskID = run.TaskID
+		ci.RunID = run.ID
+		ci.SkipReason = nextSkipReason
+		ci.FailureReason = nextFailureReason
+		return nil
+	})
+	return updated, true, wrapCampaignErr("sync campaign item state", err)
+}
+
+func (s *server) enqueueCampaignItems(campaign state.Campaign, items []state.CampaignItem) (bool, error) {
+	summary := state.SummarizeCampaignItems(items)
+	available := campaign.Policy.MaxConcurrent - summary.ActiveItems
+	if available <= 0 {
+		return false, nil
+	}
+	changed := false
+	for _, item := range items {
+		if available <= 0 {
+			break
+		}
+		if item.State != state.CampaignItemStatePending {
+			continue
+		}
+		if campaignFailureThresholdReached(campaign, state.SummarizeCampaignItems(items)) {
+			break
+		}
+		if campaign.Policy.SkipIfOpenPR {
+			if existing, ok := s.findOpenPRRun(item); ok {
+				updated, err := s.store.UpdateCampaignItem(item.ID, func(ci *state.CampaignItem) error {
+					ci.State = state.CampaignItemStateSkipped
+					ci.RunID = existing.ID
+					ci.SkipReason = fmt.Sprintf("open Rascal PR already exists for run %s", existing.ID)
+					ci.FailureReason = ""
+					return nil
+				})
+				if err != nil {
+					return changed, wrapCampaignErr("skip campaign item for open PR", err)
+				}
+				items[item.Order-1] = updated
+				changed = true
+				continue
+			}
+		}
+
+		req := runRequest{
+			TaskID:          item.TaskID,
+			Repo:            item.Repo,
+			Task:            item.Task,
+			BaseBranch:      item.BaseBranch,
+			Trigger:         "campaign",
+			AgentBackend:    strings.TrimSpace(item.BackendOverride),
+			CreatedByUserID: "system",
+		}
+		run, err := s.createAndQueueRun(req)
+		if err != nil {
+			nextState := state.CampaignItemStateFailed
+			reason := err.Error()
+			if errors.Is(err, errTaskCompleted) {
+				nextState = state.CampaignItemStateSkipped
+				reason = "task is already completed"
+			}
+			updated, updateErr := s.store.UpdateCampaignItem(item.ID, func(ci *state.CampaignItem) error {
+				ci.State = nextState
+				if nextState == state.CampaignItemStateSkipped {
+					ci.SkipReason = reason
+					ci.FailureReason = ""
+				} else {
+					ci.FailureReason = reason
+					ci.SkipReason = ""
+				}
+				return nil
+			})
+			if updateErr != nil {
+				return changed, wrapCampaignErr("record campaign item enqueue failure", updateErr)
+			}
+			items[item.Order-1] = updated
+			changed = true
+			continue
+		}
+
+		updated, err := s.store.UpdateCampaignItem(item.ID, func(ci *state.CampaignItem) error {
+			ci.State = state.CampaignItemStateQueued
+			ci.TaskID = run.TaskID
+			ci.RunID = run.ID
+			ci.SkipReason = ""
+			ci.FailureReason = ""
+			return nil
+		})
+		if err != nil {
+			return changed, wrapCampaignErr("record queued campaign item", err)
+		}
+		items[item.Order-1] = updated
+		available--
+		changed = true
+	}
+	return changed, nil
+}
+
+func campaignFailureThresholdReached(campaign state.Campaign, summary state.CampaignSummary) bool {
+	if campaign.Policy.ContinueOnFailure {
+		return false
+	}
+	if campaign.Policy.StopAfterFailures <= 0 {
+		return false
+	}
+	return summary.Failed >= campaign.Policy.StopAfterFailures
+}
+
+func (s *server) findOpenPRRun(item state.CampaignItem) (state.Run, bool) {
+	taskID := strings.TrimSpace(item.TaskID)
+	task := strings.TrimSpace(item.Task)
+	for _, run := range s.store.ListRuns(10000) {
+		if !strings.EqualFold(run.Repo, item.Repo) {
+			continue
+		}
+		if run.PRStatus != state.PRStatusOpen || run.PRNumber <= 0 {
+			continue
+		}
+		if taskID != "" && run.TaskID == taskID {
+			return run, true
+		}
+		if task != "" && strings.TrimSpace(run.Task) == task {
+			return run, true
+		}
+	}
+	return state.Run{}, false
+}
+
+func normalizeCampaignBackend(raw string, fallback agent.Backend) agent.Backend {
+	raw = strings.TrimSpace(strings.ToLower(raw))
+	if raw == "" {
+		return fallback
+	}
+	return agent.NormalizeBackend(raw)
+}

--- a/cmd/rascald/campaigns_test.go
+++ b/cmd/rascald/campaigns_test.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rtzll/rascal/internal/state"
+)
+
+func TestCampaignPauseResumeFlow(t *testing.T) {
+	t.Parallel()
+
+	waitCh := make(chan struct{})
+	launcher := &fakeLauncher{waitCh: waitCh}
+	s := newTestServer(t, launcher)
+
+	campaign, _, err := s.store.CreateCampaign(state.CreateCampaignInput{
+		Name: "pause resume",
+		Policy: state.CampaignExecutionPolicy{
+			MaxConcurrent:     1,
+			StopAfterFailures: 1,
+			SkipIfOpenPR:      true,
+		},
+		Items: []state.CampaignItemInput{
+			{Repo: "owner/repo", Task: "first item"},
+			{Repo: "owner/repo", Task: "second item"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create campaign: %v", err)
+	}
+
+	if _, err := s.startCampaign(campaign.ID); err != nil {
+		t.Fatalf("start campaign: %v", err)
+	}
+	waitFor(t, time.Second, func() bool { return launcher.Calls() == 1 }, "first campaign run to start")
+
+	if _, err := s.pauseCampaign(campaign.ID); err != nil {
+		t.Fatalf("pause campaign: %v", err)
+	}
+
+	close(waitCh)
+	waitFor(t, 2*time.Second, func() bool {
+		view, err := s.buildCampaignView(campaign.ID, true)
+		if err != nil {
+			return false
+		}
+		return view.Campaign.State == state.CampaignStatePaused &&
+			view.Summary.Succeeded == 1 &&
+			view.Summary.Pending == 1 &&
+			launcher.Calls() == 1
+	}, "campaign remains paused after active item completes")
+
+	if _, err := s.resumeCampaign(campaign.ID); err != nil {
+		t.Fatalf("resume campaign: %v", err)
+	}
+	waitFor(t, time.Second, func() bool { return launcher.Calls() == 2 }, "second campaign run to start after resume")
+	waitFor(t, 2*time.Second, func() bool {
+		view, err := s.buildCampaignView(campaign.ID, true)
+		if err != nil {
+			return false
+		}
+		return view.Campaign.State == state.CampaignStateCompleted &&
+			view.Summary.Succeeded == 2
+	}, "campaign completes after resume")
+	waitForServerIdle(t, s)
+}
+
+func TestCampaignRetryFailedStopsAtThreshold(t *testing.T) {
+	t.Parallel()
+
+	launcher := &fakeLauncher{
+		resSeq: []fakeRunResult{
+			{ExitCode: 1, Error: "boom"},
+			{},
+			{},
+		},
+	}
+	s := newTestServer(t, launcher)
+
+	campaign, _, err := s.store.CreateCampaign(state.CreateCampaignInput{
+		Name: "retry failed",
+		Policy: state.CampaignExecutionPolicy{
+			MaxConcurrent:     1,
+			StopAfterFailures: 1,
+			SkipIfOpenPR:      true,
+		},
+		Items: []state.CampaignItemInput{
+			{Repo: "owner/repo", Task: "first item"},
+			{Repo: "owner/repo", Task: "second item"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create campaign: %v", err)
+	}
+
+	if _, err := s.startCampaign(campaign.ID); err != nil {
+		t.Fatalf("start campaign: %v", err)
+	}
+	waitFor(t, 2*time.Second, func() bool {
+		view, err := s.buildCampaignView(campaign.ID, true)
+		if err != nil {
+			return false
+		}
+		return view.Campaign.State == state.CampaignStateFailed &&
+			view.Summary.Failed == 1 &&
+			view.Summary.Pending == 1
+	}, "campaign stops after reaching failure threshold")
+
+	if _, err := s.retryFailedCampaignItems(campaign.ID); err != nil {
+		t.Fatalf("retry failed campaign items: %v", err)
+	}
+	waitFor(t, 2*time.Second, func() bool {
+		view, err := s.buildCampaignView(campaign.ID, true)
+		if err != nil {
+			return false
+		}
+		return view.Campaign.State == state.CampaignStateCompleted &&
+			view.Summary.Succeeded == 2 &&
+			view.Summary.Failed == 0
+	}, "campaign completes after retrying failed item")
+}
+
+func TestCampaignCancelRequestsRunCancellation(t *testing.T) {
+	t.Parallel()
+
+	waitCh := make(chan struct{})
+	launcher := &fakeLauncher{waitCh: waitCh}
+	s := newTestServer(t, launcher)
+
+	campaign, _, err := s.store.CreateCampaign(state.CreateCampaignInput{
+		Name: "cancel campaign",
+		Policy: state.CampaignExecutionPolicy{
+			MaxConcurrent:     1,
+			StopAfterFailures: 1,
+			SkipIfOpenPR:      true,
+		},
+		Items: []state.CampaignItemInput{
+			{Repo: "owner/repo", Task: "cancel me"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create campaign: %v", err)
+	}
+
+	if _, err := s.startCampaign(campaign.ID); err != nil {
+		t.Fatalf("start campaign: %v", err)
+	}
+	waitFor(t, time.Second, func() bool { return launcher.Calls() == 1 }, "campaign run to start before cancel")
+
+	view, err := s.cancelCampaign(campaign.ID)
+	if err != nil {
+		t.Fatalf("cancel campaign: %v", err)
+	}
+	if view.Campaign.State != state.CampaignStateCanceled {
+		t.Fatalf("campaign state = %s, want canceled", view.Campaign.State)
+	}
+	if len(view.Items) != 1 || strings.TrimSpace(view.Items[0].Item.RunID) == "" {
+		t.Fatalf("expected canceled campaign item to retain run id, got %+v", view.Items)
+	}
+	if cancelReq, ok := s.store.GetRunCancel(view.Items[0].Item.RunID); !ok {
+		t.Fatal("expected run cancel request to be persisted")
+	} else if cancelReq.Source != "campaign" {
+		t.Fatalf("cancel source = %q, want campaign", cancelReq.Source)
+	}
+	close(waitCh)
+	waitForServerIdle(t, s)
+}
+
+func TestCampaignSkipIfOpenPRExists(t *testing.T) {
+	t.Parallel()
+
+	launcher := &fakeLauncher{}
+	s := newTestServer(t, launcher)
+
+	if _, err := s.store.UpsertTask(state.UpsertTaskInput{ID: "existing-task", Repo: "owner/repo"}); err != nil {
+		t.Fatalf("upsert task: %v", err)
+	}
+	run, err := s.store.AddRun(state.CreateRunInput{
+		ID:         "run_existing_pr",
+		TaskID:     "existing-task",
+		Repo:       "owner/repo",
+		Task:       "Update dependencies",
+		BaseBranch: "main",
+		HeadBranch: "rascal/existing",
+		RunDir:     "/tmp/run_existing_pr",
+	})
+	if err != nil {
+		t.Fatalf("add existing run: %v", err)
+	}
+	if _, err := s.store.SetRunStatus(run.ID, state.StatusRunning, ""); err != nil {
+		t.Fatalf("set existing run running: %v", err)
+	}
+	if _, err := s.store.UpdateRun(run.ID, func(r *state.Run) error {
+		r.Status = state.StatusReview
+		r.PRNumber = 42
+		r.PRStatus = state.PRStatusOpen
+		return nil
+	}); err != nil {
+		t.Fatalf("set existing run review: %v", err)
+	}
+
+	campaign, _, err := s.store.CreateCampaign(state.CreateCampaignInput{
+		Name: "skip open pr",
+		Policy: state.CampaignExecutionPolicy{
+			MaxConcurrent:     1,
+			StopAfterFailures: 1,
+			SkipIfOpenPR:      true,
+		},
+		Items: []state.CampaignItemInput{
+			{Repo: "owner/repo", Task: "Update dependencies"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create campaign: %v", err)
+	}
+
+	if _, err := s.startCampaign(campaign.ID); err != nil {
+		t.Fatalf("start campaign: %v", err)
+	}
+	waitFor(t, 2*time.Second, func() bool {
+		view, err := s.buildCampaignView(campaign.ID, true)
+		if err != nil {
+			return false
+		}
+		return view.Campaign.State == state.CampaignStateCompleted &&
+			view.Summary.Skipped == 1 &&
+			launcher.Calls() == 0
+	}, "campaign item skipped because open PR already exists")
+}

--- a/cmd/rascald/main.go
+++ b/cmd/rascald/main.go
@@ -105,6 +105,7 @@ type runRequest struct {
 	BaseBranch      string
 	HeadBranch      string
 	Trigger         runtrigger.Name
+	AgentBackend    string
 	IssueNumber     int
 	PRNumber        int
 	PRStatus        state.PRStatus
@@ -190,6 +191,9 @@ func main() {
 	s.recoverQueuedCancels()
 	s.recoverRunningRuns()
 	s.scheduleRuns("")
+	if err := s.scheduleCampaigns(); err != nil {
+		log.Printf("campaign scheduler bootstrap failed: %v", err)
+	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", s.handleHealth)
@@ -199,6 +203,8 @@ func main() {
 	mux.HandleFunc("/v1/tasks", s.withAuth(s.handleCreateTask))
 	mux.HandleFunc("/v1/tasks/", s.withAuth(s.handleTaskSubresources))
 	mux.HandleFunc("/v1/tasks/issue", s.withAuth(s.handleCreateIssueTask))
+	mux.HandleFunc("/v1/campaigns", s.withAuth(s.handleCampaigns))
+	mux.HandleFunc("/v1/campaigns/", s.withAuth(s.handleCampaignSubresources))
 	mux.HandleFunc("/v1/credentials", s.withAuth(s.handleCredentials))
 	mux.HandleFunc("/v1/credentials/", s.withAuth(s.handleCredentialSubresources))
 	mux.HandleFunc("/v1/webhooks/github", s.handleWebhook)
@@ -1465,6 +1471,7 @@ func (s *server) createAndQueueRun(req runRequest) (state.Run, error) {
 	if req.CreatedByUserID == "" {
 		req.CreatedByUserID = "system"
 	}
+	runBackend := normalizeCampaignBackend(req.AgentBackend, s.cfg.AgentBackend)
 	if req.Trigger == "" {
 		req.Trigger = runtrigger.NameCLI
 	} else {
@@ -1495,7 +1502,7 @@ func (s *server) createAndQueueRun(req runRequest) (state.Run, error) {
 	if s.store.IsTaskCompleted(req.TaskID) {
 		return state.Run{}, errTaskCompleted
 	}
-	if existingTask, ok := s.store.GetTask(req.TaskID); ok && existingTask.AgentBackend != s.cfg.AgentBackend {
+	if existingTask, ok := s.store.GetTask(req.TaskID); ok && existingTask.AgentBackend != runBackend {
 		if err := s.store.DeleteTaskAgentSession(req.TaskID); err != nil {
 			return state.Run{}, fmt.Errorf("clear stale task session for backend migration: %w", err)
 		}
@@ -1522,7 +1529,7 @@ func (s *server) createAndQueueRun(req runRequest) (state.Run, error) {
 	_, err = s.store.UpsertTask(state.UpsertTaskInput{
 		ID:           req.TaskID,
 		Repo:         req.Repo,
-		AgentBackend: s.cfg.AgentBackend,
+		AgentBackend: runBackend,
 		IssueNumber:  req.IssueNumber,
 		PRNumber:     req.PRNumber,
 	})
@@ -1538,7 +1545,7 @@ func (s *server) createAndQueueRun(req runRequest) (state.Run, error) {
 		TaskID:       req.TaskID,
 		Repo:         req.Repo,
 		Task:         req.Task,
-		AgentBackend: s.cfg.AgentBackend,
+		AgentBackend: runBackend,
 		BaseBranch:   req.BaseBranch,
 		HeadBranch:   req.HeadBranch,
 		Trigger:      req.Trigger,
@@ -2391,6 +2398,9 @@ func (s *server) finishRun(run state.Run) {
 
 	if !s.isDraining() {
 		s.scheduleRuns(run.TaskID)
+		if err := s.scheduleCampaigns(); err != nil {
+			log.Printf("campaign scheduling failed after run %s: %v", run.ID, err)
+		}
 	}
 }
 

--- a/internal/api/campaigns.go
+++ b/internal/api/campaigns.go
@@ -1,0 +1,35 @@
+package api
+
+import "github.com/rtzll/rascal/internal/state"
+
+type CreateCampaignRequest struct {
+	ID          string                        `json:"id,omitempty" toml:"id,omitempty"`
+	Name        string                        `json:"name" toml:"name"`
+	Description string                        `json:"description,omitempty" toml:"description,omitempty"`
+	Policy      state.CampaignExecutionPolicy `json:"policy" toml:"policy"`
+	Items       []state.CampaignItemInput     `json:"items" toml:"items"`
+}
+
+type CampaignItemView struct {
+	Item state.CampaignItem `json:"item" toml:"item"`
+	Run  *state.Run         `json:"run,omitempty" toml:"run,omitempty"`
+}
+
+type CampaignView struct {
+	Campaign state.Campaign        `json:"campaign" toml:"campaign"`
+	Summary  state.CampaignSummary `json:"summary" toml:"summary"`
+	Items    []CampaignItemView    `json:"items" toml:"items"`
+}
+
+type CampaignResponse struct {
+	Campaign CampaignView `json:"campaign" toml:"campaign"`
+}
+
+type CampaignListEntry struct {
+	Campaign state.Campaign        `json:"campaign" toml:"campaign"`
+	Summary  state.CampaignSummary `json:"summary" toml:"summary"`
+}
+
+type CampaignListResponse struct {
+	Campaigns []CampaignListEntry `json:"campaigns" toml:"campaigns"`
+}

--- a/internal/runtrigger/name.go
+++ b/internal/runtrigger/name.go
@@ -9,6 +9,7 @@ type Name string
 
 const (
 	NameCLI             Name = "cli"
+	NameCampaign        Name = "campaign"
 	NameRetry           Name = "retry"
 	NameIssueAPI        Name = "issue_api"
 	NameIssueLabel      Name = "issue_label"
@@ -46,6 +47,7 @@ func (n Name) String() string {
 func (n Name) IsKnown() bool {
 	switch Normalize(n.String()) {
 	case NameCLI,
+		NameCampaign,
 		NameRetry,
 		NameIssueAPI,
 		NameIssueLabel,

--- a/internal/state/campaign_types.go
+++ b/internal/state/campaign_types.go
@@ -1,0 +1,282 @@
+package state
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type CampaignState string
+
+const (
+	CampaignStateDraft     CampaignState = "draft"
+	CampaignStateRunning   CampaignState = "running"
+	CampaignStatePaused    CampaignState = "paused"
+	CampaignStateCompleted CampaignState = "completed"
+	CampaignStateCanceled  CampaignState = "canceled"
+	CampaignStateFailed    CampaignState = "failed"
+)
+
+var campaignStateTransitions = map[CampaignState]map[CampaignState]struct{}{
+	CampaignStateDraft: {
+		CampaignStateDraft:    {},
+		CampaignStateRunning:  {},
+		CampaignStateCanceled: {},
+	},
+	CampaignStateRunning: {
+		CampaignStateRunning:   {},
+		CampaignStatePaused:    {},
+		CampaignStateCompleted: {},
+		CampaignStateCanceled:  {},
+		CampaignStateFailed:    {},
+	},
+	CampaignStatePaused: {
+		CampaignStatePaused:   {},
+		CampaignStateRunning:  {},
+		CampaignStateCanceled: {},
+		CampaignStateFailed:   {},
+	},
+	CampaignStateCompleted: {
+		CampaignStateCompleted: {},
+	},
+	CampaignStateCanceled: {
+		CampaignStateCanceled: {},
+	},
+	CampaignStateFailed: {
+		CampaignStateFailed:   {},
+		CampaignStatePaused:   {},
+		CampaignStateRunning:  {},
+		CampaignStateCanceled: {},
+	},
+}
+
+func ValidateCampaignStateTransition(from, to CampaignState) error {
+	next, ok := campaignStateTransitions[from]
+	if !ok {
+		return fmt.Errorf("invalid current campaign state %q", from)
+	}
+	if _, ok := next[to]; !ok {
+		return fmt.Errorf("invalid campaign state transition %q -> %q", from, to)
+	}
+	return nil
+}
+
+type CampaignItemState string
+
+const (
+	CampaignItemStatePending   CampaignItemState = "pending"
+	CampaignItemStateQueued    CampaignItemState = "queued"
+	CampaignItemStateRunning   CampaignItemState = "running"
+	CampaignItemStateReview    CampaignItemState = "review"
+	CampaignItemStateSucceeded CampaignItemState = "succeeded"
+	CampaignItemStateFailed    CampaignItemState = "failed"
+	CampaignItemStateSkipped   CampaignItemState = "skipped"
+	CampaignItemStateCanceled  CampaignItemState = "canceled"
+)
+
+var campaignItemStateTransitions = map[CampaignItemState]map[CampaignItemState]struct{}{
+	CampaignItemStatePending: {
+		CampaignItemStatePending:  {},
+		CampaignItemStateQueued:   {},
+		CampaignItemStateFailed:   {},
+		CampaignItemStateSkipped:  {},
+		CampaignItemStateCanceled: {},
+	},
+	CampaignItemStateQueued: {
+		CampaignItemStateQueued:    {},
+		CampaignItemStateRunning:   {},
+		CampaignItemStateReview:    {},
+		CampaignItemStateSucceeded: {},
+		CampaignItemStateFailed:    {},
+		CampaignItemStateSkipped:   {},
+		CampaignItemStateCanceled:  {},
+	},
+	CampaignItemStateRunning: {
+		CampaignItemStateRunning:   {},
+		CampaignItemStateReview:    {},
+		CampaignItemStateSucceeded: {},
+		CampaignItemStateFailed:    {},
+		CampaignItemStateCanceled:  {},
+	},
+	CampaignItemStateReview: {
+		CampaignItemStateReview:    {},
+		CampaignItemStateSucceeded: {},
+		CampaignItemStateCanceled:  {},
+	},
+	CampaignItemStateSucceeded: {
+		CampaignItemStateSucceeded: {},
+	},
+	CampaignItemStateFailed: {
+		CampaignItemStateFailed:   {},
+		CampaignItemStatePending:  {},
+		CampaignItemStateCanceled: {},
+	},
+	CampaignItemStateSkipped: {
+		CampaignItemStateSkipped:  {},
+		CampaignItemStatePending:  {},
+		CampaignItemStateCanceled: {},
+	},
+	CampaignItemStateCanceled: {
+		CampaignItemStateCanceled: {},
+		CampaignItemStatePending:  {},
+	},
+}
+
+func ValidateCampaignItemStateTransition(from, to CampaignItemState) error {
+	next, ok := campaignItemStateTransitions[from]
+	if !ok {
+		return fmt.Errorf("invalid current campaign item state %q", from)
+	}
+	if _, ok := next[to]; !ok {
+		return fmt.Errorf("invalid campaign item state transition %q -> %q", from, to)
+	}
+	return nil
+}
+
+func CampaignItemStateFromRunStatus(status RunStatus) CampaignItemState {
+	switch status {
+	case StatusQueued:
+		return CampaignItemStateQueued
+	case StatusRunning:
+		return CampaignItemStateRunning
+	case StatusReview:
+		return CampaignItemStateReview
+	case StatusSucceeded:
+		return CampaignItemStateSucceeded
+	case StatusFailed:
+		return CampaignItemStateFailed
+	case StatusCanceled:
+		return CampaignItemStateCanceled
+	default:
+		return CampaignItemStatePending
+	}
+}
+
+type CampaignExecutionPolicy struct {
+	MaxConcurrent     int  `json:"max_concurrent" toml:"max_concurrent"`
+	StopAfterFailures int  `json:"stop_after_failures" toml:"stop_after_failures"`
+	ContinueOnFailure bool `json:"continue_on_failure" toml:"continue_on_failure"`
+	SkipIfOpenPR      bool `json:"skip_if_open_pr" toml:"skip_if_open_pr"`
+}
+
+func NormalizeCampaignExecutionPolicy(in CampaignExecutionPolicy) CampaignExecutionPolicy {
+	out := in
+	if !out.SkipIfOpenPR && out.MaxConcurrent == 0 && out.StopAfterFailures == 0 && !out.ContinueOnFailure {
+		out.SkipIfOpenPR = true
+	}
+	if out.MaxConcurrent <= 0 {
+		out.MaxConcurrent = 1
+	}
+	if out.StopAfterFailures < 0 {
+		out.StopAfterFailures = 0
+	}
+	if out.StopAfterFailures == 0 && !out.ContinueOnFailure {
+		out.StopAfterFailures = 1
+	}
+	return out
+}
+
+type Campaign struct {
+	ID          string                  `json:"id" toml:"id"`
+	Name        string                  `json:"name" toml:"name"`
+	Description string                  `json:"description,omitempty" toml:"description,omitempty"`
+	State       CampaignState           `json:"state" toml:"state"`
+	Policy      CampaignExecutionPolicy `json:"policy" toml:"policy"`
+	CreatedAt   time.Time               `json:"created_at" toml:"created_at"`
+	UpdatedAt   time.Time               `json:"updated_at" toml:"updated_at"`
+	StartedAt   *time.Time              `json:"started_at,omitempty" toml:"started_at,omitempty"`
+	CompletedAt *time.Time              `json:"completed_at,omitempty" toml:"completed_at,omitempty"`
+}
+
+type CampaignItem struct {
+	ID              string            `json:"id" toml:"id"`
+	CampaignID      string            `json:"campaign_id" toml:"campaign_id"`
+	Order           int               `json:"order" toml:"order"`
+	Repo            string            `json:"repo" toml:"repo"`
+	Task            string            `json:"task" toml:"task"`
+	TaskID          string            `json:"task_id" toml:"task_id"`
+	BaseBranch      string            `json:"base_branch,omitempty" toml:"base_branch,omitempty"`
+	BackendOverride string            `json:"backend,omitempty" toml:"backend,omitempty"`
+	State           CampaignItemState `json:"state" toml:"state"`
+	RunID           string            `json:"run_id,omitempty" toml:"run_id,omitempty"`
+	SkipReason      string            `json:"skip_reason,omitempty" toml:"skip_reason,omitempty"`
+	FailureReason   string            `json:"failure_reason,omitempty" toml:"failure_reason,omitempty"`
+	CreatedAt       time.Time         `json:"created_at" toml:"created_at"`
+	UpdatedAt       time.Time         `json:"updated_at" toml:"updated_at"`
+}
+
+type CampaignItemInput struct {
+	Repo            string `json:"repo" toml:"repo"`
+	Task            string `json:"task" toml:"task"`
+	TaskID          string `json:"task_id,omitempty" toml:"task_id,omitempty"`
+	BaseBranch      string `json:"base_branch,omitempty" toml:"base_branch,omitempty"`
+	BackendOverride string `json:"backend,omitempty" toml:"backend,omitempty"`
+}
+
+type CreateCampaignInput struct {
+	ID          string
+	Name        string
+	Description string
+	Policy      CampaignExecutionPolicy
+	Items       []CampaignItemInput
+}
+
+type CampaignSummary struct {
+	TotalItems  int `json:"total_items" toml:"total_items"`
+	ActiveItems int `json:"active_items" toml:"active_items"`
+	Pending     int `json:"pending" toml:"pending"`
+	Queued      int `json:"queued" toml:"queued"`
+	Running     int `json:"running" toml:"running"`
+	Review      int `json:"review" toml:"review"`
+	Succeeded   int `json:"succeeded" toml:"succeeded"`
+	Failed      int `json:"failed" toml:"failed"`
+	Skipped     int `json:"skipped" toml:"skipped"`
+	Canceled    int `json:"canceled" toml:"canceled"`
+}
+
+func SummarizeCampaignItems(items []CampaignItem) CampaignSummary {
+	summary := CampaignSummary{TotalItems: len(items)}
+	for _, item := range items {
+		switch item.State {
+		case CampaignItemStatePending:
+			summary.Pending++
+		case CampaignItemStateQueued:
+			summary.Queued++
+			summary.ActiveItems++
+		case CampaignItemStateRunning:
+			summary.Running++
+			summary.ActiveItems++
+		case CampaignItemStateReview:
+			summary.Review++
+		case CampaignItemStateSucceeded:
+			summary.Succeeded++
+		case CampaignItemStateFailed:
+			summary.Failed++
+		case CampaignItemStateSkipped:
+			summary.Skipped++
+		case CampaignItemStateCanceled:
+			summary.Canceled++
+		}
+	}
+	return summary
+}
+
+func NewCampaignID() (string, error) {
+	buf := make([]byte, 8)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("create campaign id: %w", err)
+	}
+	return "camp_" + hex.EncodeToString(buf), nil
+}
+
+func NormalizeCampaignItemInput(in CampaignItemInput) CampaignItemInput {
+	return CampaignItemInput{
+		Repo:            NormalizeRepo(in.Repo),
+		Task:            strings.TrimSpace(in.Task),
+		TaskID:          strings.TrimSpace(in.TaskID),
+		BaseBranch:      strings.TrimSpace(in.BaseBranch),
+		BackendOverride: strings.TrimSpace(strings.ToLower(in.BackendOverride)),
+	}
+}

--- a/internal/state/campaigns.go
+++ b/internal/state/campaigns.go
@@ -1,0 +1,526 @@
+package state
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+)
+
+func (s *Store) CreateCampaign(in CreateCampaignInput) (Campaign, []CampaignItem, error) {
+	in.ID = strings.TrimSpace(in.ID)
+	in.Name = strings.TrimSpace(in.Name)
+	in.Description = strings.TrimSpace(in.Description)
+	in.Policy = NormalizeCampaignExecutionPolicy(in.Policy)
+	if in.Name == "" {
+		return Campaign{}, nil, fmt.Errorf("campaign name is required")
+	}
+	if len(in.Items) == 0 {
+		return Campaign{}, nil, fmt.Errorf("at least one campaign item is required")
+	}
+	if in.ID == "" {
+		id, err := NewCampaignID()
+		if err != nil {
+			return Campaign{}, nil, err
+		}
+		in.ID = id
+	}
+
+	now := time.Now().UTC()
+	items := make([]CampaignItem, 0, len(in.Items))
+	for i, raw := range in.Items {
+		itemInput := NormalizeCampaignItemInput(raw)
+		if itemInput.Repo == "" || itemInput.Task == "" {
+			return Campaign{}, nil, fmt.Errorf("campaign item %d requires repo and task", i+1)
+		}
+		if itemInput.TaskID == "" {
+			itemInput.TaskID = fmt.Sprintf("%s#item-%03d", in.ID, i+1)
+		}
+		items = append(items, CampaignItem{
+			ID:              fmt.Sprintf("%s_item_%03d", in.ID, i+1),
+			CampaignID:      in.ID,
+			Order:           i + 1,
+			Repo:            itemInput.Repo,
+			Task:            itemInput.Task,
+			TaskID:          itemInput.TaskID,
+			BaseBranch:      itemInput.BaseBranch,
+			BackendOverride: itemInput.BackendOverride,
+			State:           CampaignItemStatePending,
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		})
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	tx, err := s.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return Campaign{}, nil, fmt.Errorf("begin create campaign transaction: %w", err)
+	}
+	defer func() {
+		if rollbackErr := tx.Rollback(); rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+			log.Printf("rollback create campaign transaction: %v", rollbackErr)
+		}
+	}()
+
+	if _, err := tx.ExecContext(
+		context.Background(),
+		`INSERT INTO campaigns (
+			id,
+			name,
+			description,
+			state,
+			max_concurrent,
+			stop_after_failures,
+			continue_on_failure,
+			skip_if_open_pr,
+			created_at,
+			updated_at,
+			started_at,
+			completed_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL)`,
+		in.ID,
+		in.Name,
+		in.Description,
+		string(CampaignStateDraft),
+		in.Policy.MaxConcurrent,
+		in.Policy.StopAfterFailures,
+		boolToInt64(in.Policy.ContinueOnFailure),
+		boolToInt64(in.Policy.SkipIfOpenPR),
+		now.UnixNano(),
+		now.UnixNano(),
+	); err != nil {
+		return Campaign{}, nil, fmt.Errorf("insert campaign %q: %w", in.ID, err)
+	}
+
+	for _, item := range items {
+		if _, err := tx.ExecContext(
+			context.Background(),
+			`INSERT INTO campaign_items (
+				id,
+				campaign_id,
+				item_order,
+				repo,
+				task,
+				task_id,
+				base_branch,
+				backend_override,
+				state,
+				run_id,
+				skip_reason,
+				failure_reason,
+				created_at,
+				updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			item.ID,
+			item.CampaignID,
+			item.Order,
+			item.Repo,
+			item.Task,
+			item.TaskID,
+			item.BaseBranch,
+			item.BackendOverride,
+			string(item.State),
+			item.RunID,
+			item.SkipReason,
+			item.FailureReason,
+			item.CreatedAt.UnixNano(),
+			item.UpdatedAt.UnixNano(),
+		); err != nil {
+			return Campaign{}, nil, fmt.Errorf("insert campaign item %q: %w", item.ID, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return Campaign{}, nil, fmt.Errorf("commit create campaign %q: %w", in.ID, err)
+	}
+
+	campaign := Campaign{
+		ID:          in.ID,
+		Name:        in.Name,
+		Description: in.Description,
+		State:       CampaignStateDraft,
+		Policy:      in.Policy,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	return campaign, items, nil
+}
+
+func (s *Store) GetCampaign(id string) (Campaign, bool, error) {
+	row := s.db.QueryRowContext(context.Background(), `
+SELECT
+	id,
+	name,
+	description,
+	state,
+	max_concurrent,
+	stop_after_failures,
+	continue_on_failure,
+	skip_if_open_pr,
+	created_at,
+	updated_at,
+	started_at,
+	completed_at
+FROM campaigns
+WHERE id = ?`, strings.TrimSpace(id))
+	campaign, err := scanCampaign(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return Campaign{}, false, nil
+		}
+		return Campaign{}, false, fmt.Errorf("get campaign %q: %w", id, err)
+	}
+	return campaign, true, nil
+}
+
+func (s *Store) ListCampaigns() ([]Campaign, error) {
+	rows, err := s.db.QueryContext(context.Background(), `
+SELECT
+	id,
+	name,
+	description,
+	state,
+	max_concurrent,
+	stop_after_failures,
+	continue_on_failure,
+	skip_if_open_pr,
+	created_at,
+	updated_at,
+	started_at,
+	completed_at
+FROM campaigns
+ORDER BY created_at DESC, id DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("list campaigns: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			log.Printf("close campaign rows: %v", closeErr)
+		}
+	}()
+
+	var out []Campaign
+	for rows.Next() {
+		campaign, err := scanCampaign(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan campaign: %w", err)
+		}
+		out = append(out, campaign)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate campaigns: %w", err)
+	}
+	return out, nil
+}
+
+func (s *Store) ListCampaignItems(campaignID string) ([]CampaignItem, error) {
+	rows, err := s.db.QueryContext(context.Background(), `
+SELECT
+	id,
+	campaign_id,
+	item_order,
+	repo,
+	task,
+	task_id,
+	base_branch,
+	backend_override,
+	state,
+	run_id,
+	skip_reason,
+	failure_reason,
+	created_at,
+	updated_at
+FROM campaign_items
+WHERE campaign_id = ?
+ORDER BY item_order ASC, id ASC`, strings.TrimSpace(campaignID))
+	if err != nil {
+		return nil, fmt.Errorf("list campaign items for %q: %w", campaignID, err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			log.Printf("close campaign item rows for %s: %v", campaignID, closeErr)
+		}
+	}()
+
+	var out []CampaignItem
+	for rows.Next() {
+		item, err := scanCampaignItem(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan campaign item: %w", err)
+		}
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate campaign items for %q: %w", campaignID, err)
+	}
+	return out, nil
+}
+
+func (s *Store) UpdateCampaign(id string, fn func(*Campaign) error) (Campaign, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	tx, err := s.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return Campaign{}, fmt.Errorf("begin update campaign transaction for %q: %w", id, err)
+	}
+	defer func() {
+		if rollbackErr := tx.Rollback(); rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+			log.Printf("rollback update campaign transaction: %v", rollbackErr)
+		}
+	}()
+
+	row := tx.QueryRowContext(context.Background(), `
+SELECT
+	id,
+	name,
+	description,
+	state,
+	max_concurrent,
+	stop_after_failures,
+	continue_on_failure,
+	skip_if_open_pr,
+	created_at,
+	updated_at,
+	started_at,
+	completed_at
+FROM campaigns
+WHERE id = ?`, strings.TrimSpace(id))
+	campaign, err := scanCampaign(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return Campaign{}, fmt.Errorf("campaign %q not found", id)
+		}
+		return Campaign{}, fmt.Errorf("load campaign %q for update: %w", id, err)
+	}
+
+	prevState := campaign.State
+	if err := fn(&campaign); err != nil {
+		return Campaign{}, fmt.Errorf("apply campaign update for %q: %w", id, err)
+	}
+	campaign.Policy = NormalizeCampaignExecutionPolicy(campaign.Policy)
+	if err := ValidateCampaignStateTransition(prevState, campaign.State); err != nil {
+		return Campaign{}, fmt.Errorf("validate campaign state transition for %q: %w", id, err)
+	}
+	campaign.UpdatedAt = time.Now().UTC()
+
+	if _, err := tx.ExecContext(
+		context.Background(),
+		`UPDATE campaigns
+SET
+	name = ?,
+	description = ?,
+	state = ?,
+	max_concurrent = ?,
+	stop_after_failures = ?,
+	continue_on_failure = ?,
+	skip_if_open_pr = ?,
+	updated_at = ?,
+	started_at = ?,
+	completed_at = ?
+WHERE id = ?`,
+		campaign.Name,
+		campaign.Description,
+		string(campaign.State),
+		campaign.Policy.MaxConcurrent,
+		campaign.Policy.StopAfterFailures,
+		boolToInt64(campaign.Policy.ContinueOnFailure),
+		boolToInt64(campaign.Policy.SkipIfOpenPR),
+		campaign.UpdatedAt.UnixNano(),
+		toNullInt64Time(campaign.StartedAt),
+		toNullInt64Time(campaign.CompletedAt),
+		campaign.ID,
+	); err != nil {
+		return Campaign{}, fmt.Errorf("update campaign %q: %w", id, err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return Campaign{}, fmt.Errorf("commit update campaign transaction for %q: %w", id, err)
+	}
+	return campaign, nil
+}
+
+func (s *Store) UpdateCampaignItem(id string, fn func(*CampaignItem) error) (CampaignItem, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	tx, err := s.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return CampaignItem{}, fmt.Errorf("begin update campaign item transaction for %q: %w", id, err)
+	}
+	defer func() {
+		if rollbackErr := tx.Rollback(); rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+			log.Printf("rollback update campaign item transaction: %v", rollbackErr)
+		}
+	}()
+
+	row := tx.QueryRowContext(context.Background(), `
+SELECT
+	id,
+	campaign_id,
+	item_order,
+	repo,
+	task,
+	task_id,
+	base_branch,
+	backend_override,
+	state,
+	run_id,
+	skip_reason,
+	failure_reason,
+	created_at,
+	updated_at
+FROM campaign_items
+WHERE id = ?`, strings.TrimSpace(id))
+	item, err := scanCampaignItem(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return CampaignItem{}, fmt.Errorf("campaign item %q not found", id)
+		}
+		return CampaignItem{}, fmt.Errorf("load campaign item %q for update: %w", id, err)
+	}
+
+	prevState := item.State
+	if err := fn(&item); err != nil {
+		return CampaignItem{}, fmt.Errorf("apply campaign item update for %q: %w", id, err)
+	}
+	if err := ValidateCampaignItemStateTransition(prevState, item.State); err != nil {
+		return CampaignItem{}, fmt.Errorf("validate campaign item state transition for %q: %w", id, err)
+	}
+	item.UpdatedAt = time.Now().UTC()
+
+	if _, err := tx.ExecContext(
+		context.Background(),
+		`UPDATE campaign_items
+SET
+	repo = ?,
+	task = ?,
+	task_id = ?,
+	base_branch = ?,
+	backend_override = ?,
+	state = ?,
+	run_id = ?,
+	skip_reason = ?,
+	failure_reason = ?,
+	updated_at = ?
+WHERE id = ?`,
+		item.Repo,
+		item.Task,
+		item.TaskID,
+		item.BaseBranch,
+		item.BackendOverride,
+		string(item.State),
+		item.RunID,
+		item.SkipReason,
+		item.FailureReason,
+		item.UpdatedAt.UnixNano(),
+		item.ID,
+	); err != nil {
+		return CampaignItem{}, fmt.Errorf("update campaign item %q: %w", id, err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return CampaignItem{}, fmt.Errorf("commit update campaign item transaction for %q: %w", id, err)
+	}
+	return item, nil
+}
+
+type campaignScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanCampaign(scanner campaignScanner) (Campaign, error) {
+	var (
+		campaign             Campaign
+		state                string
+		continueOnFailureInt int64
+		skipIfOpenPRInt      int64
+		createdAt            int64
+		updatedAt            int64
+		startedAt            sql.NullInt64
+		completedAt          sql.NullInt64
+	)
+	if err := scanner.Scan(
+		&campaign.ID,
+		&campaign.Name,
+		&campaign.Description,
+		&state,
+		&campaign.Policy.MaxConcurrent,
+		&campaign.Policy.StopAfterFailures,
+		&continueOnFailureInt,
+		&skipIfOpenPRInt,
+		&createdAt,
+		&updatedAt,
+		&startedAt,
+		&completedAt,
+	); err != nil {
+		return Campaign{}, fmt.Errorf("scan campaign: %w", err)
+	}
+	campaign.State = CampaignState(state)
+	campaign.Policy.ContinueOnFailure = continueOnFailureInt != 0
+	campaign.Policy.SkipIfOpenPR = skipIfOpenPRInt != 0
+	campaign.Policy = NormalizeCampaignExecutionPolicy(campaign.Policy)
+	campaign.CreatedAt = time.Unix(0, createdAt).UTC()
+	campaign.UpdatedAt = time.Unix(0, updatedAt).UTC()
+	campaign.StartedAt = fromNullInt64Time(startedAt)
+	campaign.CompletedAt = fromNullInt64Time(completedAt)
+	return campaign, nil
+}
+
+func scanCampaignItem(scanner campaignScanner) (CampaignItem, error) {
+	var (
+		item      CampaignItem
+		state     string
+		createdAt int64
+		updatedAt int64
+	)
+	if err := scanner.Scan(
+		&item.ID,
+		&item.CampaignID,
+		&item.Order,
+		&item.Repo,
+		&item.Task,
+		&item.TaskID,
+		&item.BaseBranch,
+		&item.BackendOverride,
+		&state,
+		&item.RunID,
+		&item.SkipReason,
+		&item.FailureReason,
+		&createdAt,
+		&updatedAt,
+	); err != nil {
+		return CampaignItem{}, fmt.Errorf("scan campaign item: %w", err)
+	}
+	item.State = CampaignItemState(state)
+	item.CreatedAt = time.Unix(0, createdAt).UTC()
+	item.UpdatedAt = time.Unix(0, updatedAt).UTC()
+	return item, nil
+}
+
+func boolToInt64(v bool) int64 {
+	if v {
+		return 1
+	}
+	return 0
+}
+
+func fromNullInt64Time(v sql.NullInt64) *time.Time {
+	if !v.Valid {
+		return nil
+	}
+	ts := time.Unix(0, v.Int64).UTC()
+	return &ts
+}
+
+func toNullInt64Time(v *time.Time) sql.NullInt64 {
+	if v == nil || v.IsZero() {
+		return sql.NullInt64{}
+	}
+	return sql.NullInt64{Int64: v.UTC().UnixNano(), Valid: true}
+}

--- a/internal/state/campaigns_test.go
+++ b/internal/state/campaigns_test.go
@@ -1,0 +1,115 @@
+package state
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestStoreCreateCampaignAssignsDefaults(t *testing.T) {
+	t.Parallel()
+
+	store, err := New(filepath.Join(t.TempDir(), "state.db"), 200)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	campaign, items, err := store.CreateCampaign(CreateCampaignInput{
+		Name: "deps rollout",
+		Items: []CampaignItemInput{
+			{Repo: "Owner/Repo", Task: "Update dependencies"},
+			{Repo: "owner/other", Task: "Run formatter", TaskID: "fmt-task"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create campaign: %v", err)
+	}
+
+	if campaign.State != CampaignStateDraft {
+		t.Fatalf("campaign state = %s, want draft", campaign.State)
+	}
+	if campaign.Policy.MaxConcurrent != 1 {
+		t.Fatalf("max concurrent = %d, want 1", campaign.Policy.MaxConcurrent)
+	}
+	if campaign.Policy.StopAfterFailures != 1 {
+		t.Fatalf("stop after failures = %d, want 1", campaign.Policy.StopAfterFailures)
+	}
+	if !campaign.Policy.SkipIfOpenPR {
+		t.Fatal("expected skip_if_open_pr to default to true")
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 campaign items, got %d", len(items))
+	}
+	if items[0].Repo != "owner/repo" {
+		t.Fatalf("first item repo = %q, want owner/repo", items[0].Repo)
+	}
+	if items[0].TaskID == "" {
+		t.Fatal("expected first item task id to be assigned")
+	}
+	if items[1].TaskID != "fmt-task" {
+		t.Fatalf("second item task id = %q, want fmt-task", items[1].TaskID)
+	}
+
+	loaded, ok, err := store.GetCampaign(campaign.ID)
+	if err != nil {
+		t.Fatalf("get campaign: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected campaign to exist")
+	}
+	if loaded.Name != campaign.Name {
+		t.Fatalf("loaded name = %q, want %q", loaded.Name, campaign.Name)
+	}
+
+	loadedItems, err := store.ListCampaignItems(campaign.ID)
+	if err != nil {
+		t.Fatalf("list campaign items: %v", err)
+	}
+	if len(loadedItems) != 2 {
+		t.Fatalf("expected 2 persisted campaign items, got %d", len(loadedItems))
+	}
+}
+
+func TestStoreCampaignUpdateValidatesTransitions(t *testing.T) {
+	t.Parallel()
+
+	store, err := New(filepath.Join(t.TempDir(), "state.db"), 200)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	campaign, items, err := store.CreateCampaign(CreateCampaignInput{
+		Name: "transition test",
+		Items: []CampaignItemInput{
+			{Repo: "owner/repo", Task: "Do work"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create campaign: %v", err)
+	}
+
+	if _, err := store.UpdateCampaign(campaign.ID, func(c *Campaign) error {
+		c.State = CampaignStateRunning
+		return nil
+	}); err != nil {
+		t.Fatalf("set campaign running: %v", err)
+	}
+	if _, err := store.UpdateCampaign(campaign.ID, func(c *Campaign) error {
+		c.State = CampaignStateDraft
+		return nil
+	}); err == nil {
+		t.Fatal("expected invalid campaign transition to fail")
+	}
+
+	if _, err := store.UpdateCampaignItem(items[0].ID, func(item *CampaignItem) error {
+		item.State = CampaignItemStateQueued
+		return nil
+	}); err != nil {
+		t.Fatalf("set campaign item queued: %v", err)
+	}
+	if _, err := store.UpdateCampaignItem(items[0].ID, func(item *CampaignItem) error {
+		item.State = CampaignItemStatePending
+		return nil
+	}); err == nil {
+		t.Fatal("expected invalid campaign item transition to fail")
+	}
+}

--- a/internal/state/migrations/00014_campaigns.sql
+++ b/internal/state/migrations/00014_campaigns.sql
@@ -1,0 +1,43 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS campaigns (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT NOT NULL DEFAULT '',
+  state TEXT NOT NULL,
+  max_concurrent INTEGER NOT NULL DEFAULT 1,
+  stop_after_failures INTEGER NOT NULL DEFAULT 1,
+  continue_on_failure INTEGER NOT NULL DEFAULT 0,
+  skip_if_open_pr INTEGER NOT NULL DEFAULT 1,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  started_at INTEGER,
+  completed_at INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_campaigns_state_updated ON campaigns (state, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS campaign_items (
+  id TEXT PRIMARY KEY,
+  campaign_id TEXT NOT NULL,
+  item_order INTEGER NOT NULL,
+  repo TEXT NOT NULL,
+  task TEXT NOT NULL,
+  task_id TEXT NOT NULL DEFAULT '',
+  base_branch TEXT NOT NULL DEFAULT '',
+  backend_override TEXT NOT NULL DEFAULT '',
+  state TEXT NOT NULL,
+  run_id TEXT NOT NULL DEFAULT '',
+  skip_reason TEXT NOT NULL DEFAULT '',
+  failure_reason TEXT NOT NULL DEFAULT '',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY(campaign_id) REFERENCES campaigns(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_campaign_items_campaign_order ON campaign_items (campaign_id, item_order);
+CREATE INDEX IF NOT EXISTS idx_campaign_items_campaign_state ON campaign_items (campaign_id, state, item_order ASC);
+CREATE INDEX IF NOT EXISTS idx_campaign_items_run_id ON campaign_items (run_id);
+
+-- +goose Down
+DROP TABLE IF EXISTS campaign_items;
+DROP TABLE IF EXISTS campaigns;

--- a/internal/state/sql/schema.sql
+++ b/internal/state/sql/schema.sql
@@ -180,6 +180,45 @@ CREATE TABLE scheduler_pauses (
 
 CREATE INDEX idx_scheduler_pauses_until ON scheduler_pauses (paused_until ASC);
 
+CREATE TABLE campaigns (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT NOT NULL DEFAULT '',
+  state TEXT NOT NULL,
+  max_concurrent INTEGER NOT NULL DEFAULT 1,
+  stop_after_failures INTEGER NOT NULL DEFAULT 1,
+  continue_on_failure INTEGER NOT NULL DEFAULT 0,
+  skip_if_open_pr INTEGER NOT NULL DEFAULT 1,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  started_at INTEGER,
+  completed_at INTEGER
+);
+
+CREATE INDEX idx_campaigns_state_updated ON campaigns (state, updated_at DESC);
+
+CREATE TABLE campaign_items (
+  id TEXT PRIMARY KEY,
+  campaign_id TEXT NOT NULL,
+  item_order INTEGER NOT NULL,
+  repo TEXT NOT NULL,
+  task TEXT NOT NULL,
+  task_id TEXT NOT NULL DEFAULT '',
+  base_branch TEXT NOT NULL DEFAULT '',
+  backend_override TEXT NOT NULL DEFAULT '',
+  state TEXT NOT NULL,
+  run_id TEXT NOT NULL DEFAULT '',
+  skip_reason TEXT NOT NULL DEFAULT '',
+  failure_reason TEXT NOT NULL DEFAULT '',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY(campaign_id) REFERENCES campaigns(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX idx_campaign_items_campaign_order ON campaign_items (campaign_id, item_order);
+CREATE INDEX idx_campaign_items_campaign_state ON campaign_items (campaign_id, state, item_order ASC);
+CREATE INDEX idx_campaign_items_run_id ON campaign_items (run_id);
+
 CREATE TABLE deliveries (
   id TEXT PRIMARY KEY,
   status TEXT NOT NULL DEFAULT 'processing',

--- a/internal/state/sqlitegen/models.go
+++ b/internal/state/sqlitegen/models.go
@@ -18,6 +18,38 @@ type ApiKey struct {
 	DisabledAt sql.NullInt64 `json:"disabled_at"`
 }
 
+type Campaign struct {
+	ID                string        `json:"id"`
+	Name              string        `json:"name"`
+	Description       string        `json:"description"`
+	State             string        `json:"state"`
+	MaxConcurrent     int64         `json:"max_concurrent"`
+	StopAfterFailures int64         `json:"stop_after_failures"`
+	ContinueOnFailure int64         `json:"continue_on_failure"`
+	SkipIfOpenPr      int64         `json:"skip_if_open_pr"`
+	CreatedAt         int64         `json:"created_at"`
+	UpdatedAt         int64         `json:"updated_at"`
+	StartedAt         sql.NullInt64 `json:"started_at"`
+	CompletedAt       sql.NullInt64 `json:"completed_at"`
+}
+
+type CampaignItem struct {
+	ID              string `json:"id"`
+	CampaignID      string `json:"campaign_id"`
+	ItemOrder       int64  `json:"item_order"`
+	Repo            string `json:"repo"`
+	Task            string `json:"task"`
+	TaskID          string `json:"task_id"`
+	BaseBranch      string `json:"base_branch"`
+	BackendOverride string `json:"backend_override"`
+	State           string `json:"state"`
+	RunID           string `json:"run_id"`
+	SkipReason      string `json:"skip_reason"`
+	FailureReason   string `json:"failure_reason"`
+	CreatedAt       int64  `json:"created_at"`
+	UpdatedAt       int64  `json:"updated_at"`
+}
+
 type CodexCredential struct {
 	ID                string         `json:"id"`
 	OwnerUserID       sql.NullString `json:"owner_user_id"`


### PR DESCRIPTION
Add a first-class campaign layer with persisted items, CLI controls,
rascald orchestration, progress reporting, and scheduler-backed retry,
pause, resume, cancel, and open-PR skip behavior.

<details><summary>Agent Details</summary>

<pre><code>
    __( O)&gt;  ● new session · codex gpt-5.4
   \____)    20260314_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: &#34;/usr/local/bin/codex&#34;
Model: gpt-5.4
Reasoning effort: high
Skip git check: false
Prompt length: 7089 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Suggestion

The user has 7 extensions with 16 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
Consider asking if they&#39;d like to disable some extensions to improve tool selection accuracy.

# Response Guidelines

Use Markdown formatting for all responses.

Human: &lt;info-msg&gt;
It is currently 2026-03-14 14:54:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

&lt;/info-msg&gt;
# Rascal Run Instructions

Run ID: run_2abc5ffd6e67cc7f
Task ID: rtzll/rascal#164
Repository: rtzll/rascal
Issue: #164

## Task

feat(campaigns): orchestrate multi-run maintenance campaigns with progress tracking and bulk controls

Related: #120
Related: #128

## Summary
Rascal is good at one-off runs and issue/PR-driven follow-ups, but large maintenance work often needs coordinated batches: dependency rollouts, repository hygiene sweeps, migration follow-ups, or repeated remediation across many targets.

This issue adds a first-class campaign layer that groups many runs under one operator-visible objective with progress tracking, pause/resume controls, failure summaries, and bulk retry behavior.

## Outcome
Operators can create a campaign that fans out a bounded set of Rascal runs, monitor aggregate progress, pause or cancel the batch safely, and inspect which items succeeded, failed, were skipped, or still need attention.

## Goals
- Make repetitive multi-run work manageable without external scripts.
- Reuse the existing run/task/scheduler machinery rather than inventing a separate executor.
- Give operators a single object to watch and control during large maintenance efforts.
- Keep campaign behavior safe, bounded, and inspectable.
- Leave room for both single-repo and multi-repo use cases.

## Non-goals
- Building a generic DAG engine.
- Implementing arbitrary inter-item dependencies in V1.
- Auto-merging campaign PRs.
- Replacing the repository-registry work in #128.

## Scope
Implement V1 campaigns with the following pieces.

1. Campaign model
- Add persistent campaign records with at least:
  - id
  - name
  - description
  - state (`draft`, `running`, `paused`, `completed`, `canceled`, `failed`)
  - execution policy
  - created/updated timestamps
- Add campaign-item records representing planned or realized runs.
- Each item should capture at least:
  - repo
  - task template or resolved task text
  - base branch override if any
  - backend/profile override if any
  - item state (`pending`, `queued`, `running`, `review`, `succeeded`, `failed`, `skipped`, `canceled`)
  - linked task/run ids when created
  - skip/failure reason when relevant

2. Campaign creation sources
- Support creating a campaign from one of:
  - inline item definitions
  - a YAML/JSON manifest file
  - future repo-registry query results
- Keep the manifest format small and explicit.
- V1 should allow repeated tasks across one repo or multiple repos.

3. Execution policy
- Add campaign-level controls such as:
  - max concurrent items
  - stop after N failures
  - continue on failure
  - skip items when an open Rascal PR already exists
  - dry-run validation before enqueueing
- Default to conservative behavior.

4. Bulk controls
- Add CLI management such as:
  - `rascal campaign create`
  - `rascal campaign list`
  - `rascal campaign view`
  - `rascal campaign start`
  - `rascal campaign pause`
  - `rascal campaign resume`
  - `rascal campaign cancel`
  - `rascal campaign retry-failed`
- Operators must not need direct DB edits.

5. Progress and reporting
- Surface aggregate campaign progress, including counts by item state.
- Persist a campaign summary artifact or API view showing:
  - total items
  - active items
  - successes
  - failures
  - skipped items and reasons
  - linked PRs and runs
- Make the summary inspectable while the campaign is still running.

6. Scheduler integration
- Campaign items should enqueue ordinary Rascal runs.
- Campaign logic should respect existing scheduler bounds and repo/task serialization.
- The campaign layer must not bypass the existing control plane invariants.

## Suggested implementation approach
1. Keep campaigns declarative.
- A campaign is a managed set of item intents plus progress metadata.
- Item execution should still flow through normal run creation and scheduling.

2. Start with independent items only.
- V1 should not support arbitrary dependency graphs.
- If ordering is needed, allow a simple list order with bounded concurrency.

3. Reuse existing repo/run policy resolution.
- Campaign item admission should go through the same repo and scheduler rules as normal runs.
- When #128 lands, campaigns should naturally benefit from repo-scoped policy.

4. Make dry-run validation first-class.
- Validate manifest shape, repo references, and policy constraints before starting work.
- Prefer early rejection over half-started campaigns.

5. Keep campaign state separate from task state.
- The campaign is an operator-facing batch object.
- Tasks and runs remain the execution-facing objects underneath it.

## Acceptance criteria
- Operators can create, inspect, start, pause, resume, cancel, and retry campaigns from the CLI.
- Campaign items persist explicit state and link to created tasks/runs.
- Campaign execution respects bounded concurrency and normal Rascal admission rules.
- Operators can inspect aggregate progress and per-item outcomes.
- Dry-run validation exists before starting a campaign.
- Tests cover manifest parsing, state transitions, pause/resume/cancel behavior, and aggregate reporting.

## Suggested test plan
- Unit tests for campaign manifest validation and item expansion.
- Unit tests for campaign state transitions and policy evaluation.
- Integration tests for start, pause, resume, cancel, and retry-failed flows.
- Scheduler-adjacent tests proving campaign items do not bypass run admission rules.
- Regression tests for failure-threshold stop behavior and open-PR skip behavior.

## Implementation notes
- Keep V1 focused on controlled batch execution, not general workflow orchestration.
- This should remove the need for ad hoc shell loops while preserving Rascal’s existing reliability properties.
- A boring, inspectable campaign layer is the right first step.


## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run `make lint` and `make test` before finishing if those targets exist.
- If one of those commands does not exist or cannot run, explain exactly why and run the closest equivalent checks instead.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label &#39;rascal&#39; on issue #164


Assistant: 
Image files: 0
============================
{&#34;type&#34;:&#34;message&#34;,&#34;message&#34;:{&#34;id&#34;:null,&#34;role&#34;:&#34;assistant&#34;,&#34;created&#34;:1773501734,&#34;content&#34;:[{&#34;type&#34;:&#34;text&#34;,&#34;text&#34;:&#34;I’m treating this as an implementation task for issue `#164`. I’ll map the existing run/task/scheduler/CLI structure first, then make the smallest coherent set of changes for campaign persistence, orchestration, and reporting.\n\nI’m reading the repository layout and the code paths that already own runs, tasks, scheduling, and CLI commands so the campaign layer can sit on top instead of forking behavior.\n\nI’ve confirmed the current architecture already has the right seams: `rascald` owns run admission/scheduling, the store persists run/task state, and the CLI is a thin API client. Next I’m tracing `createAndQueueRun`, scheduler loops, and the state/sql layer so campaigns can reuse that exact path.\n\nI’ve got the rough design pinned down: persist campaigns/items in state, expose API endpoints under `rascald`, parse manifests and inline items in the CLI, and drive fan-out by reusing `createAndQueueRun` plus a lightweight campaign scheduler that only enqueues normal runs. I’m checking the existing test harness now so the implementation lands with targeted coverage instead of bolting on ad hoc tests.\n\nI’ve finished the read-through. The main edits are going into three seams: new campaign persistence in `internal/state`, a small campaign API surface in `rascald`, and a dedicated CLI command file so the existing `main.go` only needs wiring changes.\n\nI’ve moved into implementation and I’m correcting the first-pass wiring as I go. The current pass is tightening CLI defaults and manifest parsing so policy flags behave predictably instead of silently overwriting manifest values.\n\nI’ve got the core pieces wired: new state models, daemon endpoints, and CLI commands. I’m running formatting and a narrow test compile next so I can catch structural problems before I add the targeted campaign tests.\n\nThe first compile pass flushed out a predictable tooling mistake: I accidentally included the SQL schema in `gofmt`. I’m rerunning formatting on just the Go files and then I’ll use the compiler output to tighten the implementation before adding the campaign-specific tests.\n\nThe compile run is still chewing through dependencies and package build. I’m letting that finish once so I get the full error set in one shot instead of thrashing on partial failures.\n\nThe targeted tests are doing their job: one bug was real state churn on skipped items that already point at an existing review run, and one failure was test cleanup because the cancellation path still had an active supervisor. I’m fixing both before widening to the full suite.\n\nThe focused package tests are green now, including the new lifecycle cases. I’m running the repo’s required verification targets next: `make lint` and `make test`, which will also exercise codegen and any untouched packages.\n\nBoth repo-level targets are still in their setup phase because `make lint` and `make test` each invoke `sqlc` codegen. That was a poor candidate for parallel execution, so I’m waiting for the current runs to settle and will rerun serially if either target comes back inconclusive.\n\nThe parallel `make` runs aren’t giving useful feedback because they’re contending in the shared `sqlc` step. I’m terminating those and rerunning `make lint` and `make test` serially so the required verification is trustworthy.\n\nVerification is clean now: `make lint` and `make test` both passed after tightening a couple of campaign test cleanup paths. I’m doing one final pass over the diff and then I’ll write the required conventional commit message file.\n\nImplemented campaign orchestration end to end.\n\nThe main changes are the new persisted campaign layer in [internal/state/campaigns.go](/work/repo/internal/state/campaigns.go) and [internal/state/campaign_types.go](/work/repo/internal/state/campaign_types.go), the `rascald` control surface and scheduler integration in [cmd/rascald/campaigns.go](/work/repo/cmd/rascald/campaigns.go) plus the wiring changes in [cmd/rascald/main.go](/work/repo/cmd/rascald/main.go), and the new CLI in [cmd/rascal/campaign.go](/work/repo/cmd/rascal/campaign.go). I also added the migration [internal/state/migrations/00014_campaigns.sql](/work/repo/internal/state/migrations/00014_campaigns.sql), updated the schema/codegen artifacts, and refreshed the root help golden at [cmd/rascal/testdata/help/root.golden](/work/repo/cmd/rascal/testdata/help/root.golden).\n\nBehavior-wise, this adds draft campaigns with persisted items and policy, manifest or inline item creation, `create/list/view/start/pause/resume/cancel/retry-failed` CLI/API flows, aggregate progress reporting, bounded fan-out through normal run creation, failure-threshold stopping, open-PR skipping, and per-item run linking. Coverage was added in [cmd/rascald/campaigns_test.go](/work/repo/cmd/rascald/campaigns_test.go), [cmd/rascal/campaign_test.go](/work/repo/cmd/rascal/campaign_test.go), and [internal/state/campaigns_test.go](/work/repo/internal/state/campaigns_test.go).\n\nVerification passed with `make lint` and `make test`. The required commit message was written to `/rascal-meta/commit_message.txt`.&#34;}],&#34;metadata&#34;:{&#34;userVisible&#34;:true,&#34;agentVisible&#34;:true}}}
{&#34;type&#34;:&#34;complete&#34;,&#34;total_tokens&#34;:13084452}
</code></pre>

</details>

Closes #164

---

Rascal run `run_2abc5ffd6e67cc7f` completed in 28m 7s · 13.08M tokens