### PR TITLE
feat(runner): add pi agent backend support

### DIFF
--- a/cmd/rascal-runner/main_test.go
+++ b/cmd/rascal-runner/main_test.go
@@ -286,6 +286,7 @@ func TestLoadConfigRespectsDirectoryOverrides(t *testing.T) {
 	t.Setenv("RASCAL_WORK_ROOT", workRoot)
 	t.Setenv("RASCAL_REPO_DIR", repoDir)
 	t.Setenv("GOOSE_PATH_ROOT", "")
+	t.Setenv("GOOSE_MOIM_MESSAGE_FILE", "")
 	t.Setenv("RASCAL_TASK_SESSION_MODE", "")
 	t.Setenv("RASCAL_TASK_SESSION_RESUME", "")
 	t.Setenv("RASCAL_TASK_SESSION_KEY", "")
@@ -345,6 +346,37 @@ func TestLoadConfigRespectsTaskSessionEnv(t *testing.T) {
 	}
 	if cfg.GoosePathRoot != "/rascal-goose-session" {
 		t.Fatalf("GoosePathRoot = %q, want /rascal-goose-session", cfg.GoosePathRoot)
+	}
+}
+
+func TestLoadConfigRespectsPiSessionEnv(t *testing.T) {
+	metaDir := filepath.Join(t.TempDir(), "meta")
+	workRoot := filepath.Join(t.TempDir(), "work")
+	t.Setenv("RASCAL_RUN_ID", "run_pi")
+	t.Setenv("RASCAL_TASK_ID", "owner/repo#pi")
+	t.Setenv("RASCAL_REPO", "owner/repo")
+	t.Setenv("GH_TOKEN", "token")
+	t.Setenv("RASCAL_AGENT_RUNTIME", "pi")
+	t.Setenv("RASCAL_META_DIR", metaDir)
+	t.Setenv("RASCAL_WORK_ROOT", workRoot)
+	t.Setenv("RASCAL_TASK_SESSION_MODE", "all")
+	t.Setenv("RASCAL_TASK_SESSION_RESUME", "true")
+	t.Setenv("RASCAL_TASK_SESSION_KEY", "owner-repo-pi-abc123")
+	t.Setenv("RASCAL_TASK_SESSION_ID", "pi-session-123")
+	t.Setenv("PI_SESSION_DIR", "/rascal-pi-session")
+
+	cfg, err := worker.LoadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig returned error: %v", err)
+	}
+	if cfg.AgentRuntime != runtime.RuntimePi {
+		t.Fatalf("AgentRuntime = %q, want %q", cfg.AgentRuntime, runtime.RuntimePi)
+	}
+	if cfg.PiSessionDir != "/rascal-pi-session" {
+		t.Fatalf("PiSessionDir = %q, want /rascal-pi-session", cfg.PiSessionDir)
+	}
+	if cfg.TaskSession.RuntimeSessionID != "pi-session-123" {
+		t.Fatalf("RuntimeSessionID = %q, want pi-session-123", cfg.TaskSession.RuntimeSessionID)
 	}
 }
 
@@ -1019,6 +1051,130 @@ func TestRunCodexSkipsRecordedUsageWhenSessionUsageInvalid(t *testing.T) {
 	}
 }
 
+func TestRunPiFreshSession(t *testing.T) {
+	root := t.TempDir()
+	cfg := worker.Config{
+		RepoDir:          root,
+		InstructionsPath: filepath.Join(root, "instructions.md"),
+		GooseLogPath:     filepath.Join(root, "agent.ndjson"),
+		AgentOutputPath:  filepath.Join(root, "agent_output.txt"),
+		PiSessionDir:     filepath.Join(root, "pi-sessions"),
+		AgentRuntime:     runtime.RuntimePi,
+	}
+	if err := os.WriteFile(cfg.InstructionsPath, []byte("do pi thing"), 0o644); err != nil {
+		t.Fatalf("write instructions: %v", err)
+	}
+
+	var gotArgs []string
+	ex := fakeExecutor{
+		runFn: func(_ string, _ []string, stdout, _ io.Writer, name string, args ...string) error {
+			if name != "pi" {
+				t.Fatalf("unexpected command: %s", name)
+			}
+			gotArgs = append([]string(nil), args...)
+			if _, err := io.WriteString(stdout, `{"type":"session","id":"pi-session-1"}`+"\n"); err != nil {
+				return fmt.Errorf("write fake pi session: %w", err)
+			}
+			if _, err := io.WriteString(stdout, `{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"final pi response"}]}}`+"\n"); err != nil {
+				return fmt.Errorf("write fake pi assistant message: %w", err)
+			}
+			return nil
+		},
+	}
+
+	output, sessionID, err := worker.RunPi(ex, cfg)
+	if err != nil {
+		t.Fatalf("RunPi returned error: %v", err)
+	}
+	if output != "final pi response" {
+		t.Fatalf("output = %q, want final pi response", output)
+	}
+	if sessionID != "pi-session-1" {
+		t.Fatalf("sessionID = %q, want pi-session-1", sessionID)
+	}
+	argsText := strings.Join(gotArgs, " ")
+	for _, want := range []string{"--mode", "json", "--session-dir", cfg.PiSessionDir, "do pi thing"} {
+		if !strings.Contains(argsText, want) {
+			t.Fatalf("expected %q in args, got %q", want, argsText)
+		}
+	}
+	if strings.Contains(argsText, "--session pi-session-") {
+		t.Fatalf("did not expect explicit session selection in fresh pi run, got %q", argsText)
+	}
+	if !strings.Contains(argsText, "--no-session") {
+		t.Fatalf("expected --no-session in fresh pi run, got %q", argsText)
+	}
+	data, err := os.ReadFile(cfg.AgentOutputPath)
+	if err != nil {
+		t.Fatalf("read pi agent output: %v", err)
+	}
+	if string(data) != "final pi response" {
+		t.Fatalf("agent output file = %q, want final pi response", string(data))
+	}
+}
+
+func TestRunPiResumeSession(t *testing.T) {
+	root := t.TempDir()
+	sessionPath := filepath.Join(root, "pi-sessions", "nested", "session.jsonl")
+	if err := os.MkdirAll(filepath.Dir(sessionPath), 0o755); err != nil {
+		t.Fatalf("mkdir pi sessions: %v", err)
+	}
+	if err := os.WriteFile(sessionPath, []byte(`{"type":"session","id":"pi-session-abc"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write pi session file: %v", err)
+	}
+
+	cfg := worker.Config{
+		RepoDir:          root,
+		InstructionsPath: filepath.Join(root, "instructions.md"),
+		GooseLogPath:     filepath.Join(root, "agent.ndjson"),
+		AgentOutputPath:  filepath.Join(root, "agent_output.txt"),
+		PiSessionDir:     filepath.Join(root, "pi-sessions"),
+		AgentRuntime:     runtime.RuntimePi,
+		TaskSession: runner.TaskSessionSpec{
+			Mode:             runtime.SessionModeAll,
+			Resume:           true,
+			RuntimeSessionID: "pi-session-abc",
+		},
+	}
+	if err := os.WriteFile(cfg.InstructionsPath, []byte("continue pi task"), 0o644); err != nil {
+		t.Fatalf("write instructions: %v", err)
+	}
+
+	var gotArgs []string
+	ex := fakeExecutor{
+		runFn: func(_ string, _ []string, stdout, _ io.Writer, name string, args ...string) error {
+			if name != "pi" {
+				t.Fatalf("unexpected command: %s", name)
+			}
+			gotArgs = append([]string(nil), args...)
+			if _, err := io.WriteString(stdout, `{"type":"session","id":"pi-session-abc"}`+"\n"); err != nil {
+				return fmt.Errorf("write fake pi resumed session: %w", err)
+			}
+			if _, err := io.WriteString(stdout, `{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"continued pi response"}]}}`+"\n"); err != nil {
+				return fmt.Errorf("write fake pi continued assistant message: %w", err)
+			}
+			return nil
+		},
+	}
+
+	_, sessionID, err := worker.RunPi(ex, cfg)
+	if err != nil {
+		t.Fatalf("RunPi returned error: %v", err)
+	}
+	if sessionID != "pi-session-abc" {
+		t.Fatalf("sessionID = %q, want pi-session-abc", sessionID)
+	}
+	argsText := strings.Join(gotArgs, " ")
+	for _, want := range []string{"--mode", "json", "--session-dir", cfg.PiSessionDir, "--session", "pi-session-abc"} {
+		if !strings.Contains(argsText, want) {
+			t.Fatalf("expected %q in args, got %q", want, argsText)
+		}
+	}
+	if strings.Contains(argsText, "--no-session") {
+		t.Fatalf("did not expect --no-session in resumed pi run, got %q", argsText)
+	}
+}
+
 func TestRunClaudeFreshSession(t *testing.T) {
 	root := t.TempDir()
 	cfg := worker.Config{
@@ -1636,6 +1792,7 @@ func TestRunWithExecutorFailsWhenRequiredCommandMissing(t *testing.T) {
 	}{
 		{name: "goose", backend: "goose", missingCommand: "goose"},
 		{name: "codex", backend: "codex", missingCommand: "codex"},
+		{name: "pi", backend: "pi", missingCommand: "pi"},
 	}
 
 	for _, tc := range tests {

--- a/cmd/rascal/doctor_remote.go
+++ b/cmd/rascal/doctor_remote.go
@@ -23,8 +23,10 @@ type remoteDoctorStatus struct {
 	RunnerImagePresent      bool   `json:"runner_image_present"`
 	RunnerImageGooseCodex   string `json:"runner_image_goose,omitempty"`
 	RunnerImageCodex        string `json:"runner_image_codex,omitempty"`
+	RunnerImagePi           string `json:"runner_image_pi,omitempty"`
 	RunnerImageGooseCodexID string `json:"runner_image_goose_id,omitempty"`
 	RunnerImageCodexID      string `json:"runner_image_codex_id,omitempty"`
+	RunnerImagePiID         string `json:"runner_image_pi_id,omitempty"`
 }
 
 func runRemoteDoctor(cfg deployConfig) (remoteDoctorStatus, error) {
@@ -76,14 +78,16 @@ func runRemoteDoctor(cfg deployConfig) (remoteDoctorStatus, error) {
 		"set -eu",
 		fmt.Sprintf(`goose_image=%q`, defaults.GooseCodexRunnerImageTag),
 		fmt.Sprintf(`codex_image=%q`, defaults.CodexRunnerImageTag),
+		fmt.Sprintf(`pi_image=%q`, defaults.PiRunnerImageTag),
 		`if [ -f /etc/rascal/rascal.env ]; then`,
 		`  set -a`,
 		`  . /etc/rascal/rascal.env`,
 		`  set +a`,
 		`  if [ -n "${RASCAL_RUNNER_IMAGE_GOOSE_CODEX:-}" ]; then goose_image=$RASCAL_RUNNER_IMAGE_GOOSE_CODEX; elif [ -n "${RASCAL_RUNNER_IMAGE_GOOSE:-}" ]; then goose_image=$RASCAL_RUNNER_IMAGE_GOOSE; fi`,
 		`  if [ -n "${RASCAL_RUNNER_IMAGE_CODEX:-}" ]; then codex_image=$RASCAL_RUNNER_IMAGE_CODEX; fi`,
+		`  if [ -n "${RASCAL_RUNNER_IMAGE_PI:-}" ]; then pi_image=$RASCAL_RUNNER_IMAGE_PI; fi`,
 		`fi`,
-		`printf 'goose=%s\ncodex=%s\n' "$goose_image" "$codex_image"`,
+		`printf 'goose=%s\ncodex=%s\npi=%s\n' "$goose_image" "$codex_image" "$pi_image"`,
 	}, "\n"))...)
 	if err != nil {
 		log.Printf("resolve runner images over SSH failed: %v", err)
@@ -98,6 +102,8 @@ func runRemoteDoctor(cfg deployConfig) (remoteDoctorStatus, error) {
 				status.RunnerImageGooseCodex = strings.TrimSpace(value)
 			case "codex":
 				status.RunnerImageCodex = strings.TrimSpace(value)
+			case "pi":
+				status.RunnerImagePi = strings.TrimSpace(value)
 			}
 		}
 	}
@@ -109,10 +115,13 @@ func runRemoteDoctor(cfg deployConfig) (remoteDoctorStatus, error) {
 		`set +a`,
 		`goose_image=${RASCAL_RUNNER_IMAGE_GOOSE_CODEX:-${RASCAL_RUNNER_IMAGE_GOOSE:-}}`,
 		`codex_image=${RASCAL_RUNNER_IMAGE_CODEX:-}`,
+		`pi_image=${RASCAL_RUNNER_IMAGE_PI:-}`,
 		`[ -n "$goose_image" ]`,
 		`[ -n "$codex_image" ]`,
+		`[ -n "$pi_image" ]`,
 		`printf 'goose_id=%s\n' "$(docker image inspect -f '{{.Id}}' "$goose_image")"`,
 		`printf 'codex_id=%s\n' "$(docker image inspect -f '{{.Id}}' "$codex_image")"`,
+		`printf 'pi_id=%s\n' "$(docker image inspect -f '{{.Id}}' "$pi_image")"`,
 	}, "\n"))...)
 	if err != nil {
 		log.Printf("resolve runner image IDs over SSH failed: %v", err)
@@ -127,6 +136,8 @@ func runRemoteDoctor(cfg deployConfig) (remoteDoctorStatus, error) {
 				status.RunnerImageGooseCodexID = strings.TrimSpace(value)
 			case "codex_id":
 				status.RunnerImageCodexID = strings.TrimSpace(value)
+			case "pi_id":
+				status.RunnerImagePiID = strings.TrimSpace(value)
 			}
 		}
 	}
@@ -138,6 +149,7 @@ func runRemoteDoctor(cfg deployConfig) (remoteDoctorStatus, error) {
 		`set +a`,
 		`[ -n "${RASCAL_RUNNER_IMAGE_GOOSE_CODEX:-${RASCAL_RUNNER_IMAGE_GOOSE:-}}" ]`,
 		`[ -n "${RASCAL_RUNNER_IMAGE_CODEX:-}" ]`,
+		`[ -n "${RASCAL_RUNNER_IMAGE_PI:-}" ]`,
 		"echo ok",
 	}, "\n"))
 	status.RunnerImagePresent = check(fmt.Sprintf(strings.Join([]string{
@@ -150,11 +162,13 @@ func runRemoteDoctor(cfg deployConfig) (remoteDoctorStatus, error) {
 		`  set +a`,
 		`  goose_image=${RASCAL_RUNNER_IMAGE_GOOSE_CODEX:-${RASCAL_RUNNER_IMAGE_GOOSE:-}}`,
 		`  codex_image=${RASCAL_RUNNER_IMAGE_CODEX:-}`,
+		`  pi_image=${RASCAL_RUNNER_IMAGE_PI:-}`,
 		`  [ -n "$goose_image" ]`,
 		`  [ -n "$codex_image" ]`,
+		`  [ -n "$pi_image" ]`,
 		`fi`,
-		`docker image inspect "$goose_image" "$codex_image" >/dev/null 2>&1 && echo ok`,
-	}, "\n"), defaults.GooseCodexRunnerImageTag, defaults.CodexRunnerImageTag))
+		`docker image inspect "$goose_image" "$codex_image" "$pi_image" >/dev/null 2>&1 && echo ok`,
+	}, "\n"), defaults.GooseCodexRunnerImageTag, defaults.CodexRunnerImageTag, defaults.PiRunnerImageTag))
 	return status, nil
 }
 

--- a/cmd/rascal/doctor_remote_test.go
+++ b/cmd/rascal/doctor_remote_test.go
@@ -37,11 +37,17 @@ func TestRunRemoteDoctorUsesSlotUnitsOnly(t *testing.T) {
 	if status.RunnerImageCodex != "rascal-runner-codex:latest" {
 		t.Fatalf("runner image codex = %q, want rascal-runner-codex:latest", status.RunnerImageCodex)
 	}
+	if status.RunnerImagePi != "rascal-runner-pi:latest" {
+		t.Fatalf("runner image pi = %q, want rascal-runner-pi:latest", status.RunnerImagePi)
+	}
 	if status.RunnerImageGooseCodexID != "sha256:goose123" {
 		t.Fatalf("runner image goose-codex id = %q, want sha256:goose123", status.RunnerImageGooseCodexID)
 	}
 	if status.RunnerImageCodexID != "sha256:codex456" {
 		t.Fatalf("runner image codex id = %q, want sha256:codex456", status.RunnerImageCodexID)
+	}
+	if status.RunnerImagePiID != "sha256:pi789" {
+		t.Fatalf("runner image pi id = %q, want sha256:pi789", status.RunnerImagePiID)
 	}
 
 	sshLog, err := os.ReadFile(filepath.Join(logDir, "ssh_calls.log"))
@@ -99,12 +105,12 @@ if [[ "$cmd" == *"case \"\$slot\" in blue|green) echo \"\$slot\" ;;"* ]]; then
   printf 'blue'
   exit 0
 fi
-if [[ "$cmd" == *"printf 'goose=%s\\ncodex=%s\\n'"* ]]; then
-  printf 'goose=rascal-runner-goose-codex:latest\ncodex=rascal-runner-codex:latest\n'
+if [[ "$cmd" == *"printf 'goose=%s\\ncodex=%s\\npi=%s\\n'"* ]]; then
+  printf 'goose=rascal-runner-goose-codex:latest\ncodex=rascal-runner-codex:latest\npi=rascal-runner-pi:latest\n'
   exit 0
 fi
 if [[ "$cmd" == *"printf 'goose_id=%s\\n'"* ]]; then
-  printf 'goose_id=sha256:goose123\ncodex_id=sha256:codex456\n'
+  printf 'goose_id=sha256:goose123\ncodex_id=sha256:codex456\npi_id=sha256:pi789\n'
   exit 0
 fi
 if [[ "$cmd" == *"echo ok"* ]]; then

--- a/cmd/rascal/infra.go
+++ b/cmd/rascal/infra.go
@@ -192,6 +192,7 @@ func (a *app) newDeployExistingCmd(use, short string) *cobra.Command {
 		agentRuntime           string
 		runnerImageGoose       string
 		runnerImageCodex       string
+		runnerImagePi          string
 		runnerImageClaude      string
 		runnerImageGooseClaude string
 		uploadEnv              bool
@@ -215,6 +216,7 @@ func (a *app) newDeployExistingCmd(use, short string) *cobra.Command {
 				AgentRuntime:           agentRuntime,
 				RunnerImageGooseCodex:  runnerImageGoose,
 				RunnerImageCodex:       runnerImageCodex,
+				RunnerImagePi:          runnerImagePi,
 				RunnerImageClaude:      runnerImageClaude,
 				RunnerImageGooseClaude: runnerImageGooseClaude,
 				SkipEnvUpload:          !uploadEnv,
@@ -248,9 +250,10 @@ func (a *app) newDeployExistingCmd(use, short string) *cobra.Command {
 	cmd.Flags().StringVar(&webhookSecret, "webhook-secret", "", "GitHub webhook secret")
 	cmd.Flags().StringVar(&codexAuthPath, "codex-auth", "", "local Codex auth.json path to seed as a stored shared credential")
 	cmd.Flags().StringVar(&domain, "domain", "", "public domain for TLS/Caddy")
-	cmd.Flags().StringVar(&agentRuntime, "agent-runtime", "", "agent runtime to use on the server (goose or codex)")
+	cmd.Flags().StringVar(&agentRuntime, "agent-runtime", "", "agent runtime to use on the server (goose-codex, codex, pi, claude, or goose-claude)")
 	cmd.Flags().StringVar(&runnerImageGoose, "runner-image-goose-codex", defaults.GooseCodexRunnerImageTag, "goose-codex runner docker image tag")
 	cmd.Flags().StringVar(&runnerImageCodex, "runner-image-codex", defaults.CodexRunnerImageTag, "codex runner docker image tag")
+	cmd.Flags().StringVar(&runnerImagePi, "runner-image-pi", defaults.PiRunnerImageTag, "pi runner docker image tag")
 	cmd.Flags().StringVar(&runnerImageClaude, "runner-image-claude", defaults.ClaudeRunnerImageTag, "claude runner docker image tag")
 	cmd.Flags().StringVar(&runnerImageGooseClaude, "runner-image-goose-claude", defaults.GooseClaudeRunnerImageTag, "goose-claude runner docker image tag")
 	cmd.Flags().BoolVar(&uploadEnv, "upload-env", false, "upload/update /etc/rascal/rascal.env on server")
@@ -272,6 +275,7 @@ type deployExistingInput struct {
 	AgentRuntime           string
 	RunnerImageGooseCodex  string
 	RunnerImageCodex       string
+	RunnerImagePi          string
 	RunnerImageClaude      string
 	RunnerImageGooseClaude string
 	SkipEnvUpload          bool
@@ -312,6 +316,7 @@ func (a *app) runDeployExisting(input deployExistingInput) (deployExistingResult
 	}
 	runnerImageGoose := firstNonEmpty(strings.TrimSpace(input.RunnerImageGooseCodex), defaults.GooseCodexRunnerImageTag)
 	runnerImageCodex := firstNonEmpty(strings.TrimSpace(input.RunnerImageCodex), defaults.CodexRunnerImageTag)
+	runnerImagePi := firstNonEmpty(strings.TrimSpace(input.RunnerImagePi), defaults.PiRunnerImageTag)
 	runnerImageClaude := firstNonEmpty(strings.TrimSpace(input.RunnerImageClaude), defaults.ClaudeRunnerImageTag)
 	runnerImageGooseClaude := firstNonEmpty(strings.TrimSpace(input.RunnerImageGooseClaude), defaults.GooseClaudeRunnerImageTag)
 	sshPort := input.SSHPort
@@ -414,6 +419,7 @@ func (a *app) runDeployExisting(input deployExistingInput) (deployExistingResult
 		AgentRuntime:           agentRuntime,
 		RunnerImageGooseCodex:  runnerImageGoose,
 		RunnerImageCodex:       runnerImageCodex,
+		RunnerImagePi:          runnerImagePi,
 		RunnerImageClaude:      runnerImageClaude,
 		RunnerImageGooseClaude: runnerImageGooseClaude,
 		ServerListenAddr:       ":8080",

--- a/cmd/rascal/main.go
+++ b/cmd/rascal/main.go
@@ -1637,6 +1637,12 @@ func (a *app) newDoctorCmd() *cobra.Command {
 						if codexImageID := strings.TrimSpace(remote.RunnerImageCodexID); codexImageID != "" {
 							a.println("remote codex runner image id: %s", codexImageID)
 						}
+						if piImage := strings.TrimSpace(remote.RunnerImagePi); piImage != "" {
+							a.println("remote pi runner image: %s", piImage)
+						}
+						if piImageID := strings.TrimSpace(remote.RunnerImagePiID); piImageID != "" {
+							a.println("remote pi runner image id: %s", piImageID)
+						}
 					}
 				}
 				if !cfgExists {
@@ -1657,7 +1663,7 @@ func (a *app) newDoctorCmd() *cobra.Command {
 					if strings.TrimSpace(remote.Error) == "" && !remote.RunnerImageConfigured {
 						targetUser := firstNonEmpty(strings.TrimSpace(sshUser), strings.TrimSpace(a.cfg.SSHUser), "root")
 						targetHost := firstNonEmpty(strings.TrimSpace(host), strings.TrimSpace(a.cfg.SSHHost), strings.TrimSpace(a.cfg.Host))
-						a.println("hint: remote rascal.env must set explicit runner images: `ssh %s@%s 'printf \"RASCAL_RUNNER_IMAGE_GOOSE_CODEX=rascal-runner-goose-codex:latest\\nRASCAL_RUNNER_IMAGE_CODEX=rascal-runner-codex:latest\\n\" >> /etc/rascal/rascal.env'`", targetUser, targetHost)
+						a.println("hint: remote rascal.env must set explicit runner images: `ssh %s@%s 'printf \"RASCAL_RUNNER_IMAGE_GOOSE_CODEX=rascal-runner-goose-codex:latest\\nRASCAL_RUNNER_IMAGE_CODEX=rascal-runner-codex:latest\\nRASCAL_RUNNER_IMAGE_PI=rascal-runner-pi:latest\\n\" >> /etc/rascal/rascal.env'`", targetUser, targetHost)
 					}
 				}
 				return nil

--- a/cmd/rascal/main_test.go
+++ b/cmd/rascal/main_test.go
@@ -293,6 +293,7 @@ func TestDoctorJSONOutputIncludesTypedRemoteStatus(t *testing.T) {
 			RunnerImagePresent:    true,
 			RunnerImageGooseCodex: "rascal-runner-goose-codex:latest",
 			RunnerImageCodex:      "rascal-runner-codex:latest",
+			RunnerImagePi:         "rascal-runner-pi:latest",
 		}, nil
 	}
 
@@ -335,6 +336,9 @@ func TestDoctorJSONOutputIncludesTypedRemoteStatus(t *testing.T) {
 	}
 	if out.Remote.RunnerImageGooseCodex != "rascal-runner-goose-codex:latest" {
 		t.Fatalf("runner_image_goose_codex = %q, want rascal-runner-goose-codex:latest", out.Remote.RunnerImageGooseCodex)
+	}
+	if out.Remote.RunnerImagePi != "rascal-runner-pi:latest" {
+		t.Fatalf("runner_image_pi = %q, want rascal-runner-pi:latest", out.Remote.RunnerImagePi)
 	}
 }
 

--- a/cmd/rascal/testdata/help/deploy.golden
+++ b/cmd/rascal/testdata/help/deploy.golden
@@ -9,7 +9,7 @@ rascal deploy --host "$SERVER_IP" --upload-env --github-runtime-token "$RASCAL_G
 rascal deploy --host "$SERVER_IP" --codex-auth ~/.codex/auth.json
 
 Flags:
-      --agent-runtime string               agent runtime to use on the server (goose or codex)
+      --agent-runtime string               agent runtime to use on the server (goose-codex, codex, pi, claude, or goose-claude)
       --api-token string                   orchestrator API token
       --codex-auth string                  local Codex auth.json path to seed as a stored shared credential
       --domain string                      public domain for TLS/Caddy
@@ -21,6 +21,7 @@ Flags:
       --runner-image-codex string          codex runner docker image tag (default "rascal-runner-codex:latest")
       --runner-image-goose-claude string   goose-claude runner docker image tag (default "rascal-runner-goose-claude:latest")
       --runner-image-goose-codex string    goose-codex runner docker image tag (default "rascal-runner-goose-codex:latest")
+      --runner-image-pi string             pi runner docker image tag (default "rascal-runner-pi:latest")
       --ssh-key string                     SSH private key path
       --ssh-port int                       SSH target port (default 22)
       --ssh-user string                    SSH target user (default "root")

--- a/deploy/systemd/rascal.env.example
+++ b/deploy/systemd/rascal.env.example
@@ -9,6 +9,7 @@ RASCAL_RUNNER_MODE=docker
 # Set explicit runner images per runtime.
 RASCAL_RUNNER_IMAGE_GOOSE_CODEX=rascal-runner-goose-codex:latest
 RASCAL_RUNNER_IMAGE_CODEX=rascal-runner-codex:latest
+RASCAL_RUNNER_IMAGE_PI=rascal-runner-pi:latest
 RASCAL_RUNNER_MAX_ATTEMPTS=1
 RASCAL_TASK_SESSION_MODE=all
 RASCAL_TASK_SESSION_ROOT=/var/lib/rascal/agent-sessions

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,11 +10,11 @@ from execution-plane responsibilities.
 
 - Control plane: `rascal` and `rascald`
 - Execution plane: detached runner containers launched via the Docker launcher
-- Runtimes: `goose-codex`, `codex`, `claude`, and `goose-claude`
+- Runtimes: `goose-codex`, `codex`, `pi`, `claude`, and `goose-claude`
 - Harnesses (derived from runtime): `goose` and `direct`
-- Model providers (derived from runtime): `codex` and `anthropic`
-- Packaging: separate runner images per runtime (Goose-Codex, Codex, Claude,
-  Goose-Claude)
+- Model providers (derived from runtime): `codex`, `pi`, and `anthropic`
+- Packaging: separate runner images per runtime (Goose-Codex, Codex, Pi,
+  Claude, Goose-Claude)
 
 In simple terms:
 
@@ -53,7 +53,7 @@ rascal (CLI) or GitHub webhook
             v
    rascal-runner in container
   - clone repo
-  - run goose or codex
+  - run the selected runtime
   - write artifacts and meta.json
   - push branch / update PR
             |
@@ -86,7 +86,7 @@ rascal (CLI) or GitHub webhook
 3. Runner container (`rascal-runner`)
 
 - Clones the repository and checks out the target branches.
-- Executes the selected runtime (`goose-codex`, `codex`, `claude`, or
+- Executes the selected runtime (`goose-codex`, `codex`, `pi`, `claude`, or
   `goose-claude`).
 - Commits changes, pushes the head branch, and creates or reuses a PR.
 - Writes canonical artifacts into mounted `/rascal-meta`.
@@ -106,7 +106,7 @@ These are the main layers in the Go codebase.
 
 2. Agent abstraction
 
-- `internal/agent` defines `Runtime`, `Harness`, `ModelProvider`, and
+- `internal/runtime` defines `Runtime`, `Harness`, `ModelProvider`, and
   `SessionMode`.
 - `Runtime` is the user-facing selection; `Harness` and `ModelProvider` are
   derived from it via `Runtime.Harness()` and `Runtime.Provider()` methods.
@@ -117,8 +117,9 @@ These are the main layers in the Go codebase.
   `Spec`/`ExecutionHandle` contract.
 - Current production implementation is Docker; `noop` exists for
   non-runtime/test scenarios.
-- Session mounting is harness-aware: Goose uses `GOOSE_PATH_ROOT`, Codex uses
-  `CODEX_HOME`, Claude uses `CLAUDE_CONFIG_DIR`.
+- Session mounting is runtime-aware: Goose uses `GOOSE_PATH_ROOT`, Codex uses
+  `CODEX_HOME`, Pi uses `PI_SESSION_DIR`, and Claude uses
+  `CLAUDE_CONFIG_DIR`.
 
 4. Control-plane and client boundaries
 
@@ -149,8 +150,8 @@ These are the main layers in the Go codebase.
 
 - Rascal builds and deploys one orchestrator binary: `rascald`.
 - Rascal also builds one runner binary: `rascal-runner`.
-- That runner binary is packaged into separate Docker images for Goose and
-  Codex.
+- That runner binary is packaged into separate Docker images for Goose-Codex,
+  Codex, Pi, Claude, and Goose-Claude.
 - `rascald` selects the runner image based on the task/run runtime.
 - Blue/green deploy replaces the control plane, while runner containers remain
   detached in the execution plane.
@@ -314,6 +315,8 @@ Rascal uses stored credentials tagged by provider and managed by `rascald`.
   which runtimes can use it:
   - `codex` credentials (default, including legacy credentials with empty
     provider): used by `codex` and `goose-codex` runtimes via `auth.json`.
+  - `pi`: env/API-key auth only in the current rollout; no stored credential
+    lease is used.
   - `anthropic` credentials: used by `claude` and `goose-claude` runtimes via
     OAuth token.
 - Each credential is either `personal` (owned by a user) or `shared`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -22,7 +22,8 @@ Rascal deploy uploads/builds these artifacts on the server:
 - `/etc/caddy/Caddyfile` + `/etc/caddy/rascal-upstream.caddy` (proxy target)
 - Docker images for the configured runner tags (defaults:
   `rascal-runner-goose-codex:latest`, `rascal-runner-codex:latest`,
-  `rascal-runner-claude:latest`, and `rascal-runner-goose-claude:latest`)
+  `rascal-runner-pi:latest`, `rascal-runner-claude:latest`, and
+  `rascal-runner-goose-claude:latest`)
 
 It also writes:
 
@@ -45,8 +46,8 @@ default):
 - `RASCAL_TASK_SESSION_ROOT=/var/lib/rascal/agent-sessions`
 - `RASCAL_TASK_SESSION_TTL_DAYS=14`
 - `RASCAL_RUNNER_IMAGE_GOOSE_CODEX`, `RASCAL_RUNNER_IMAGE_CODEX`,
-  `RASCAL_RUNNER_IMAGE_CLAUDE`, and `RASCAL_RUNNER_IMAGE_GOOSE_CLAUDE` set the
-  runtime-specific runner images
+  `RASCAL_RUNNER_IMAGE_PI`, `RASCAL_RUNNER_IMAGE_CLAUDE`, and
+  `RASCAL_RUNNER_IMAGE_GOOSE_CLAUDE` set the runtime-specific runner images
 - `RASCAL_AGENT_RUNTIME` is optional and overrides the default runtime when set
 
 ## Blue/Green Sequence

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -12,14 +12,14 @@
 - `Worker`: the in-execution component that performs a run inside the launched
   environment.
 - `Runtime`: the user-facing selection that determines both the harness and the
-  model provider. Valid runtimes are `goose-codex`, `codex`, `claude`, and
-  `goose-claude`.
+  model provider. Valid runtimes are `goose-codex`, `codex`, `pi`, `claude`,
+  and `goose-claude`.
 - `Harness`: the tool wrapper invoked by the worker, derived from the runtime.
-  `goose-codex` and `goose-claude` use the `goose` harness; `codex` and `claude`
-  use the `direct` harness.
+  `goose-codex` and `goose-claude` use the `goose` harness; `codex`, `pi`, and
+  `claude` use the `direct` harness.
 - `ModelProvider`: the underlying model/service used by a runtime. `codex` and
-  `goose-codex` runtimes use the `codex` provider; `claude` and `goose-claude`
-  runtimes use the `anthropic` provider.
+  `goose-codex` runtimes use the `codex` provider; `pi` uses the `pi`
+  provider; `claude` and `goose-claude` runtimes use the `anthropic` provider.
 - `SessionMode`: policy governing whether a task-scoped session may resume
   (`off`, `pr-only`, `all`). Defined in `internal/runtime`.
 - `TaskSession`: optional task-scoped harness state used to resume later runs.
@@ -33,7 +33,7 @@
   state, schedules runs, and supervises execution.
 - `Execution plane`: detached Docker containers started for `rascal-runner`.
 - `Runner image`: Docker image used to execute a run. Rascal maintains separate
-  images per runtime (Goose-Codex, Codex, Claude, Goose-Claude).
+  images per runtime (Goose-Codex, Codex, Pi, Claude, Goose-Claude).
 - `Active slot`: the currently live `rascald` slot in blue/green deploys. Only
   this slot should process webhook traffic.
 - `Inactive slot`: the standby slot prepared during blue/green deploys before
@@ -74,5 +74,6 @@
   use it.
 - `Credential lease`: temporary assignment of a stored credential to one run.
 - `Credential provider`: the credential family a run needs, derived from its
-  runtime. `codex` and `goose-codex` runtimes use `codex` credentials; `claude`
-  and `goose-claude` runtimes use `anthropic` credentials.
+  runtime. `codex` and `goose-codex` runtimes use `codex` credentials; `pi`
+  currently uses env/API-key auth without stored credentials; `claude` and
+  `goose-claude` runtimes use `anthropic` credentials.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -113,6 +113,8 @@ Agent runtime notes:
   directory.
 - Codex resumes by reusing a task-scoped `CODEX_HOME` and the last discovered
   runtime session id.
+- Pi resumes by reusing a task-scoped `PI_SESSION_DIR` and the last discovered
+  runtime session id.
 - Claude resumes by reusing a named Claude Code session with `--resume`.
 - Goose-Claude uses Goose with Claude Code as provider, sharing the same session
   resume behavior as Goose.
@@ -121,12 +123,15 @@ Agent runtime notes:
 
 ## Credential Leasing
 
-Rascal uses leased stored credentials tagged by provider for all agent runs.
+Rascal uses leased stored credentials tagged by provider for runtimes that
+support brokered auth.
 
 Each credential is tagged with a `provider` (`codex` or `anthropic`). The
 broker automatically selects credentials matching the run's runtime:
 
 - `codex` and `goose-codex` runs use `codex` credentials (auth.json format).
+- `pi` runs currently use env/API-key auth only and do not lease stored
+  credentials.
 - `claude` and `goose-claude` runs use `anthropic` credentials (OAuth token
   format).
 - Legacy credentials with no provider tag are treated as `codex` credentials.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,7 @@ type ServerConfig struct {
 	RunnerImage             string
 	RunnerImageGooseCodex   string
 	RunnerImageCodex        string
+	RunnerImagePi           string
 	RunnerImageClaude       string
 	RunnerImageGooseClaude  string
 	RunnerMaxAttempts       int
@@ -96,6 +97,7 @@ func LoadServerConfig() (ServerConfig, error) {
 		AgentRuntime:            agentRuntime,
 		RunnerImageGooseCodex:   firstNonEmptyEnvOrDefault(defaults.GooseCodexRunnerImageTag, "RASCAL_RUNNER_IMAGE_GOOSE_CODEX", "RASCAL_RUNNER_IMAGE_GOOSE"),
 		RunnerImageCodex:        envOrDefault("RASCAL_RUNNER_IMAGE_CODEX", defaults.CodexRunnerImageTag),
+		RunnerImagePi:           envOrDefault("RASCAL_RUNNER_IMAGE_PI", defaults.PiRunnerImageTag),
 		RunnerImageClaude:       envOrDefault("RASCAL_RUNNER_IMAGE_CLAUDE", defaults.ClaudeRunnerImageTag),
 		RunnerImageGooseClaude:  envOrDefault("RASCAL_RUNNER_IMAGE_GOOSE_CLAUDE", defaults.GooseClaudeRunnerImageTag),
 		RunnerMaxAttempts:       envIntOrDefault("RASCAL_RUNNER_MAX_ATTEMPTS", 1),
@@ -136,6 +138,8 @@ func (c ServerConfig) RunnerImageForRuntime(rt runtime.Runtime) string {
 	switch runtime.NormalizeRuntime(string(rt)) {
 	case runtime.RuntimeCodex:
 		return strings.TrimSpace(c.RunnerImageCodex)
+	case runtime.RuntimePi:
+		return strings.TrimSpace(c.RunnerImagePi)
 	case runtime.RuntimeClaude:
 		return strings.TrimSpace(c.RunnerImageClaude)
 	case runtime.RuntimeGooseClaude:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -191,6 +191,25 @@ func TestLoadServerConfigDefaultsAgentRuntimeToGoose(t *testing.T) {
 	}
 }
 
+func TestLoadServerConfigPiRuntimeUsesPiRunnerImage(t *testing.T) {
+	t.Setenv("RASCAL_AGENT_RUNTIME", "pi")
+	t.Setenv("RASCAL_RUNNER_IMAGE_PI", "custom-pi:latest")
+
+	cfg, err := LoadServerConfig()
+	if err != nil {
+		t.Fatalf("LoadServerConfig returned error: %v", err)
+	}
+	if cfg.AgentRuntime != runtime.RuntimePi {
+		t.Fatalf("AgentRuntime = %q, want %q", cfg.AgentRuntime, runtime.RuntimePi)
+	}
+	if cfg.RunnerImagePi != "custom-pi:latest" {
+		t.Fatalf("RunnerImagePi = %q, want custom-pi:latest", cfg.RunnerImagePi)
+	}
+	if cfg.RunnerImage != "custom-pi:latest" {
+		t.Fatalf("RunnerImage = %q, want custom-pi:latest", cfg.RunnerImage)
+	}
+}
+
 func TestLoadServerConfigGooseSessionOverrides(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "goose-root")
 	t.Setenv("RASCAL_TASK_SESSION_MODE", "PR-ONLY")

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -3,6 +3,7 @@ package defaults
 const (
 	GooseCodexRunnerImageTag  = "rascal-runner-goose-codex:latest"
 	CodexRunnerImageTag       = "rascal-runner-codex:latest"
+	PiRunnerImageTag          = "rascal-runner-pi:latest"
 	ClaudeRunnerImageTag      = "rascal-runner-claude:latest"
 	GooseClaudeRunnerImageTag = "rascal-runner-goose-claude:latest"
 	AgentSessionDirName       = "agent-sessions"

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -39,6 +39,7 @@ type Config struct {
 	AgentRuntime           runtime.Runtime
 	RunnerImageGooseCodex  string
 	RunnerImageCodex       string
+	RunnerImagePi          string
 	RunnerImageClaude      string
 	RunnerImageGooseClaude string
 	ServerListenAddr       string
@@ -62,6 +63,7 @@ type plan struct {
 	AgentRuntime           string   `json:"agent_runtime"`
 	RunnerImageGooseCodex  string   `json:"runner_image_goose"`
 	RunnerImageCodex       string   `json:"runner_image_codex"`
+	RunnerImagePi          string   `json:"runner_image_pi"`
 	RunnerImageClaude      string   `json:"runner_image_claude"`
 	RunnerImageGooseClaude string   `json:"runner_image_goose_claude"`
 	UploadEnvFile          bool     `json:"upload_env_file"`
@@ -147,6 +149,7 @@ func Execute(cfg Config) error {
 		AgentRuntime:           firstNonEmpty(strings.TrimSpace(string(cfg.AgentRuntime)), string(runtime.RuntimeGooseCodex)),
 		RunnerImageGooseCodex:  strings.TrimSpace(cfg.RunnerImageGooseCodex),
 		RunnerImageCodex:       strings.TrimSpace(cfg.RunnerImageCodex),
+		RunnerImagePi:          strings.TrimSpace(cfg.RunnerImagePi),
 		RunnerImageClaude:      strings.TrimSpace(cfg.RunnerImageClaude),
 		RunnerImageGooseClaude: strings.TrimSpace(cfg.RunnerImageGooseClaude),
 		UploadEnvFile:          cfg.UploadEnvFile,
@@ -219,11 +222,12 @@ install -m 0755 /tmp/rascal-bootstrap/rascal-runner /opt/rascal/runner/rascal-ru
 CACHE_BUST="$(sha256sum /opt/rascal/runner/rascal-runner | cut -d' ' -f1)"
 docker build --quiet --build-arg CACHE_BUST="$CACHE_BUST" --target goose-codex-runner -t %s /opt/rascal/runner
 docker build --quiet --build-arg CACHE_BUST="$CACHE_BUST" --target codex-runner -t %s /opt/rascal/runner
+docker build --quiet --build-arg CACHE_BUST="$CACHE_BUST" --target pi-runner -t %s /opt/rascal/runner
 docker build --quiet --build-arg CACHE_BUST="$CACHE_BUST" --target claude-runner -t %s /opt/rascal/runner
 docker build --quiet --build-arg CACHE_BUST="$CACHE_BUST" --target goose-claude-runner -t %s /opt/rascal/runner
 install -m 0755 /tmp/rascal-bootstrap/rascald /opt/rascal/rascald
 install -m 0644 /tmp/rascal-bootstrap/rascal@.service /etc/systemd/system/rascal@.service
-`)+"\n", shellSingleQuote(cfg.RunnerImageGooseCodex), shellSingleQuote(cfg.RunnerImageCodex), shellSingleQuote(cfg.RunnerImageClaude), shellSingleQuote(cfg.RunnerImageGooseClaude))); err != nil {
+`)+"\n", shellSingleQuote(cfg.RunnerImageGooseCodex), shellSingleQuote(cfg.RunnerImageCodex), shellSingleQuote(cfg.RunnerImagePi), shellSingleQuote(cfg.RunnerImageClaude), shellSingleQuote(cfg.RunnerImageGooseClaude))); err != nil {
 		return err
 	}
 	if cfg.UploadEnvFile {
@@ -634,6 +638,7 @@ func serverEnvFile(cfg Config) string {
 	runtime := strings.TrimSpace(string(cfg.AgentRuntime))
 	gooseImage := firstNonEmpty(strings.TrimSpace(cfg.RunnerImageGooseCodex), defaults.GooseCodexRunnerImageTag)
 	codexImage := firstNonEmpty(strings.TrimSpace(cfg.RunnerImageCodex), defaults.CodexRunnerImageTag)
+	piImage := firstNonEmpty(strings.TrimSpace(cfg.RunnerImagePi), defaults.PiRunnerImageTag)
 	claudeImage := firstNonEmpty(strings.TrimSpace(cfg.RunnerImageClaude), defaults.ClaudeRunnerImageTag)
 	gooseClaudeImage := firstNonEmpty(strings.TrimSpace(cfg.RunnerImageGooseClaude), defaults.GooseClaudeRunnerImageTag)
 	lines := []string{
@@ -646,6 +651,7 @@ func serverEnvFile(cfg Config) string {
 		fmt.Sprintf("RASCAL_RUNNER_MODE=%s", cfg.RunnerMode),
 		fmt.Sprintf("RASCAL_RUNNER_IMAGE_GOOSE_CODEX=%s", gooseImage),
 		fmt.Sprintf("RASCAL_RUNNER_IMAGE_CODEX=%s", codexImage),
+		fmt.Sprintf("RASCAL_RUNNER_IMAGE_PI=%s", piImage),
 		fmt.Sprintf("RASCAL_RUNNER_IMAGE_CLAUDE=%s", claudeImage),
 		fmt.Sprintf("RASCAL_RUNNER_IMAGE_GOOSE_CLAUDE=%s", gooseClaudeImage),
 		"RASCAL_RUNNER_MAX_ATTEMPTS=1",

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -313,6 +313,13 @@ func TestServerEnvFileOmitsLegacyRunnerImageEnv(t *testing.T) {
 	}
 }
 
+func TestServerEnvFileIncludesPiRunnerImage(t *testing.T) {
+	content := serverEnvFile(testDeployConfig())
+	if !strings.Contains(content, "RASCAL_RUNNER_IMAGE_PI=rascal-runner-pi:latest") {
+		t.Fatalf("expected pi runner image env, got:\n%s", content)
+	}
+}
+
 func testDeployConfig() Config {
 	return Config{
 		Host:                  "example-host",
@@ -322,6 +329,7 @@ func testDeployConfig() Config {
 		AgentRuntime:          runtime.RuntimeCodex,
 		RunnerImageGooseCodex: defaults.GooseCodexRunnerImageTag,
 		RunnerImageCodex:      defaults.CodexRunnerImageTag,
+		RunnerImagePi:         defaults.PiRunnerImageTag,
 		ServerListenAddr:      ":8080",
 		ServerDataDir:         "/var/lib/rascal",
 		ServerStatePath:       "/var/lib/rascal/state.db",

--- a/internal/orchestrator/execution.go
+++ b/internal/orchestrator/execution.go
@@ -117,6 +117,8 @@ func (s *Server) failRunForMissingExecution(run state.Run, reason string) {
 
 func credentialAuthPath(runDir string, rt runtime.Runtime) (dir, file string) {
 	switch runtime.NormalizeRuntime(string(rt)) {
+	case runtime.RuntimePi:
+		return "", ""
 	case runtime.RuntimeClaude, runtime.RuntimeGooseClaude:
 		dir = filepath.Join(runDir, "claude")
 		file = filepath.Join(dir, "oauth_token")
@@ -128,6 +130,9 @@ func credentialAuthPath(runDir string, rt runtime.Runtime) (dir, file string) {
 }
 
 func (s *Server) prepareRunCredentialAuth(runID, runDir, requesterUserID string, rt runtime.Runtime) (string, error) {
+	if runtime.NormalizeRuntime(string(rt)) == runtime.RuntimePi {
+		return "", nil
+	}
 	requesterUserID = strings.TrimSpace(requesterUserID)
 	if requesterUserID == "" {
 		requesterUserID = "system"
@@ -209,6 +214,9 @@ func (s *Server) prepareRunCredentialAuth(runID, runDir, requesterUserID string,
 }
 
 func (s *Server) cleanupRunCredentialAuth(runDir, credentialLeaseID string, rt runtime.Runtime) {
+	if runtime.NormalizeRuntime(string(rt)) == runtime.RuntimePi {
+		return
+	}
 	if strings.TrimSpace(credentialLeaseID) != "" && s.Broker != nil {
 		if err := s.Broker.Release(context.Background(), credentialLeaseID); err != nil {
 			log.Printf("release credential lease %s failed: %v", credentialLeaseID, err)

--- a/internal/runner/docker.go
+++ b/internal/runner/docker.go
@@ -33,8 +33,10 @@ const (
 	containerWorkDir          = "/work"
 	containerGooseStateDir    = "/rascal-meta/goose"
 	containerCodexStateDir    = "/rascal-meta/codex"
+	containerPiStateDir       = "/rascal-meta/pi"
 	containerGooseSessionDir  = "/rascal-goose-session"
 	containerCodexSessionDir  = "/rascal-codex-session"
+	containerPiSessionDir     = "/rascal-pi-session"
 	containerClaudeStateDir   = "/rascal-meta/claude"
 	containerClaudeSessionDir = "/rascal-claude-session"
 	containerContextJSONPath  = "/rascal-meta/context.json"
@@ -91,6 +93,7 @@ func (l DockerRunner) StartDetached(ctx context.Context, spec Spec) (handle Exec
 
 	codexHome := containerCodexStateDir
 	goosePathRoot := containerGooseStateDir
+	piSessionDir := containerPiStateDir
 	claudeConfigDir := containerClaudeStateDir
 	sessionMountTarget := ""
 	if sessionResume && sessionDir != "" {
@@ -98,6 +101,9 @@ func (l DockerRunner) StartDetached(ctx context.Context, spec Spec) (handle Exec
 		case runtime.RuntimeCodex:
 			codexHome = containerCodexSessionDir
 			sessionMountTarget = containerCodexSessionDir
+		case runtime.RuntimePi:
+			piSessionDir = containerPiSessionDir
+			sessionMountTarget = containerPiSessionDir
 		case runtime.RuntimeClaude:
 			claudeConfigDir = containerClaudeSessionDir
 			sessionMountTarget = containerClaudeSessionDir
@@ -125,6 +131,7 @@ func (l DockerRunner) StartDetached(ctx context.Context, spec Spec) (handle Exec
 		"RASCAL_TASK_SESSION_KEY":    sessionKey,
 		"RASCAL_TASK_SESSION_ID":     runtimeSessionID,
 		"CODEX_HOME":                 codexHome,
+		"PI_SESSION_DIR":             piSessionDir,
 		"GH_PROMPT_DISABLED":         "1",
 		"GIT_TERMINAL_PROMPT":        "0",
 	}
@@ -184,7 +191,7 @@ func (l DockerRunner) StartDetached(ctx context.Context, spec Spec) (handle Exec
 		sessionResume,
 		sessionKey,
 		runtimeSessionID,
-		firstNonEmptySessionPath(sessionMountTarget, goosePathRoot),
+		firstNonEmptySessionPath(sessionMountTarget, goosePathRoot, piSessionDir, codexHome, claudeConfigDir),
 	); err != nil {
 		return ExecutionHandle{}, fmt.Errorf("write runner session log: %w", err)
 	}

--- a/internal/runner/docker_test.go
+++ b/internal/runner/docker_test.go
@@ -389,6 +389,72 @@ exit 0
 	}
 }
 
+func TestDockerRunnerUsesTaskScopedPiSessionDirWhenResumeEnabled(t *testing.T) {
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "docker_calls.log")
+	fakeDocker := filepath.Join(tmp, "docker")
+	script := `#!/bin/sh
+set -eu
+echo "$@" >> "` + logPath + `"
+if [ "${1:-}" = "run" ]; then
+  echo "container-pi-session"
+fi
+exit 0
+`
+	if err := os.WriteFile(fakeDocker, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake docker: %v", err)
+	}
+	t.Setenv("PATH", tmp+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	runDir := filepath.Join(tmp, "run")
+	sessionDir := filepath.Join(tmp, "sessions", "task")
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatalf("create run dir: %v", err)
+	}
+
+	launcher := DockerRunner{Image: "rascal-runner-pi:latest", GitHubToken: "gh-token"}
+	_, err := launcher.StartDetached(context.Background(), Spec{
+		RunID:        "run_pi_1",
+		TaskID:       "owner/repo#1",
+		Repo:         "owner/repo",
+		Instruction:  "task",
+		AgentRuntime: runtime.RuntimePi,
+		BaseBranch:   "main",
+		HeadBranch:   "rascal/task-1",
+		Trigger:      "pr_comment",
+		Debug:        true,
+		RunDir:       runDir,
+		TaskSession: TaskSessionSpec{
+			Mode:             runtime.SessionModePROnly,
+			Resume:           true,
+			TaskDir:          sessionDir,
+			TaskKey:          "owner-repo-1-abc123",
+			RuntimeSessionID: "session-456",
+		},
+	})
+	if err != nil {
+		t.Fatalf("launcher start: %v", err)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read docker calls log: %v", err)
+	}
+	call := string(data)
+	if !strings.Contains(call, "-e PI_SESSION_DIR=/rascal-pi-session") {
+		t.Fatalf("expected persistent pi session dir env, got:\n%s", call)
+	}
+	if !strings.Contains(call, "-e RASCAL_TASK_SESSION_ID=session-456") {
+		t.Fatalf("expected task session id env, got:\n%s", call)
+	}
+	if !strings.Contains(call, sessionDir+":/rascal-pi-session") {
+		t.Fatalf("expected task session mount, got:\n%s", call)
+	}
+	if strings.Contains(call, "-e GOOSE_PROVIDER=") {
+		t.Fatalf("did not expect goose env for pi runtime, got:\n%s", call)
+	}
+}
+
 func TestDockerRunnerIncludesNoNewPrivilegesSecurityOpt(t *testing.T) {
 	tmp := t.TempDir()
 	logPath := filepath.Join(tmp, "docker_calls.log")

--- a/internal/runtime/agent.go
+++ b/internal/runtime/agent.go
@@ -22,6 +22,7 @@ type Runtime string
 const (
 	RuntimeGooseCodex  Runtime = "goose-codex"
 	RuntimeCodex       Runtime = "codex"
+	RuntimePi          Runtime = "pi"
 	RuntimeClaude      Runtime = "claude"
 	RuntimeGooseClaude Runtime = "goose-claude"
 )
@@ -129,6 +130,8 @@ func ParseRuntime(raw string) (Runtime, error) {
 		return RuntimeGooseCodex, nil
 	case string(RuntimeCodex):
 		return RuntimeCodex, nil
+	case string(RuntimePi):
+		return RuntimePi, nil
 	case string(RuntimeClaude):
 		return RuntimeClaude, nil
 	case string(RuntimeGooseClaude):
@@ -154,6 +157,8 @@ func (r Runtime) Provider() ModelProvider {
 	switch NormalizeRuntime(string(r)) {
 	case RuntimeGooseCodex, RuntimeCodex:
 		return ModelProviderCodex
+	case RuntimePi:
+		return ModelProviderPi
 	case RuntimeClaude, RuntimeGooseClaude:
 		return ModelProviderAnthropic
 	default:

--- a/internal/runtime/agent_test.go
+++ b/internal/runtime/agent_test.go
@@ -18,6 +18,7 @@ func TestNormalizeRuntime(t *testing.T) {
 		{name: "default empty", in: "", want: RuntimeGooseCodex},
 		{name: "default unknown", in: "other", want: RuntimeGooseCodex},
 		{name: "codex explicit", in: " codex ", want: RuntimeCodex},
+		{name: "pi explicit", in: " pi ", want: RuntimePi},
 		{name: "goose-codex explicit", in: "GOOSE-CODEX", want: RuntimeGooseCodex},
 		{name: "goose alias", in: "GOOSE", want: RuntimeGooseCodex},
 		{name: "claude explicit", in: " claude ", want: RuntimeClaude},
@@ -47,6 +48,7 @@ func TestParseRuntime(t *testing.T) {
 	}{
 		{name: "default empty", in: "", want: RuntimeGooseCodex},
 		{name: "codex explicit", in: " codex ", want: RuntimeCodex},
+		{name: "pi explicit", in: " pi ", want: RuntimePi},
 		{name: "goose-codex explicit", in: "GOOSE-CODEX", want: RuntimeGooseCodex},
 		{name: "goose alias", in: "GOOSE", want: RuntimeGooseCodex},
 		{name: "claude explicit", in: " claude ", want: RuntimeClaude},
@@ -180,6 +182,7 @@ func TestRuntimeHarness(t *testing.T) {
 		{name: "goose-codex is goose", runtime: RuntimeGooseCodex, want: HarnessGoose},
 		{name: "goose-claude is goose", runtime: RuntimeGooseClaude, want: HarnessGoose},
 		{name: "codex is direct", runtime: RuntimeCodex, want: HarnessDirect},
+		{name: "pi is direct", runtime: RuntimePi, want: HarnessDirect},
 		{name: "claude is direct", runtime: RuntimeClaude, want: HarnessDirect},
 		{name: "empty defaults to goose", runtime: Runtime(""), want: HarnessGoose},
 		{name: "unknown defaults to goose", runtime: Runtime("other"), want: HarnessGoose},
@@ -206,6 +209,7 @@ func TestRuntimeProvider(t *testing.T) {
 		want    ModelProvider
 	}{
 		{name: "codex maps to codex", runtime: RuntimeCodex, want: ModelProviderCodex},
+		{name: "pi maps to pi", runtime: RuntimePi, want: ModelProviderPi},
 		{name: "goose-codex maps to codex", runtime: RuntimeGooseCodex, want: ModelProviderCodex},
 		{name: "claude maps to anthropic", runtime: RuntimeClaude, want: ModelProviderAnthropic},
 		{name: "goose-claude maps to anthropic", runtime: RuntimeGooseClaude, want: ModelProviderAnthropic},

--- a/internal/runtime/types.go
+++ b/internal/runtime/types.go
@@ -6,4 +6,5 @@ const (
 	ModelProviderCodex     ModelProvider = "codex"
 	ModelProviderGemini    ModelProvider = "gemini"
 	ModelProviderAnthropic ModelProvider = "anthropic"
+	ModelProviderPi        ModelProvider = "pi"
 )

--- a/internal/worker/agent_runtime.go
+++ b/internal/worker/agent_runtime.go
@@ -24,6 +24,8 @@ func runAgent(ex CommandExecutor, cfg Config) (string, string, error) {
 	switch configuredAgentRuntime(cfg) {
 	case runtime.RuntimeCodex:
 		return RunCodex(ex, cfg)
+	case runtime.RuntimePi:
+		return RunPi(ex, cfg)
 	case runtime.RuntimeClaude:
 		return RunClaude(ex, cfg)
 	case runtime.RuntimeGooseClaude:
@@ -201,6 +203,81 @@ func CodexRunArgs(cfg Config) []string {
 		args = append(args, sessionID)
 	}
 	args = append(args, "-")
+	return args
+}
+
+func RunPi(ex CommandExecutor, cfg Config) (output string, sessionID string, err error) {
+	sessionID = configuredRuntimeSessionID(cfg)
+	resume := configuredSessionResume(cfg)
+	if resume && sessionID != "" {
+		exists, existsErr := piSessionExists(cfg.PiSessionDir, sessionID)
+		if existsErr != nil {
+			log.Printf("[%s] pi session preflight warning: id=%s error=%v", nowUTC(), sessionID, existsErr)
+		} else if !exists {
+			log.Printf("[%s] pi session missing; starting fresh session id=%s", nowUTC(), sessionID)
+			resume = false
+		}
+	}
+
+	args := PiRunArgs(cfg, resume)
+	log.Printf("[%s] running pi (backend=%s session_mode=%s session_key=%s session_id=%s resume=%t session_dir=%s)",
+		nowUTC(),
+		configuredAgentRuntime(cfg),
+		configuredSessionMode(cfg),
+		configuredSessionKey(cfg),
+		sessionID,
+		resume && sessionID != "",
+		cfg.PiSessionDir,
+	)
+
+	logFile, err := os.OpenFile(cfg.GooseLogPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return "", sessionID, fmt.Errorf("open pi log: %w", err)
+	}
+	defer func() {
+		if closeErr := logFile.Close(); err == nil && closeErr != nil {
+			err = fmt.Errorf("close pi log: %w", closeErr)
+		}
+	}()
+
+	instructions, err := os.ReadFile(cfg.InstructionsPath)
+	if err != nil {
+		return "", sessionID, fmt.Errorf("read instructions: %w", err)
+	}
+	if err := ex.Run(cfg.RepoDir, nil, logFile, logFile, "pi", append(args, string(instructions))...); err != nil {
+		discoveredSessionID, discoverErr := discoverPiSessionID(cfg.GooseLogPath, cfg.PiSessionDir)
+		if discoverErr != nil {
+			log.Printf("[%s] pi session discovery warning: %v", nowUTC(), discoverErr)
+		}
+		if strings.TrimSpace(discoveredSessionID) != "" {
+			sessionID = strings.TrimSpace(discoveredSessionID)
+		}
+		return "", sessionID, fmt.Errorf("pi run failed: %w", err)
+	}
+
+	discoveredSessionID, err := discoverPiSessionID(cfg.GooseLogPath, cfg.PiSessionDir)
+	if err != nil {
+		return "", sessionID, fmt.Errorf("discover pi session: %w", err)
+	}
+	if strings.TrimSpace(discoveredSessionID) != "" {
+		sessionID = strings.TrimSpace(discoveredSessionID)
+	}
+
+	output, err = loadPiOutput(cfg.AgentOutputPath, cfg.GooseLogPath)
+	if err != nil {
+		return "", sessionID, err
+	}
+	return output, sessionID, nil
+}
+
+func PiRunArgs(cfg Config, resume bool) []string {
+	args := []string{"--mode", "json", "--session-dir", cfg.PiSessionDir}
+	sessionID := strings.TrimSpace(configuredRuntimeSessionID(cfg))
+	if configuredSessionMode(cfg) == runtime.SessionModeOff {
+		args = append(args, "--no-session")
+	} else if resume && sessionID != "" {
+		args = append(args, "--session", sessionID)
+	}
 	return args
 }
 
@@ -409,6 +486,17 @@ func loadAgentOutput(outputPath, fallbackLogPath, backend string) (string, error
 	return string(data), nil
 }
 
+func loadPiOutput(outputPath, logPath string) (string, error) {
+	output, err := extractPiAssistantText(logPath)
+	if err != nil {
+		return "", fmt.Errorf("extract pi assistant output: %w", err)
+	}
+	if writeErr := os.WriteFile(outputPath, []byte(output), 0o644); writeErr != nil {
+		return "", fmt.Errorf("write pi agent output: %w", writeErr)
+	}
+	return output, nil
+}
+
 func discoverLatestCodexSessionID(codexHome string) (string, error) {
 	sessionFiles, err := listCodexSessionFiles(filepath.Join(strings.TrimSpace(codexHome), defaultCodexSessionDir))
 	if err != nil {
@@ -498,6 +586,203 @@ func parseCodexSessionID(path string) (sessionID string, err error) {
 		return "", fmt.Errorf("decode codex session metadata: %w", err)
 	}
 	return strings.TrimSpace(record.Payload.ID), nil
+}
+
+func piSessionExists(sessionRoot, wantID string) (bool, error) {
+	sessionFiles, err := listPiSessionFiles(sessionRoot)
+	if err != nil {
+		return false, err
+	}
+	for _, sessionFile := range sessionFiles {
+		sessionID, err := parsePiSessionID(sessionFile)
+		if err != nil {
+			continue
+		}
+		if strings.TrimSpace(sessionID) == strings.TrimSpace(wantID) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func discoverPiSessionID(logPath, sessionRoot string) (string, error) {
+	if sessionID, err := parsePiSessionIDFromLog(logPath); err == nil && strings.TrimSpace(sessionID) != "" {
+		return strings.TrimSpace(sessionID), nil
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+
+	sessionFiles, err := listPiSessionFiles(sessionRoot)
+	if err != nil {
+		return "", err
+	}
+	for _, sessionFile := range sessionFiles {
+		sessionID, err := parsePiSessionID(sessionFile)
+		if err != nil {
+			continue
+		}
+		if strings.TrimSpace(sessionID) != "" {
+			return strings.TrimSpace(sessionID), nil
+		}
+	}
+	return "", nil
+}
+
+func listPiSessionFiles(root string) ([]string, error) {
+	if strings.TrimSpace(root) == "" {
+		return nil, nil
+	}
+	if _, err := os.Stat(root); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("stat pi sessions root: %w", err)
+	}
+
+	type sessionFile struct {
+		path    string
+		modTime time.Time
+	}
+	var sessionFiles []sessionFile
+	if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("walk pi sessions: %w", err)
+		}
+		if info.IsDir() || filepath.Ext(path) != ".jsonl" {
+			return nil
+		}
+		sessionFiles = append(sessionFiles, sessionFile{path: path, modTime: info.ModTime()})
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("walk pi sessions: %w", err)
+	}
+
+	sort.Slice(sessionFiles, func(i, j int) bool {
+		if sessionFiles[i].modTime.Equal(sessionFiles[j].modTime) {
+			return sessionFiles[i].path > sessionFiles[j].path
+		}
+		return sessionFiles[i].modTime.After(sessionFiles[j].modTime)
+	})
+
+	paths := make([]string, 0, len(sessionFiles))
+	for _, sessionFile := range sessionFiles {
+		paths = append(paths, sessionFile.path)
+	}
+	return paths, nil
+}
+
+func parsePiSessionID(path string) (sessionID string, err error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open pi session file: %w", err)
+	}
+	defer func() {
+		if closeErr := file.Close(); err == nil && closeErr != nil {
+			err = fmt.Errorf("close pi session file: %w", closeErr)
+		}
+	}()
+	return parsePiSessionIDFromReader(file)
+}
+
+func parsePiSessionIDFromLog(path string) (sessionID string, err error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open pi log %s: %w", path, err)
+	}
+	defer func() {
+		if closeErr := file.Close(); err == nil && closeErr != nil {
+			err = fmt.Errorf("close pi log: %w", closeErr)
+		}
+	}()
+	return parsePiSessionIDFromReader(file)
+}
+
+func parsePiSessionIDFromReader(r io.Reader) (string, error) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var record struct {
+			Type string `json:"type"`
+			ID   string `json:"id"`
+		}
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			continue
+		}
+		if record.Type == "session" && strings.TrimSpace(record.ID) != "" {
+			return strings.TrimSpace(record.ID), nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("read pi session stream: %w", err)
+	}
+	return "", nil
+}
+
+func extractPiAssistantText(logPath string) (output string, err error) {
+	file, err := os.Open(logPath)
+	if err != nil {
+		return "", fmt.Errorf("open pi log: %w", err)
+	}
+	defer func() {
+		if closeErr := file.Close(); err == nil && closeErr != nil {
+			err = fmt.Errorf("close pi log: %w", closeErr)
+		}
+	}()
+
+	scanner := bufio.NewScanner(file)
+	lastText := ""
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var record struct {
+			Type    string `json:"type"`
+			Message struct {
+				Role    string `json:"role"`
+				Content []struct {
+					Type string `json:"type"`
+					Text string `json:"text"`
+				} `json:"content"`
+			} `json:"message"`
+		}
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			continue
+		}
+		if record.Type != "message_end" || record.Message.Role != "assistant" {
+			continue
+		}
+		var b strings.Builder
+		for _, content := range record.Message.Content {
+			if content.Type != "text" || content.Text == "" {
+				continue
+			}
+			if b.Len() > 0 {
+				b.WriteString("\n\n")
+			}
+			b.WriteString(content.Text)
+		}
+		if strings.TrimSpace(b.String()) != "" {
+			lastText = b.String()
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("read pi log: %w", err)
+	}
+	if strings.TrimSpace(lastText) == "" {
+		data, err := os.ReadFile(logPath)
+		if err != nil {
+			return "", fmt.Errorf("read pi log: %w", err)
+		}
+		if strings.TrimSpace(string(data)) == "" {
+			return "(no pi output captured)", nil
+		}
+		return string(data), nil
+	}
+	return lastText, nil
 }
 
 func samePath(left, right string) bool {

--- a/internal/worker/config.go
+++ b/internal/worker/config.go
@@ -40,6 +40,7 @@ type Config struct {
 
 	GoosePathRoot   string
 	CodexHome       string
+	PiSessionDir    string
 	ClaudeConfigDir string
 	TaskSession     runner.TaskSessionSpec
 }
@@ -126,6 +127,7 @@ func LoadConfig() (Config, error) {
 	}
 	goosePathRoot := firstNonEmptyValue(strings.TrimSpace(os.Getenv("GOOSE_PATH_ROOT")), filepath.Join(metaDir, "goose"))
 	codexHome := firstNonEmptyValue(strings.TrimSpace(os.Getenv("CODEX_HOME")), filepath.Join(metaDir, "codex"))
+	piSessionDir := firstNonEmptyValue(strings.TrimSpace(os.Getenv("PI_SESSION_DIR")), filepath.Join(metaDir, "pi", defaultCodexSessionDir))
 	claudeConfigDir := firstNonEmptyValue(strings.TrimSpace(os.Getenv("CLAUDE_CONFIG_DIR")), filepath.Join(metaDir, "claude"))
 	persistentInstructionsPath := firstNonEmptyValue(strings.TrimSpace(os.Getenv("GOOSE_MOIM_MESSAGE_FILE")), filepath.Join(metaDir, defaultPersistentInstructionsFile))
 
@@ -153,6 +155,7 @@ func LoadConfig() (Config, error) {
 		AgentRuntime:               agentRuntime,
 		GoosePathRoot:              goosePathRoot,
 		CodexHome:                  codexHome,
+		PiSessionDir:               piSessionDir,
 		ClaudeConfigDir:            claudeConfigDir,
 		TaskSession: runner.TaskSessionSpec{
 			Mode:             agentSessionMode,
@@ -279,6 +282,8 @@ func validateCommands(ex CommandExecutor, cfg Config) error {
 	switch configuredAgentRuntime(cfg) {
 	case runtime.RuntimeCodex:
 		names = append(names, "codex")
+	case runtime.RuntimePi:
+		names = append(names, "pi")
 	case runtime.RuntimeClaude:
 		names = append(names, "claude")
 	case runtime.RuntimeGooseClaude:

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -147,6 +147,12 @@ func RunWithExecutor(ex CommandExecutor) error {
 		if err := os.MkdirAll(cfg.CodexHome, 0o755); err != nil {
 			return fmt.Errorf("create codex home: %w", err)
 		}
+		if err := os.MkdirAll(filepath.Join(cfg.MetaDir, "pi"), 0o755); err != nil {
+			return fmt.Errorf("create pi dir: %w", err)
+		}
+		if err := os.MkdirAll(cfg.PiSessionDir, 0o755); err != nil {
+			return fmt.Errorf("create pi session dir: %w", err)
+		}
 		if err := os.MkdirAll(cfg.WorkRoot, 0o755); err != nil {
 			return fmt.Errorf("create work dir: %w", err)
 		}

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -1,6 +1,7 @@
 ARG GO_VERSION=1.26.1
 ARG GOOSE_VERSION=1.28.0
 ARG GOLANGCI_LINT_VERSION=v2.11.2
+ARG PI_VERSION=0.58.1
 ARG SQLC_VERSION=v1.30.0
 
 FROM golang:${GO_VERSION}-bookworm AS go-runtime
@@ -18,6 +19,13 @@ RUN npm install -g --silent --no-progress --no-fund --no-audit @openai/codex \
     && node --version \
     && npm --version \
     && codex --version
+
+FROM node:24-bookworm-slim AS pi-runtime
+ARG PI_VERSION
+RUN npm install -g --silent --no-progress --no-fund --no-audit @mariozechner/pi-coding-agent@"${PI_VERSION}" \
+    && node --version \
+    && npm --version \
+    && pi --version
 
 FROM ubuntu:24.04 AS goose-runtime
 ARG DEBIAN_FRONTEND=noninteractive
@@ -100,6 +108,12 @@ USER rascal:rascal
 ENTRYPOINT ["/usr/local/bin/rascal-entrypoint"]
 
 FROM runner-base AS codex-runner
+USER rascal:rascal
+ENTRYPOINT ["/usr/local/bin/rascal-entrypoint"]
+
+FROM runner-base AS pi-runner
+COPY --from=pi-runtime /usr/local/ /usr/local/
+RUN pi --version
 USER rascal:rascal
 ENTRYPOINT ["/usr/local/bin/rascal-entrypoint"]
 


### PR DESCRIPTION
Wire Pi into backend parsing, runner dispatch, Docker session/image config,
deploy and doctor surfaces, and runner help/docs for Phase 1 backend support.

<details><summary>Agent Details</summary>

<pre><code>
    __( O)&gt;  ● new session · codex gpt-5.4
   \____)    20260315_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: &#34;/usr/local/bin/codex&#34;
Model: gpt-5.4
Reasoning effort: high
Skip git check: false
Prompt length: 5651 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Suggestion

The user has 7 extensions with 16 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
Consider asking if they&#39;d like to disable some extensions to improve tool selection accuracy.

# Response Guidelines

Use Markdown formatting for all responses.

Human: &lt;info-msg&gt;
It is currently 2026-03-15 08:24:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

&lt;/info-msg&gt;
# Rascal Run Instructions

Run ID: run_924b92806c7a9d35
Task ID: rtzll/rascal#173
Repository: rtzll/rascal
Issue: #173

## Task

Add pi as an agent backend alongside Goose and Codex

## Summary

Add [pi](https://github.com/badlogic/pi-mono) as a third agent backend so Rascal can run tasks with `pi`, `goose`, or `codex`.

This is feasible with the current architecture, but it is not just an enum addition. The control plane is already mostly backend-agnostic for task/run/session state, while the runner, deploy surfaces, and stored-credential flow are still shaped around exactly two backends and one credential type.

## Current state

Rascal already stores `agent_backend` on tasks/runs and persists backend-specific task sessions, so the basic scheduling/state model can support a third backend.

The main coupling points today are:

- `internal/agent`: backend parsing/normalization only supports `goose` and `codex`
- `cmd/rascal-runner`: backend dispatch only supports `runGoose` and `runCodex`
- `internal/runner/docker`: session mounts and env wiring are only `GOOSE_PATH_ROOT` or `CODEX_HOME`
- `runner/Dockerfile`: only `goose-runner` and `codex-runner` images exist
- deploy / doctor / CLI flags: assume exactly two runner images
- stored credentials: explicitly modeled as `codex_credentials` and written to `runDir/codex/auth.json`

## What needs to change

### Backend plumbing

- Add `pi` to backend parsing and normalization
- Update config/image selection to support a Pi runner image
- Update CLI help/docs/tests that currently say `goose or codex`

### Runner implementation

- Add a `runPi(...)` path in `cmd/rascal-runner`
- Validate the `pi` binary in backend-specific command checks
- Map Rascal instructions/output/session handling onto Pi CLI behavior
- Preserve the canonical run artifacts (`agent.ndjson`, `agent_output.txt`, `meta.json`)

### Session support

- Add Pi-specific session root/home env wiring in Docker launcher
- Mount task-scoped Pi session state when session resume is enabled
- Persist/reuse backend session IDs for Pi if needed by its CLI model

### Runner image / deploy

- Add a `pi-runner` image target or install Pi in the shared runner base image
- Extend deploy/bootstrap to build/publish the Pi runner image
- Extend remote doctor to inspect Pi image config and presence
- Add config/env support for `RASCAL_RUNNER_IMAGE_PI`

### Credentials

This is the main design decision.

Short term:
- Support Pi with env/API-key auth only

Long term:
- Generalize stored credentials from `codex_credentials` to backend/provider-aware credentials
- Allow Rascal to broker both Codex and Pi credentials cleanly
- Stop hardcoding `runDir/codex/auth.json` as the only leased auth material path

## Proposed rollout

### Phase 1: MVP Pi backend

- Add `pi` backend enum/config/runner dispatch
- Add Pi runner image
- Add Pi session-dir wiring
- Support Pi with env/API-key auth only
- Keep existing Codex credential broker unchanged

### Phase 2: Credential model refactor

- Generalize stored credentials to support multiple backends/providers
- Add Pi credential acquisition/lease/write/cleanup flow
- Update auth management CLI and API accordingly

### Phase 3: Parity work

- Add Pi token-usage extraction if Pi JSON output exposes it
- Update docs/runbook/config/deploy help text
- Extend tests across runner, deploy, config, doctor, and state flows

## Acceptance criteria

- Rascal accepts `RASCAL_AGENT_BACKEND=pi`
- The orchestrator can schedule and execute Pi-backed runs end-to-end
- Pi runs can create/update PRs the same way Goose/Codex runs do today
- Session resume works for Pi when agent sessions are enabled
- Deploy/bootstrap/doctor support a Pi runner image
- Tests and docs are updated to describe all three backends

## Open questions

- Should Pi be introduced only as a direct/API-key backend first, or should stored/brokered Pi credentials be part of the first implementation?
- Does Pi expose stable enough session identifiers that we should persist `backend_session_id`, or is mounted session storage alone sufficient?
- Do we want three distinct runner images (`goose`, `codex`, `pi`) or a consolidated image with all agent CLIs installed?

## Suggested first milestone

Ship Phase 1 first: Pi backend + runner image + session support, without blocking on the credential-schema refactor.


## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run `make lint` and `make test` before finishing if those targets exist.
- If one of those commands does not exist or cannot run, explain exactly why and run the closest equivalent checks instead.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label &#39;rascal&#39; on issue #173


Assistant: 
Image files: 0
============================
{&#34;type&#34;:&#34;message&#34;,&#34;message&#34;:{&#34;id&#34;:null,&#34;role&#34;:&#34;assistant&#34;,&#34;created&#34;:1773564162,&#34;content&#34;:[{&#34;type&#34;:&#34;text&#34;,&#34;text&#34;:&#34;Using the repo directly to add `pi` as a third backend. I’m starting by locating the backend enum/config, runner dispatch, docker/session wiring, and any tests or docs that currently assume only `goose` and `codex`.\n\nI’ve confirmed the main coupling points match the issue summary: backend parsing, runner dispatch, docker env/session mounts, runner image config, and deploy/doctor help text are all hard-coded for two backends. Next I’m reading those exact codepaths to patch the minimal set cleanly.\n\nThe backend model is simple enough that Phase 1 can stay scoped: add `pi` anywhere backend/image/session selection branches today, keep the existing Codex credential broker untouched, and let Pi rely on env/API-key auth only. I’m checking whether the runner already has enough generic plumbing to map Pi onto the existing `agent.ndjson` / `agent_output.txt` / `meta.json` artifacts without touching orchestration state.\n\nI have the Pi CLI shape now. The cleanest MVP path is: `pi --mode json` for the canonical NDJSON log, extract the final assistant text into `agent_output.txt`, use task-scoped `--session-dir` for resume, and keep credentials env-only. I’m moving into edits across backend parsing, docker env/session wiring, deploy/doctor image config, and the runner implementation/tests.\n\nI’m updating the shared backend/config layer first so every higher-level path can branch on `pi` cleanly instead of carrying special cases. After that I’ll wire the runner and deployment surfaces to the new backend-specific image/session paths.\n\nThe next edit is the runner itself: `runPi` plus Pi-specific config/session handling. I’m keeping the artifact contract unchanged by treating Pi’s JSON event stream as the canonical `agent.ndjson` and deriving `agent_output.txt` from the last assistant message.\n\nThe code changes are in place across the main plumbing. I’m formatting and then I’ll run focused tests to catch the expected misses: Pi-specific struct fields/defaults, deploy/doctor flag coverage, and any runner behavior I still need to adjust.\n\nThe first test batch is still running; the new backend constants and some runner logic already compile. I’m waiting out the rest so I can fix the actual breakpoints instead of guessing.\n\nI’m down to user-facing fallout now: help snapshots and docs still describe a two-backend world. I’m updating those references and then I’ll rerun the full checks plus `make lint` / `make test` if the repo exposes them.\n\nThe targeted Go packages are passing. The remaining requirement is repository-level verification, so I’m running the actual `make lint` and `make test` targets now rather than substituting narrower checks.\n\n`make lint` is still in progress because it has to regenerate sqlc output and bootstrap the pinned linter toolchain first. I’m letting that complete so we get the repo’s actual lint signal, not just the targeted package pass I already have.\n\n`make lint` found only `wrapcheck` issues in the new Pi runner path and its tests. I’m fixing those now, then I’ll rerun lint and the full test target.\n\nVerification is clean now. I’m checking the final diff for any generated/sqlc changes from the required `make` targets, then I’ll write the conventional commit message file before wrapping up.\n\nImplemented Phase 1 Pi backend support alongside Goose and Codex.\n\nThe main changes are in [cmd/rascal-runner/main.go](/work/repo/cmd/rascal-runner/main.go), [internal/runner/docker.go](/work/repo/internal/runner/docker.go), [internal/deploy/deploy.go](/work/repo/internal/deploy/deploy.go), [cmd/rascal/doctor_remote.go](/work/repo/cmd/rascal/doctor_remote.go), and [runner/Dockerfile](/work/repo/runner/Dockerfile). Rascal now accepts `pi` in backend parsing/config, selects a Pi runner image, dispatches a `runPi(...)` path, mounts task-scoped Pi session storage via `PI_SESSION_DIR`, and preserves the canonical run artifacts by treating Pi JSON mode as `agent.ndjson` and extracting the final assistant text into `agent_output.txt`. Stored credentials remain unchanged; Pi is env/API-key only.\n\nI also updated deploy/doctor/CLI help and docs for three backends, added Pi image env support (`RASCAL_RUNNER_IMAGE_PI`), extended tests, and wrote the commit message to `/rascal-meta/commit_message.txt`.\n\nVerification: `make lint` passed, `make test` passed.&#34;}],&#34;metadata&#34;:{&#34;userVisible&#34;:true,&#34;agentVisible&#34;:true}}}
{&#34;type&#34;:&#34;complete&#34;,&#34;total_tokens&#34;:13140849}
</code></pre>

</details>

Closes #173

---

Rascal run `run_924b92806c7a9d35` completed in 18m 4s · 13.14M tokens