### PR TITLE
feat(planning): compile trigger input into run briefs

### DIFF
--- a/cmd/rascal/main.go
+++ b/cmd/rascal/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/rtzll/rascal/internal/clientconfig"
 	"github.com/rtzll/rascal/internal/config"
 	deployengine "github.com/rtzll/rascal/internal/deploy"
+	"github.com/rtzll/rascal/internal/planning"
 	"github.com/rtzll/rascal/internal/remote"
 	"github.com/rtzll/rascal/internal/runtrigger"
 	"github.com/rtzll/rascal/internal/state"
@@ -897,6 +898,7 @@ rascal deploy --host "$SERVER_IP" --codex-auth ~/.codex/auth.json
 func (a *app) newRunCmd() *cobra.Command {
 	var repo, instruction, baseBranch, issueRef string
 	var debug bool
+	var dryRunBrief bool
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Start a run",
@@ -920,11 +922,15 @@ rascal run --issue OWNER/REPO#123
 					return &cliError{Code: exitInput, Message: err.Error()}
 				}
 				debugValue := optionalBoolFlagValue(cmd, "debug", debug)
-				req := buildCreateTaskPayload(createTaskPayloadInput{
+				payloadInput := createTaskPayloadInput{
 					Repo:        repo,
 					IssueNumber: issueNumber,
 					Debug:       debugValue,
-				})
+				}
+				req := buildCreateTaskPayload(payloadInput)
+				if dryRunBrief {
+					req = buildCompileBriefPayload(payloadInput)
+				}
 				resp, err := req.send(a.client, http.MethodPost)
 				if err != nil {
 					return &cliError{Code: exitServer, Message: "request failed", Cause: err}
@@ -932,6 +938,13 @@ rascal run --issue OWNER/REPO#123
 				defer closeWithLog("close issue task response body", resp.Body)
 				if resp.StatusCode >= 300 {
 					return decodeServerError(resp)
+				}
+				if dryRunBrief {
+					var out api.RunBriefResponse
+					if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+						return &cliError{Code: exitServer, Message: "failed to decode server response", Cause: err}
+					}
+					return emitRunBrief(a, out)
 				}
 				var out api.RunResponse
 				if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
@@ -951,12 +964,16 @@ rascal run --issue OWNER/REPO#123
 			}
 
 			debugValue := optionalBoolFlagValue(cmd, "debug", debug)
-			req := buildCreateTaskPayload(createTaskPayloadInput{
+			payloadInput := createTaskPayloadInput{
 				Repo:        repo,
 				Instruction: instruction,
 				BaseBranch:  baseBranch,
 				Debug:       debugValue,
-			})
+			}
+			req := buildCreateTaskPayload(payloadInput)
+			if dryRunBrief {
+				req = buildCompileBriefPayload(payloadInput)
+			}
 			resp, err := req.send(a.client, http.MethodPost)
 			if err != nil {
 				return &cliError{Code: exitServer, Message: "request failed", Hint: "verify server URL and network access", Cause: err}
@@ -964,6 +981,13 @@ rascal run --issue OWNER/REPO#123
 			defer closeWithLog("close task creation response body", resp.Body)
 			if resp.StatusCode >= 300 {
 				return decodeServerError(resp)
+			}
+			if dryRunBrief {
+				var out api.RunBriefResponse
+				if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+					return &cliError{Code: exitServer, Message: "failed to decode server response", Cause: err}
+				}
+				return emitRunBrief(a, out)
 			}
 			var out api.RunResponse
 			if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
@@ -983,6 +1007,7 @@ rascal run --issue OWNER/REPO#123
 	cmd.Flags().StringVarP(&baseBranch, "base-branch", "b", "main", "base branch")
 	cmd.Flags().StringVar(&issueRef, "issue", "", "issue reference in OWNER/REPO#NUMBER form")
 	cmd.Flags().BoolVar(&debug, "debug", true, "stream detailed agent execution logs (use --debug=false to reduce verbosity)")
+	cmd.Flags().BoolVar(&dryRunBrief, "dry-run-brief", false, "compile and print the normalized run brief without creating a run")
 	return cmd
 }
 
@@ -2860,6 +2885,47 @@ func buildCreateTaskPayload(input createTaskPayloadInput) createTaskRequestPaylo
 		path: "/v1/tasks",
 		task: &payload,
 	}
+}
+
+func buildCompileBriefPayload(input createTaskPayloadInput) createTaskRequestPayload {
+	payload := buildCreateTaskPayload(input)
+	if input.IssueNumber > 0 {
+		payload.path = "/v1/briefs/issue"
+		return payload
+	}
+	payload.path = "/v1/briefs"
+	return payload
+}
+
+func emitRunBrief(a *app, out api.RunBriefResponse) error {
+	return emit(a, out, func() error {
+		fmt.Print(planning.RenderMarkdown(out.Brief, planning.RenderOptions{
+			IncludeProvenance: true,
+			Title:             "Run Brief",
+		}))
+		if summary := planning.RenderSourceSummary(planning.Input{Sources: summariesToSources(out.SourceSummary)}); summary != "" {
+			fmt.Print("\n" + summary)
+		}
+		return nil
+	})
+}
+
+func summariesToSources(summaries []planning.SourceSummary) []planning.Source {
+	if len(summaries) == 0 {
+		return nil
+	}
+	sources := make([]planning.Source, 0, len(summaries))
+	for _, summary := range summaries {
+		sources = append(sources, planning.Source{
+			ID:       summary.ID,
+			Kind:     summary.Kind,
+			Label:    summary.Label,
+			URL:      summary.URL,
+			Location: summary.Location,
+			Text:     summary.Preview,
+		})
+	}
+	return sources
 }
 
 func doJSON[T any](client apiClient, method, path string, payload T) (*http.Response, error) {

--- a/cmd/rascal/main_test.go
+++ b/cmd/rascal/main_test.go
@@ -168,6 +168,39 @@ func TestBuildCreateTaskPayloadForIssue(t *testing.T) {
 	}
 }
 
+func TestBuildCompileBriefPayloadForIssue(t *testing.T) {
+	t.Parallel()
+
+	req := buildCompileBriefPayload(createTaskPayloadInput{
+		Repo:        "owner/repo",
+		IssueNumber: 42,
+	})
+
+	if req.path != "/v1/briefs/issue" {
+		t.Fatalf("path = %q, want /v1/briefs/issue", req.path)
+	}
+	if req.issueTask == nil {
+		t.Fatal("expected issue payload")
+	}
+}
+
+func TestBuildCompileBriefPayloadForManualRun(t *testing.T) {
+	t.Parallel()
+
+	req := buildCompileBriefPayload(createTaskPayloadInput{
+		Repo:        "owner/repo",
+		Instruction: "Fix flaky tests",
+		BaseBranch:  "main",
+	})
+
+	if req.path != "/v1/briefs" {
+		t.Fatalf("path = %q, want /v1/briefs", req.path)
+	}
+	if req.task == nil {
+		t.Fatal("expected task payload")
+	}
+}
+
 func TestDecodeServerErrorIncludesRequestID(t *testing.T) {
 	t.Parallel()
 
@@ -1363,6 +1396,110 @@ func TestRunIssueSendsExplicitDebugOverride(t *testing.T) {
 
 	if payload.Debug == nil || *payload.Debug != false {
 		t.Fatalf("expected explicit debug override false, got: %v", payload.Debug)
+	}
+}
+
+func TestRunDryRunBriefUsesBriefEndpoint(t *testing.T) {
+	var payload api.CreateTaskRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/v1/briefs" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(api.RunBriefResponse{
+			Brief: api.RunBriefResponse{}.Brief,
+		}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	a := &app{
+		cfg: config.ClientConfig{
+			ServerURL: srv.URL,
+			APIToken:  "test-token",
+			Transport: "http",
+		},
+		client: apiClient{
+			baseURL:   srv.URL,
+			token:     "test-token",
+			http:      srv.Client(),
+			transport: "http",
+		},
+		output: "json",
+	}
+
+	cmd := mustNewRunCmd(t, a)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"--repo", "owner/repo", "--instruction", "Fix flaky tests", "--dry-run-brief"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("run --dry-run-brief: %v", err)
+	}
+
+	if payload.Repo != "owner/repo" || payload.Instruction != "Fix flaky tests" {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+}
+
+func TestRunIssueDryRunBriefUsesIssueBriefEndpoint(t *testing.T) {
+	var payload api.CreateIssueTaskRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/v1/briefs/issue" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(api.RunBriefResponse{}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	a := &app{
+		cfg: config.ClientConfig{
+			ServerURL: srv.URL,
+			APIToken:  "test-token",
+			Transport: "http",
+		},
+		client: apiClient{
+			baseURL:   srv.URL,
+			token:     "test-token",
+			http:      srv.Client(),
+			transport: "http",
+		},
+		output: "json",
+	}
+
+	cmd := mustNewRunCmd(t, a)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"--issue", "owner/repo#123", "--dry-run-brief"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("run --issue --dry-run-brief: %v", err)
+	}
+
+	if payload.Repo != "owner/repo" || payload.IssueNumber != 123 {
+		t.Fatalf("unexpected payload: %+v", payload)
 	}
 }
 

--- a/cmd/rascal/testdata/help/run.golden
+++ b/cmd/rascal/testdata/help/run.golden
@@ -11,6 +11,7 @@ rascal run --issue OWNER/REPO#123
 Flags:
   -b, --base-branch string   base branch (default "main")
       --debug                stream detailed agent execution logs (use --debug=false to reduce verbosity) (default true)
+      --dry-run-brief        compile and print the normalized run brief without creating a run
   -h, --help                 help for run
   -t, --instruction string   instruction text
       --issue string         issue reference in OWNER/REPO#NUMBER form

--- a/cmd/rascald/main_test.go
+++ b/cmd/rascald/main_test.go
@@ -47,6 +47,10 @@ func TestInstructionTextPRGitContext(t *testing.T) {
 	got := orchestrator.InstructionText(run)
 
 	for _, want := range []string{
+		"# Execution Brief",
+		"## Primary Objective",
+		"Address PR #137 feedback",
+		"## Background Summary",
 		"## Git Context",
 		"- Remote: `origin`",
 		"- Base branch: `main`",
@@ -56,7 +60,6 @@ func TestInstructionTextPRGitContext(t *testing.T) {
 		"`git push --force-with-lease origin HEAD:rascal/task-xyz789`",
 		"`git push origin HEAD:rascal/task-xyz789`",
 		"do not rely on the harness to publish those changes for you",
-		"## Additional Context",
 		"Please rebase this on main and fix the conflicts.",
 	} {
 		if !strings.Contains(got, want) {
@@ -125,6 +128,28 @@ func TestWriteRunFilesWritesTypedContextJSON(t *testing.T) {
 	}
 	if got != want {
 		t.Fatalf("context.json mismatch: got %#v want %#v", got, want)
+	}
+
+	for _, name := range []string{"trigger-input.json", "run-brief.json", "run-brief.md", "instructions.md"} {
+		if _, err := os.Stat(filepath.Join(runDir, name)); err != nil {
+			t.Fatalf("expected %s to be written: %v", name, err)
+		}
+	}
+
+	briefData, err := os.ReadFile(filepath.Join(runDir, "run-brief.json"))
+	if err != nil {
+		t.Fatalf("ReadFile(run-brief.json) error = %v", err)
+	}
+	var brief struct {
+		PrimaryObjective struct {
+			Text string `json:"text"`
+		} `json:"primary_objective"`
+	}
+	if err := json.Unmarshal(briefData, &brief); err != nil {
+		t.Fatalf("Unmarshal(run-brief.json) error = %v", err)
+	}
+	if brief.PrimaryObjective.Text != "Address PR feedback" {
+		t.Fatalf("unexpected primary objective: %q", brief.PrimaryObjective.Text)
 	}
 }
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/rtzll/rascal/internal/planning"
 	"github.com/rtzll/rascal/internal/runtrigger"
 	"github.com/rtzll/rascal/internal/state"
 )
@@ -48,6 +49,11 @@ type CreateIssueTaskRequest struct {
 
 type RunResponse struct {
 	Run state.Run `json:"run" toml:"run"`
+}
+
+type RunBriefResponse struct {
+	Brief         planning.RunBrief        `json:"brief" toml:"brief"`
+	SourceSummary []planning.SourceSummary `json:"source_summary,omitempty" toml:"source_summary,omitempty"`
 }
 
 type RunsResponse struct {

--- a/internal/github/interpret.go
+++ b/internal/github/interpret.go
@@ -53,6 +53,21 @@ func ReviewThreadContext(thread ReviewThread) string {
 	return "review thread marked unresolved"
 }
 
+func ReviewThreadSourceText(thread ReviewThread) string {
+	var parts []string
+	if location := FormatReviewCommentLocation(thread.Path, thread.StartLine, thread.Line); location != "" {
+		parts = append(parts, fmt.Sprintf("Thread location: %s", location))
+	}
+	for _, comment := range thread.Comments {
+		body := strings.TrimSpace(comment.Body)
+		if body == "" {
+			continue
+		}
+		parts = append(parts, body)
+	}
+	return strings.TrimSpace(strings.Join(parts, "\n\n"))
+}
+
 func IssueTaskFromIssue(title, body string) string {
 	title = strings.TrimSpace(title)
 	body = strings.TrimSpace(body)

--- a/internal/orchestrator/api.go
+++ b/internal/orchestrator/api.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rtzll/rascal/internal/api"
 	ghapi "github.com/rtzll/rascal/internal/github"
 	"github.com/rtzll/rascal/internal/logs"
+	"github.com/rtzll/rascal/internal/planning"
 	"github.com/rtzll/rascal/internal/runtrigger"
 	"github.com/rtzll/rascal/internal/state"
 )
@@ -49,6 +50,8 @@ func (s *Server) Mount(mux *http.ServeMux) {
 	mux.HandleFunc("/readyz", s.HandleReady)
 	mux.HandleFunc("/v1/runs", s.WithAuth(s.HandleListRuns))
 	mux.HandleFunc("/v1/runs/", s.WithAuth(s.HandleRunSubresources))
+	mux.HandleFunc("/v1/briefs", s.WithAuth(s.HandleCompileBrief))
+	mux.HandleFunc("/v1/briefs/issue", s.WithAuth(s.HandleCompileIssueBrief))
 	mux.HandleFunc("/v1/tasks", s.WithAuth(s.HandleCreateTask))
 	mux.HandleFunc("/v1/tasks/", s.WithAuth(s.HandleTaskSubresources))
 	mux.HandleFunc("/v1/tasks/issue", s.WithAuth(s.HandleCreateIssueTask))
@@ -246,6 +249,18 @@ func (s *Server) HandleCreateTask(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid trigger", http.StatusBadRequest)
 		return
 	}
+	plan, err := planning.Compile(planning.Input{
+		Trigger:     trigger,
+		Repo:        req.Repo,
+		Instruction: req.Instruction,
+		Sources: []planning.Source{
+			planning.ManualPromptSource(req.Instruction),
+		},
+	})
+	if err != nil {
+		http.Error(w, "failed to compile run brief: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
 
 	run, err := s.CreateAndQueueRun(RunRequest{
 		TaskID:          req.TaskID,
@@ -255,6 +270,7 @@ func (s *Server) HandleCreateTask(w http.ResponseWriter, r *http.Request) {
 		Trigger:         trigger,
 		Debug:           req.Debug,
 		CreatedByUserID: requesterUserID(r.Context()),
+		Plan:            &plan,
 	})
 	if err != nil {
 		if errors.Is(err, errServerDraining) {
@@ -292,6 +308,9 @@ func (s *Server) HandleCreateIssueTask(w http.ResponseWriter, r *http.Request) {
 	taskID := repoIssueTaskID(req.Repo, req.IssueNumber)
 	taskText := fmt.Sprintf("Work on issue #%d in %s", req.IssueNumber, req.Repo)
 	ctxText := ""
+	sources := []planning.Source{
+		planning.ReferenceSource("Issue reference", fmt.Sprintf("%s#%d", req.Repo, req.IssueNumber)),
+	}
 	requestedBy := requesterUserID(r.Context())
 	if requestedBy == "system" {
 		requestedBy = ""
@@ -304,6 +323,21 @@ func (s *Server) HandleCreateIssueTask(w http.ResponseWriter, r *http.Request) {
 		}
 		taskText = ghapi.IssueTaskFromIssue(issue.Title, issue.Body)
 		ctxText = fmt.Sprintf("Issue URL: %s", issue.HTMLURL)
+		sources = []planning.Source{
+			planning.IssueSource(issue.Title, issue.Body, issue.HTMLURL),
+		}
+	}
+	plan, err := planning.Compile(planning.Input{
+		Trigger:     runtrigger.NameIssueAPI,
+		Repo:        req.Repo,
+		Instruction: taskText,
+		Context:     ctxText,
+		IssueNumber: req.IssueNumber,
+		Sources:     sources,
+	})
+	if err != nil {
+		http.Error(w, "failed to compile run brief: "+err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	run, err := s.CreateAndQueueRun(RunRequest{
@@ -315,6 +349,7 @@ func (s *Server) HandleCreateIssueTask(w http.ResponseWriter, r *http.Request) {
 		Context:         ctxText,
 		Debug:           req.Debug,
 		CreatedByUserID: requesterUserID(r.Context()),
+		Plan:            &plan,
 		ResponseTarget: &RunResponseTarget{
 			Repo:        req.Repo,
 			IssueNumber: req.IssueNumber,
@@ -335,6 +370,98 @@ func (s *Server) HandleCreateIssueTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusAccepted, api.RunResponse{Run: run})
+}
+
+func (s *Server) HandleCompileBrief(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req createTaskRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+	req.Repo = strings.TrimSpace(req.Repo)
+	req.Instruction = strings.TrimSpace(req.Instruction)
+	if req.Repo == "" || req.Instruction == "" {
+		http.Error(w, "repo and task are required", http.StatusBadRequest)
+		return
+	}
+	trigger, err := runtrigger.ParseOrDefault(req.Trigger.String(), runtrigger.NameCLI)
+	if err != nil {
+		http.Error(w, "invalid trigger", http.StatusBadRequest)
+		return
+	}
+	compiled, err := planning.Compile(planning.Input{
+		Trigger:     trigger,
+		Repo:        req.Repo,
+		Instruction: req.Instruction,
+		Sources: []planning.Source{
+			planning.ManualPromptSource(req.Instruction),
+		},
+	})
+	if err != nil {
+		http.Error(w, "failed to compile brief: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, api.RunBriefResponse{
+		Brief:         compiled.Brief,
+		SourceSummary: planning.Summaries(compiled.Input),
+	})
+}
+
+func (s *Server) HandleCompileIssueBrief(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req createIssueTaskRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+	req.Repo = state.NormalizeRepo(strings.TrimSpace(req.Repo))
+	if req.Repo == "" || req.IssueNumber <= 0 {
+		http.Error(w, "repo and issue_number are required", http.StatusBadRequest)
+		return
+	}
+
+	taskText := fmt.Sprintf("Work on issue #%d in %s", req.IssueNumber, req.Repo)
+	ctxText := ""
+	sources := []planning.Source{
+		planning.ReferenceSource("Issue reference", fmt.Sprintf("%s#%d", req.Repo, req.IssueNumber)),
+	}
+	if strings.TrimSpace(s.Config.GitHubToken) != "" {
+		issue, err := s.GitHub.GetIssue(r.Context(), req.Repo, req.IssueNumber)
+		if err != nil {
+			http.Error(w, "failed to fetch issue: "+err.Error(), http.StatusBadGateway)
+			return
+		}
+		taskText = ghapi.IssueTaskFromIssue(issue.Title, issue.Body)
+		ctxText = fmt.Sprintf("Issue URL: %s", issue.HTMLURL)
+		sources = []planning.Source{
+			planning.IssueSource(issue.Title, issue.Body, issue.HTMLURL),
+		}
+	}
+	compiled, err := planning.Compile(planning.Input{
+		Trigger:     runtrigger.NameIssueAPI,
+		Repo:        req.Repo,
+		Instruction: taskText,
+		Context:     ctxText,
+		IssueNumber: req.IssueNumber,
+		Sources:     sources,
+	})
+	if err != nil {
+		http.Error(w, "failed to compile brief: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, api.RunBriefResponse{
+		Brief:         compiled.Brief,
+		SourceSummary: planning.Summaries(compiled.Input),
+	})
 }
 
 func (s *Server) HandleCredentials(w http.ResponseWriter, r *http.Request) {

--- a/internal/orchestrator/runs.go
+++ b/internal/orchestrator/runs.go
@@ -8,8 +8,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rtzll/rascal/internal/planning"
 	"github.com/rtzll/rascal/internal/runtrigger"
 	"github.com/rtzll/rascal/internal/state"
+)
+
+const (
+	RunBriefJSONFile     = "run-brief.json"
+	RunBriefMarkdownFile = "run-brief.md"
+	TriggerInputFile     = "trigger-input.json"
 )
 
 func (s *Server) CreateAndQueueRun(req RunRequest) (state.Run, error) {
@@ -36,6 +43,10 @@ func (s *Server) CreateAndQueueRun(req RunRequest) (state.Run, error) {
 		if !req.Trigger.IsKnown() {
 			return state.Run{}, fmt.Errorf("unknown workflow trigger %q", req.Trigger)
 		}
+	}
+	compiled, err := compileRunPlan(req)
+	if err != nil {
+		return state.Run{}, fmt.Errorf("compile run brief: %w", err)
 	}
 	if req.PRStatus == "" {
 		if req.PRNumber > 0 {
@@ -120,7 +131,7 @@ func (s *Server) CreateAndQueueRun(req RunRequest) (state.Run, error) {
 		return state.Run{}, fmt.Errorf("set run requester: %w", err)
 	}
 
-	if err := s.WriteRunFiles(run); err != nil {
+	if err := s.writeRunFilesWithPlan(run, compiled); err != nil {
 		s.setRunStatusBestEffort(run.ID, state.StatusFailed, err.Error())
 		return state.Run{}, fmt.Errorf("prepare run files: %w", err)
 	}
@@ -133,6 +144,22 @@ func (s *Server) CreateAndQueueRun(req RunRequest) (state.Run, error) {
 }
 
 func (s *Server) WriteRunFiles(run state.Run) (err error) {
+	compiled, err := compileRunPlan(RunRequest{
+		TaskID:      run.TaskID,
+		Repo:        run.Repo,
+		Instruction: run.Instruction,
+		Trigger:     run.Trigger,
+		IssueNumber: run.IssueNumber,
+		PRNumber:    run.PRNumber,
+		Context:     run.Context,
+	})
+	if err != nil {
+		return fmt.Errorf("compile run brief: %w", err)
+	}
+	return s.writeRunFilesWithPlan(run, compiled)
+}
+
+func (s *Server) writeRunFilesWithPlan(run state.Run, compiled planning.Compiled) (err error) {
 	if err := os.MkdirAll(filepath.Join(run.RunDir, "codex"), 0o755); err != nil {
 		return fmt.Errorf("create codex run directory: %w", err)
 	}
@@ -156,7 +183,31 @@ func (s *Server) WriteRunFiles(run state.Run) (err error) {
 		return fmt.Errorf("write run context file: %w", err)
 	}
 
-	instructions := InstructionText(run)
+	inputData, err := json.MarshalIndent(compiled.Input, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal trigger input: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(run.RunDir, TriggerInputFile), inputData, 0o644); err != nil {
+		return fmt.Errorf("write trigger input file: %w", err)
+	}
+
+	briefData, err := json.MarshalIndent(compiled.Brief, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal run brief: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(run.RunDir, RunBriefJSONFile), briefData, 0o644); err != nil {
+		return fmt.Errorf("write run brief json: %w", err)
+	}
+
+	briefMarkdown := planning.RenderMarkdown(compiled.Brief, planning.RenderOptions{
+		IncludeProvenance: true,
+		Title:             "Run Brief",
+	})
+	if err := os.WriteFile(filepath.Join(run.RunDir, RunBriefMarkdownFile), []byte(briefMarkdown), 0o644); err != nil {
+		return fmt.Errorf("write run brief markdown: %w", err)
+	}
+
+	instructions := instructionTextFromBrief(run, compiled.Brief)
 	if err := os.WriteFile(filepath.Join(run.RunDir, "instructions.md"), []byte(instructions), 0o644); err != nil {
 		return fmt.Errorf("write run instructions: %w", err)
 	}
@@ -176,6 +227,27 @@ func (s *Server) WriteRunFiles(run state.Run) (err error) {
 		return fmt.Errorf("write runner log entry: %w", err)
 	}
 	return nil
+}
+
+func compileRunPlan(req RunRequest) (planning.Compiled, error) {
+	if req.Plan != nil {
+		return *req.Plan, nil
+	}
+	compiled, err := planning.Compile(planning.Input{
+		Trigger:     req.Trigger,
+		Repo:        req.Repo,
+		Instruction: req.Instruction,
+		Context:     req.Context,
+		IssueNumber: req.IssueNumber,
+		PRNumber:    req.PRNumber,
+		Sources: []planning.Source{
+			planning.ManualPromptSource(req.Instruction),
+		},
+	})
+	if err != nil {
+		return planning.Compiled{}, fmt.Errorf("compile plan from run request: %w", err)
+	}
+	return compiled, nil
 }
 
 type RunContextFile struct {
@@ -226,6 +298,26 @@ func (s *Server) WriteRunResponseTarget(run state.Run, target *RunResponseTarget
 }
 
 func InstructionText(run state.Run) string {
+	compiled, err := compileRunPlan(RunRequest{
+		TaskID:      run.TaskID,
+		Repo:        run.Repo,
+		Instruction: run.Instruction,
+		Trigger:     run.Trigger,
+		IssueNumber: run.IssueNumber,
+		PRNumber:    run.PRNumber,
+		Context:     run.Context,
+	})
+	if err != nil {
+		return instructionTextFromBrief(run, planning.RunBrief{
+			Version:          planning.SchemaVersion,
+			Trigger:          run.Trigger,
+			PrimaryObjective: planning.Field{Text: strings.TrimSpace(run.Instruction)},
+		})
+	}
+	return instructionTextFromBrief(run, compiled.Brief)
+}
+
+func instructionTextFromBrief(run state.Run, brief planning.RunBrief) string {
 	var b strings.Builder
 	_, _ = fmt.Fprintf(&b, `# Rascal Run Instructions
 
@@ -239,14 +331,12 @@ Repository: %s
 	if run.PRNumber > 0 {
 		_, _ = fmt.Fprintf(&b, "Pull Request: #%d\n", run.PRNumber)
 	}
-	b.WriteString(`
-## Task
-
-`)
-	b.WriteString(run.Instruction)
-	b.WriteString(`
-
-`)
+	b.WriteString("\n")
+	b.WriteString(planning.RenderMarkdown(brief, planning.RenderOptions{
+		IncludeProvenance: false,
+		Title:             "Execution Brief",
+	}))
+	b.WriteString("\n")
 	if shouldIncludeGitContext(run) {
 		b.WriteString(`## Git Context
 
@@ -280,15 +370,6 @@ Repository: %s
 - If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
 - Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.
 `)
-	if strings.TrimSpace(run.Context) != "" {
-		b.WriteString(`
-## Additional Context
-
-`)
-		b.WriteString(run.Context)
-		b.WriteString(`
-`)
-	}
 	return b.String()
 }
 

--- a/internal/orchestrator/service.go
+++ b/internal/orchestrator/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rtzll/rascal/internal/config"
 	"github.com/rtzll/rascal/internal/credentials"
 	ghapi "github.com/rtzll/rascal/internal/github"
+	"github.com/rtzll/rascal/internal/planning"
 	"github.com/rtzll/rascal/internal/runner"
 	"github.com/rtzll/rascal/internal/runtrigger"
 	"github.com/rtzll/rascal/internal/state"
@@ -102,6 +103,7 @@ type RunRequest struct {
 	Context         string
 	Debug           *bool
 	CreatedByUserID string
+	Plan            *planning.Compiled
 
 	ResponseTarget *RunResponseTarget
 }

--- a/internal/orchestrator/webhook.go
+++ b/internal/orchestrator/webhook.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/rtzll/rascal/internal/api"
 	ghapi "github.com/rtzll/rascal/internal/github"
+	"github.com/rtzll/rascal/internal/planning"
 	"github.com/rtzll/rascal/internal/runtrigger"
 	"github.com/rtzll/rascal/internal/state"
 )
@@ -97,7 +98,21 @@ func (s *Server) processWebhookEvent(ctx context.Context, eventType string, payl
 				return nil
 			}
 			taskID := repoIssueTaskID(ev.Repository.FullName, ev.Issue.Number)
-			_, err := s.CreateAndQueueRun(RunRequest{
+			plan, err := planning.Compile(planning.Input{
+				Trigger:     runtrigger.NameIssueLabel,
+				Repo:        ev.Repository.FullName,
+				Instruction: ghapi.IssueTaskFromIssue(ev.Issue.Title, ev.Issue.Body),
+				Context:     fmt.Sprintf("Triggered by label 'rascal' on issue #%d", ev.Issue.Number),
+				IssueNumber: ev.Issue.Number,
+				Sources: []planning.Source{
+					planning.IssueSource(ev.Issue.Title, ev.Issue.Body, ""),
+					planning.ContextSource("Trigger context", fmt.Sprintf("Triggered by label 'rascal' on issue #%d", ev.Issue.Number)),
+				},
+			})
+			if err != nil {
+				return fmt.Errorf("compile issue label brief: %w", err)
+			}
+			_, err = s.CreateAndQueueRun(RunRequest{
 				TaskID:      taskID,
 				Repo:        ev.Repository.FullName,
 				Instruction: ghapi.IssueTaskFromIssue(ev.Issue.Title, ev.Issue.Body),
@@ -105,6 +120,7 @@ func (s *Server) processWebhookEvent(ctx context.Context, eventType string, payl
 				IssueNumber: ev.Issue.Number,
 				Context:     fmt.Sprintf("Triggered by label 'rascal' on issue #%d", ev.Issue.Number),
 				Debug:       boolPtr(true),
+				Plan:        &plan,
 				ResponseTarget: &RunResponseTarget{
 					Repo:        ev.Repository.FullName,
 					IssueNumber: ev.Issue.Number,
@@ -130,7 +146,21 @@ func (s *Server) processWebhookEvent(ctx context.Context, eventType string, payl
 			if err := s.Store.CancelQueuedRuns(taskID, "issue edited", state.RunStatusReasonIssueEdited); err != nil {
 				return fmt.Errorf("cancel queued runs for edited issue: %w", err)
 			}
-			_, err := s.CreateAndQueueRun(RunRequest{
+			plan, err := planning.Compile(planning.Input{
+				Trigger:     runtrigger.NameIssueEdited,
+				Repo:        ev.Repository.FullName,
+				Instruction: ghapi.IssueTaskFromIssue(ev.Issue.Title, ev.Issue.Body),
+				Context:     fmt.Sprintf("Triggered by issue edit on issue #%d", ev.Issue.Number),
+				IssueNumber: ev.Issue.Number,
+				Sources: []planning.Source{
+					planning.IssueSource(ev.Issue.Title, ev.Issue.Body, ""),
+					planning.ContextSource("Trigger context", fmt.Sprintf("Triggered by issue edit on issue #%d", ev.Issue.Number)),
+				},
+			})
+			if err != nil {
+				return fmt.Errorf("compile issue edited brief: %w", err)
+			}
+			_, err = s.CreateAndQueueRun(RunRequest{
 				TaskID:      taskID,
 				Repo:        ev.Repository.FullName,
 				Instruction: ghapi.IssueTaskFromIssue(ev.Issue.Title, ev.Issue.Body),
@@ -138,6 +168,7 @@ func (s *Server) processWebhookEvent(ctx context.Context, eventType string, payl
 				IssueNumber: ev.Issue.Number,
 				Context:     fmt.Sprintf("Triggered by issue edit on issue #%d", ev.Issue.Number),
 				Debug:       boolPtr(true),
+				Plan:        &plan,
 				ResponseTarget: &RunResponseTarget{
 					Repo:        ev.Repository.FullName,
 					IssueNumber: ev.Issue.Number,
@@ -184,7 +215,21 @@ func (s *Server) processWebhookEvent(ctx context.Context, eventType string, payl
 			if err := s.Store.MarkTaskOpen(taskID); err != nil {
 				return fmt.Errorf("mark task open for reopened issue: %w", err)
 			}
-			_, err := s.CreateAndQueueRun(RunRequest{
+			plan, err := planning.Compile(planning.Input{
+				Trigger:     runtrigger.NameIssueReopened,
+				Repo:        ev.Repository.FullName,
+				Instruction: ghapi.IssueTaskFromIssue(ev.Issue.Title, ev.Issue.Body),
+				Context:     fmt.Sprintf("Triggered by issue reopen on issue #%d", ev.Issue.Number),
+				IssueNumber: ev.Issue.Number,
+				Sources: []planning.Source{
+					planning.IssueSource(ev.Issue.Title, ev.Issue.Body, ""),
+					planning.ContextSource("Trigger context", fmt.Sprintf("Triggered by issue reopen on issue #%d", ev.Issue.Number)),
+				},
+			})
+			if err != nil {
+				return fmt.Errorf("compile issue reopened brief: %w", err)
+			}
+			_, err = s.CreateAndQueueRun(RunRequest{
 				TaskID:      taskID,
 				Repo:        ev.Repository.FullName,
 				Instruction: ghapi.IssueTaskFromIssue(ev.Issue.Title, ev.Issue.Body),
@@ -193,6 +238,7 @@ func (s *Server) processWebhookEvent(ctx context.Context, eventType string, payl
 				PRStatus:    state.PRStatusNone,
 				Context:     fmt.Sprintf("Triggered by issue reopen on issue #%d", ev.Issue.Number),
 				Debug:       boolPtr(true),
+				Plan:        &plan,
 				ResponseTarget: &RunResponseTarget{
 					Repo:        ev.Repository.FullName,
 					IssueNumber: ev.Issue.Number,
@@ -239,8 +285,22 @@ func (s *Server) processWebhookEvent(ctx context.Context, eventType string, payl
 		}
 		s.addIssueCommentReactionBestEffort(ev.Repository.FullName, ev.Comment.ID, ghapi.ReactionEyes)
 		baseBranch, headBranch := s.resolvePRBranches(ctx, ev.Repository.FullName, ev.Issue.Number, "", "")
+		plan, err := planning.Compile(planning.Input{
+			Trigger:     runtrigger.NamePRComment,
+			Repo:        ev.Repository.FullName,
+			Instruction: fmt.Sprintf("Address PR #%d feedback", ev.Issue.Number),
+			Context:     strings.TrimSpace(ev.Comment.Body),
+			IssueNumber: task.IssueNumber,
+			PRNumber:    ev.Issue.Number,
+			Sources: []planning.Source{
+				planning.PRCommentSource(ev.Comment.Body, ev.Comment.User.Login),
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("compile pr comment brief: %w", err)
+		}
 
-		_, err := s.CreateAndQueueRun(RunRequest{
+		_, err = s.CreateAndQueueRun(RunRequest{
 			TaskID:      task.ID,
 			Repo:        ev.Repository.FullName,
 			Instruction: fmt.Sprintf("Address PR #%d feedback", ev.Issue.Number),
@@ -252,6 +312,7 @@ func (s *Server) processWebhookEvent(ctx context.Context, eventType string, payl
 			BaseBranch:  s.firstKnownBaseBranch(task.ID, baseBranch),
 			HeadBranch:  s.firstKnownHeadBranch(task.ID, headBranch),
 			Debug:       boolPtr(true),
+			Plan:        &plan,
 			ResponseTarget: &RunResponseTarget{
 				Repo:        ev.Repository.FullName,
 				IssueNumber: ev.Issue.Number,
@@ -288,7 +349,21 @@ func (s *Server) processWebhookEvent(ctx context.Context, eventType string, payl
 		if contextText == "" {
 			contextText = fmt.Sprintf("review state: %s", ev.Review.State)
 		}
-		_, err := s.CreateAndQueueRun(RunRequest{
+		plan, err := planning.Compile(planning.Input{
+			Trigger:     runtrigger.NamePRReview,
+			Repo:        ev.Repository.FullName,
+			Instruction: fmt.Sprintf("Address PR #%d review feedback", ev.PullRequest.Number),
+			Context:     contextText,
+			IssueNumber: task.IssueNumber,
+			PRNumber:    ev.PullRequest.Number,
+			Sources: []planning.Source{
+				planning.PRReviewSource(ev.Review.Body, ev.Review.State, ev.Review.User.Login),
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("compile pr review brief: %w", err)
+		}
+		_, err = s.CreateAndQueueRun(RunRequest{
 			TaskID:      task.ID,
 			Repo:        ev.Repository.FullName,
 			Instruction: fmt.Sprintf("Address PR #%d review feedback", ev.PullRequest.Number),
@@ -300,6 +375,7 @@ func (s *Server) processWebhookEvent(ctx context.Context, eventType string, payl
 			BaseBranch:  s.firstKnownBaseBranch(task.ID, baseBranch),
 			HeadBranch:  s.firstKnownHeadBranch(task.ID, headBranch),
 			Debug:       boolPtr(true),
+			Plan:        &plan,
 			ResponseTarget: &RunResponseTarget{
 				Repo:        ev.Repository.FullName,
 				IssueNumber: ev.PullRequest.Number,
@@ -339,7 +415,8 @@ func (s *Server) processWebhookEvent(ctx context.Context, eventType string, payl
 		baseBranch, headBranch := s.resolvePRBranches(ctx, ev.Repository.FullName, ev.PullRequest.Number, ev.PullRequest.Base.Ref, ev.PullRequest.Head.Ref)
 
 		contextText := strings.TrimSpace(ev.Comment.Body)
-		if location := ghapi.FormatReviewCommentLocation(ev.Comment.Path, ev.Comment.StartLine, ev.Comment.Line); location != "" {
+		location := ghapi.FormatReviewCommentLocation(ev.Comment.Path, ev.Comment.StartLine, ev.Comment.Line)
+		if location != "" {
 			if contextText == "" {
 				contextText = fmt.Sprintf("inline review comment at %s", location)
 			} else {
@@ -348,7 +425,21 @@ func (s *Server) processWebhookEvent(ctx context.Context, eventType string, payl
 Inline comment location: %s`, contextText, location)
 			}
 		}
-		_, err := s.CreateAndQueueRun(RunRequest{
+		plan, err := planning.Compile(planning.Input{
+			Trigger:     runtrigger.NamePRReviewComment,
+			Repo:        ev.Repository.FullName,
+			Instruction: fmt.Sprintf("Address PR #%d inline review comment", ev.PullRequest.Number),
+			Context:     contextText,
+			IssueNumber: task.IssueNumber,
+			PRNumber:    ev.PullRequest.Number,
+			Sources: []planning.Source{
+				planning.PRReviewCommentSource(ev.Comment.Body, location, ev.Comment.User.Login),
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("compile pr review comment brief: %w", err)
+		}
+		_, err = s.CreateAndQueueRun(RunRequest{
 			TaskID:      task.ID,
 			Repo:        ev.Repository.FullName,
 			Instruction: fmt.Sprintf("Address PR #%d inline review comment", ev.PullRequest.Number),
@@ -360,6 +451,7 @@ Inline comment location: %s`, contextText, location)
 			BaseBranch:  s.firstKnownBaseBranch(task.ID, baseBranch),
 			HeadBranch:  s.firstKnownHeadBranch(task.ID, headBranch),
 			Debug:       boolPtr(true),
+			Plan:        &plan,
 			ResponseTarget: &RunResponseTarget{
 				Repo:        ev.Repository.FullName,
 				IssueNumber: ev.PullRequest.Number,
@@ -389,7 +481,22 @@ Inline comment location: %s`, contextText, location)
 				return nil
 			}
 			baseBranch, headBranch := s.resolvePRBranches(ctx, ev.Repository.FullName, ev.PullRequest.Number, ev.PullRequest.Base.Ref, ev.PullRequest.Head.Ref)
-			_, err := s.CreateAndQueueRun(RunRequest{
+			location := ghapi.FormatReviewCommentLocation(ev.Thread.Path, ev.Thread.StartLine, ev.Thread.Line)
+			plan, err := planning.Compile(planning.Input{
+				Trigger:     runtrigger.NamePRReviewThread,
+				Repo:        ev.Repository.FullName,
+				Instruction: fmt.Sprintf("Address PR #%d unresolved review thread", ev.PullRequest.Number),
+				Context:     ghapi.ReviewThreadContext(ev.Thread),
+				IssueNumber: task.IssueNumber,
+				PRNumber:    ev.PullRequest.Number,
+				Sources: []planning.Source{
+					planning.PRReviewThreadSource(ghapi.ReviewThreadSourceText(ev.Thread), location),
+				},
+			})
+			if err != nil {
+				return fmt.Errorf("compile pr review thread brief: %w", err)
+			}
+			_, err = s.CreateAndQueueRun(RunRequest{
 				TaskID:      task.ID,
 				Repo:        ev.Repository.FullName,
 				Instruction: fmt.Sprintf("Address PR #%d unresolved review thread", ev.PullRequest.Number),
@@ -401,6 +508,7 @@ Inline comment location: %s`, contextText, location)
 				BaseBranch:  s.firstKnownBaseBranch(task.ID, baseBranch),
 				HeadBranch:  s.firstKnownHeadBranch(task.ID, headBranch),
 				Debug:       boolPtr(true),
+				Plan:        &plan,
 				ResponseTarget: &RunResponseTarget{
 					Repo:           ev.Repository.FullName,
 					IssueNumber:    ev.PullRequest.Number,

--- a/internal/planning/compile.go
+++ b/internal/planning/compile.go
@@ -1,0 +1,433 @@
+package planning
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/rtzll/rascal/internal/runtrigger"
+)
+
+var genericPRInstructionPattern = regexp.MustCompile(`(?i)^address pr #\d+ (?:feedback|review feedback|inline review comment|unresolved review thread)$`)
+
+func Compile(input Input) (Compiled, error) {
+	normalized := normalizeInput(input)
+	if normalized.Version == "" {
+		normalized.Version = SchemaVersion
+	}
+
+	brief := RunBrief{
+		Version: normalized.Version,
+		Trigger: normalized.Trigger,
+		Sources: sourceRefs(normalized.Sources),
+	}
+
+	objective, objectiveSources, objectiveDerivation := deriveObjective(normalized)
+	brief.PrimaryObjective = Field{
+		Text:       objective,
+		SourceIDs:  objectiveSources,
+		Derivation: objectiveDerivation,
+	}
+
+	background, backgroundSources := deriveBackground(normalized, objective)
+	if background != "" {
+		brief.BackgroundSummary = Field{
+			Text:       background,
+			SourceIDs:  backgroundSources,
+			Derivation: "combined from remaining source context",
+		}
+	}
+
+	var constraints []Item
+	var acceptance []Item
+	var validation []Item
+	var followUp []Item
+	var relevantFiles []PathRef
+	for _, source := range normalized.Sources {
+		extracted := extractSource(source.Text)
+		constraints = append(constraints, itemsFromStrings(extracted.constraints, source.ID, "")...)
+		acceptance = append(acceptance, itemsFromStrings(extracted.acceptance, source.ID, "")...)
+		validation = append(validation, itemsFromStrings(extracted.validation, source.ID, "")...)
+		followUp = append(followUp, itemsFromStrings(extracted.followUp, source.ID, "")...)
+		relevantFiles = append(relevantFiles, pathRefsFromStrings(extracted.paths, source.ID)...)
+		if source.Location != "" {
+			relevantFiles = append(relevantFiles, pathRefsFromStrings([]string{source.Location}, source.ID)...)
+		}
+	}
+	brief.Constraints = dedupeItems(constraints)
+	brief.AcceptanceCriteria = dedupeItems(acceptance)
+	brief.Validation = dedupeItems(validation)
+	brief.FollowUp = dedupeItems(followUp)
+	brief.RelevantFiles = dedupePathRefs(relevantFiles)
+
+	brief.Ambiguities = buildAmbiguities(normalized, brief)
+	brief.Assumptions = buildAssumptions(normalized, brief)
+
+	return Compiled{
+		Input: normalized,
+		Brief: brief,
+	}, nil
+}
+
+func Summaries(input Input) []SourceSummary {
+	input = normalizeInput(input)
+	out := make([]SourceSummary, 0, len(input.Sources))
+	for _, source := range input.Sources {
+		out = append(out, SourceSummary{
+			ID:       source.ID,
+			Kind:     source.Kind,
+			Label:    source.Label,
+			URL:      source.URL,
+			Location: source.Location,
+			Preview:  preview(source.Text, 180),
+		})
+	}
+	return out
+}
+
+func normalizeInput(input Input) Input {
+	input.Version = strings.TrimSpace(input.Version)
+	input.Trigger = runtrigger.Normalize(input.Trigger.String())
+	input.Repo = strings.TrimSpace(input.Repo)
+	input.Instruction = strings.TrimSpace(input.Instruction)
+	input.Context = strings.TrimSpace(input.Context)
+
+	sources := make([]Source, 0, len(input.Sources)+2)
+	for idx, source := range input.Sources {
+		source.ID = sourceID(source.ID, idx+1)
+		source.Label = strings.TrimSpace(source.Label)
+		source.URL = strings.TrimSpace(source.URL)
+		source.Author = strings.TrimSpace(source.Author)
+		source.Location = strings.TrimSpace(source.Location)
+		source.Text = strings.TrimSpace(source.Text)
+		sources = append(sources, source)
+	}
+	if len(sources) == 0 && input.Instruction != "" {
+		sources = append(sources, Source{
+			ID:    sourceID("", 1),
+			Kind:  fallbackSourceKind(input.Trigger),
+			Label: "Primary task text",
+			Text:  input.Instruction,
+		})
+	}
+	if input.Context != "" && !containsSourceText(sources, input.Context) {
+		sources = append(sources, Source{
+			ID:    sourceID("", len(sources)+1),
+			Kind:  SourceKindTriggerContext,
+			Label: "Additional context",
+			Text:  input.Context,
+		})
+	}
+	input.Sources = sources
+	return input
+}
+
+func sourceID(existing string, index int) string {
+	if strings.TrimSpace(existing) != "" {
+		return strings.TrimSpace(existing)
+	}
+	return fmt.Sprintf("source-%d", index)
+}
+
+func fallbackSourceKind(trigger runtrigger.Name) SourceKind {
+	switch {
+	case trigger.IsIssue():
+		return SourceKindGitHubIssue
+	case trigger.IsComment():
+		return SourceKindTriggerContext
+	default:
+		return SourceKindManualPrompt
+	}
+}
+
+func containsSourceText(sources []Source, text string) bool {
+	normalized := normalizeWhitespace(text)
+	for _, source := range sources {
+		if normalizeWhitespace(source.Text) == normalized {
+			return true
+		}
+	}
+	return false
+}
+
+func deriveObjective(input Input) (string, []string, string) {
+	if text := firstObjectiveCandidate(input); text != "" {
+		for _, source := range input.Sources {
+			if sourceText := firstMeaningfulLine(source.Text); sourceText != "" && sourceText == text {
+				return text, []string{source.ID}, "selected from the most specific source text"
+			}
+		}
+	}
+	line := firstMeaningfulLine(input.Instruction)
+	if line != "" {
+		return line, sourceIDsForInstruction(input), "selected from normalized instruction text"
+	}
+	for _, source := range input.Sources {
+		if line := firstMeaningfulLine(source.Text); line != "" {
+			return line, []string{source.ID}, "selected from source text"
+		}
+	}
+	return "", nil, ""
+}
+
+func firstObjectiveCandidate(input Input) string {
+	if genericPRInstructionPattern.MatchString(input.Instruction) || input.Instruction == "" {
+		for _, source := range input.Sources {
+			if source.Kind == SourceKindTriggerContext || source.Kind == SourceKindReference {
+				continue
+			}
+			if line := firstMeaningfulLine(source.Text); line != "" {
+				return line
+			}
+		}
+	}
+	return ""
+}
+
+func sourceIDsForInstruction(input Input) []string {
+	if len(input.Sources) == 0 {
+		return nil
+	}
+	return []string{input.Sources[0].ID}
+}
+
+func firstMeaningfulLine(text string) string {
+	for _, raw := range strings.Split(normalizeNewlines(text), "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, ">") || markdownFencePattern.MatchString(line) {
+			continue
+		}
+		line = normalizeWhitespace(strings.TrimPrefix(line, "#"))
+		line = strings.Trim(line, "-* ")
+		if line != "" {
+			return line
+		}
+	}
+	return ""
+}
+
+func deriveBackground(input Input, objective string) (string, []string) {
+	var parts []string
+	var ids []string
+
+	rest := remainingInstruction(input.Instruction, objective)
+	if rest != "" {
+		parts = append(parts, rest)
+		ids = append(ids, sourceIDsForInstruction(input)...)
+	}
+	for _, source := range input.Sources {
+		extracted := extractSource(source.Text)
+		for _, part := range extracted.background {
+			if sameText(part, objective) || sameText(part, rest) {
+				continue
+			}
+			parts = append(parts, part)
+			ids = append(ids, source.ID)
+		}
+		if source.Kind == SourceKindTriggerContext && source.Text != "" && !sameText(source.Text, input.Context) {
+			parts = append(parts, normalizeWhitespace(source.Text))
+			ids = append(ids, source.ID)
+		}
+	}
+	parts = uniqueStrings(parts)
+	ids = uniqueStrings(ids)
+	return strings.Join(parts, "\n\n"), ids
+}
+
+func remainingInstruction(instruction, objective string) string {
+	instruction = normalizeNewlines(instruction)
+	if strings.TrimSpace(instruction) == "" {
+		return ""
+	}
+	lines := strings.Split(instruction, "\n")
+	start := 0
+	for start < len(lines) && strings.TrimSpace(lines[start]) == "" {
+		start++
+	}
+	if start < len(lines) && sameText(lines[start], objective) {
+		start++
+	}
+	return strings.TrimSpace(strings.Join(lines[start:], "\n"))
+}
+
+func itemsFromStrings(values []string, sourceID, derivation string) []Item {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]Item, 0, len(values))
+	for _, value := range values {
+		out = append(out, Item{
+			Text:       value,
+			SourceIDs:  []string{sourceID},
+			Derivation: derivation,
+		})
+	}
+	return out
+}
+
+func pathRefsFromStrings(values []string, sourceID string) []PathRef {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]PathRef, 0, len(values))
+	for _, value := range values {
+		out = append(out, PathRef{
+			Path:       value,
+			SourceIDs:  []string{sourceID},
+			Derivation: "detected from source text",
+		})
+	}
+	return out
+}
+
+func buildAmbiguities(input Input, brief RunBrief) []Note {
+	var notes []Note
+	if brief.PrimaryObjective.Text == "" {
+		notes = append(notes, Note{Text: "The trigger input did not provide a clear primary objective."})
+	}
+	if len(brief.AcceptanceCriteria) == 0 {
+		notes = append(notes, Note{Text: "Acceptance criteria were not explicit in the trigger input."})
+	}
+	if len(brief.RelevantFiles) == 0 {
+		notes = append(notes, Note{Text: "Target files or paths were not directly inferable from the trigger input."})
+	}
+	if input.Trigger.IsIssue() && !hasSourceKind(input.Sources, SourceKindGitHubIssue) {
+		notes = append(notes, Note{Text: "GitHub issue content was not available, so the brief is based on the issue reference rather than the issue body."})
+	}
+	if len(brief.PrimaryObjective.Text) > 0 &&
+		len(brief.AcceptanceCriteria) == 0 &&
+		len(brief.Validation) == 0 &&
+		len(brief.Constraints) == 0 &&
+		len(strings.Fields(brief.PrimaryObjective.Text)) <= 4 {
+		notes = append(notes, Note{Text: "The trigger input is terse, so execution should stay conservative and avoid expanding scope."})
+	}
+	return dedupeNotes(notes)
+}
+
+func buildAssumptions(input Input, brief RunBrief) []Note {
+	var notes []Note
+	if genericPRInstructionPattern.MatchString(input.Instruction) && len(brief.PrimaryObjective.Text) > 0 {
+		notes = append(notes, Note{
+			Text:       "Treat the supplied pull request feedback as the concrete change request and avoid unrelated edits.",
+			SourceIDs:  brief.PrimaryObjective.SourceIDs,
+			Derivation: "derived from generic PR feedback instruction plus source text",
+		})
+	}
+	return dedupeNotes(notes)
+}
+
+func hasSourceKind(sources []Source, kind SourceKind) bool {
+	for _, source := range sources {
+		if source.Kind == kind && strings.TrimSpace(source.Text) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func sourceRefs(sources []Source) []SourceRef {
+	if len(sources) == 0 {
+		return nil
+	}
+	refs := make([]SourceRef, 0, len(sources))
+	for _, source := range sources {
+		refs = append(refs, SourceRef{
+			ID:       source.ID,
+			Kind:     source.Kind,
+			Label:    source.Label,
+			URL:      source.URL,
+			Location: source.Location,
+		})
+	}
+	return refs
+}
+
+func preview(text string, limit int) string {
+	text = normalizeWhitespace(text)
+	if len(text) <= limit {
+		return text
+	}
+	return strings.TrimSpace(text[:limit-3]) + "..."
+}
+
+func sameText(a, b string) bool {
+	return normalizeWhitespace(a) == normalizeWhitespace(b)
+}
+
+func dedupeItems(values []Item) []Item {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]int, len(values))
+	out := make([]Item, 0, len(values))
+	for _, value := range values {
+		key := strings.ToLower(normalizeWhitespace(value.Text))
+		if key == "" {
+			continue
+		}
+		if idx, ok := seen[key]; ok {
+			out[idx].SourceIDs = uniqueStrings(append(out[idx].SourceIDs, value.SourceIDs...))
+			continue
+		}
+		value.Text = normalizeWhitespace(value.Text)
+		value.SourceIDs = uniqueStrings(value.SourceIDs)
+		seen[key] = len(out)
+		out = append(out, value)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func dedupePathRefs(values []PathRef) []PathRef {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]int, len(values))
+	out := make([]PathRef, 0, len(values))
+	for _, value := range values {
+		key := strings.ToLower(normalizeWhitespace(value.Path))
+		if key == "" {
+			continue
+		}
+		if idx, ok := seen[key]; ok {
+			out[idx].SourceIDs = uniqueStrings(append(out[idx].SourceIDs, value.SourceIDs...))
+			continue
+		}
+		value.Path = normalizeWhitespace(value.Path)
+		value.SourceIDs = uniqueStrings(value.SourceIDs)
+		seen[key] = len(out)
+		out = append(out, value)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func dedupeNotes(values []Note) []Note {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]int, len(values))
+	out := make([]Note, 0, len(values))
+	for _, value := range values {
+		key := strings.ToLower(normalizeWhitespace(value.Text))
+		if key == "" {
+			continue
+		}
+		if idx, ok := seen[key]; ok {
+			out[idx].SourceIDs = uniqueStrings(append(out[idx].SourceIDs, value.SourceIDs...))
+			continue
+		}
+		value.Text = normalizeWhitespace(value.Text)
+		value.SourceIDs = uniqueStrings(value.SourceIDs)
+		seen[key] = len(out)
+		out = append(out, value)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/planning/compile_test.go
+++ b/internal/planning/compile_test.go
@@ -1,0 +1,141 @@
+package planning
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rtzll/rascal/internal/runtrigger"
+)
+
+func TestCompileIssueBriefExtractsStructuredFields(t *testing.T) {
+	input := Input{
+		Trigger:     runtrigger.NameIssueLabel,
+		Repo:        "owner/repo",
+		Instruction: "Compile trigger input into a structured run brief\n\nSummary paragraph.",
+		IssueNumber: 162,
+		Sources: []Source{
+			IssueSource(
+				"Compile trigger input into a structured run brief",
+				strings.TrimSpace(`
+## Summary
+Rascal should normalize trigger input before execution.
+
+## Acceptance Criteria
+- [ ] Persist run-brief.json
+- [ ] Persist run-brief.md
+
+## Constraints
+- Do not invent requirements.
+
+## Suggested Test Plan
+- Run make test
+
+## Implementation Notes
+- Check internal/orchestrator/runs.go
+- Update /rascal-meta/commit_message.txt
+
+> quoted prior feedback that should not dominate
+
+`+"```go\nfmt.Println(\"ignore code block\")\n```"+`
+`),
+				"https://github.com/owner/repo/issues/162",
+			),
+		},
+	}
+
+	compiled, err := Compile(input)
+	if err != nil {
+		t.Fatalf("Compile() error = %v", err)
+	}
+
+	if got := compiled.Brief.PrimaryObjective.Text; got != "Compile trigger input into a structured run brief" {
+		t.Fatalf("primary objective = %q", got)
+	}
+	if len(compiled.Brief.AcceptanceCriteria) != 2 {
+		t.Fatalf("acceptance criteria = %d, want 2", len(compiled.Brief.AcceptanceCriteria))
+	}
+	if len(compiled.Brief.Constraints) == 0 || !strings.Contains(compiled.Brief.Constraints[0].Text, "Do not invent requirements") {
+		t.Fatalf("constraints = %+v", compiled.Brief.Constraints)
+	}
+	if len(compiled.Brief.Validation) == 0 || compiled.Brief.Validation[0].Text != "Run make test" {
+		t.Fatalf("validation = %+v", compiled.Brief.Validation)
+	}
+	if !containsPath(compiled.Brief.RelevantFiles, "internal/orchestrator/runs.go") {
+		t.Fatalf("relevant files missing internal/orchestrator/runs.go: %+v", compiled.Brief.RelevantFiles)
+	}
+	if !containsPath(compiled.Brief.RelevantFiles, "/rascal-meta/commit_message.txt") {
+		t.Fatalf("relevant files missing /rascal-meta/commit_message.txt: %+v", compiled.Brief.RelevantFiles)
+	}
+}
+
+func TestCompilePRReviewCommentPrefersFeedbackText(t *testing.T) {
+	input := Input{
+		Trigger:     runtrigger.NamePRReviewComment,
+		Repo:        "owner/repo",
+		Instruction: "Address PR #99 inline review comment",
+		PRNumber:    99,
+		Sources: []Source{
+			PRReviewCommentSource(strings.TrimSpace(`
+> old quoted feedback
+Please rename helper in internal/orchestrator/runs.go.
+
+Do not change API behavior.
+
+`+"```go\nfmt.Println(\"ignore\")\n```"), "internal/orchestrator/runs.go:120", "reviewer"),
+		},
+	}
+
+	compiled, err := Compile(input)
+	if err != nil {
+		t.Fatalf("Compile() error = %v", err)
+	}
+
+	if got := compiled.Brief.PrimaryObjective.Text; got != "Please rename helper in internal/orchestrator/runs.go." {
+		t.Fatalf("primary objective = %q", got)
+	}
+	if len(compiled.Brief.Constraints) == 0 || !strings.Contains(compiled.Brief.Constraints[0].Text, "Do not change API behavior") {
+		t.Fatalf("constraints = %+v", compiled.Brief.Constraints)
+	}
+	if !containsPath(compiled.Brief.RelevantFiles, "internal/orchestrator/runs.go") {
+		t.Fatalf("relevant files = %+v", compiled.Brief.RelevantFiles)
+	}
+}
+
+func TestCompileIssueReferenceRecordsAmbiguity(t *testing.T) {
+	input := Input{
+		Trigger:     runtrigger.NameIssueAPI,
+		Repo:        "owner/repo",
+		Instruction: "Work on issue #7 in owner/repo",
+		IssueNumber: 7,
+		Sources: []Source{
+			ReferenceSource("Issue reference", "owner/repo#7"),
+		},
+	}
+
+	compiled, err := Compile(input)
+	if err != nil {
+		t.Fatalf("Compile() error = %v", err)
+	}
+
+	if !containsNote(compiled.Brief.Ambiguities, "GitHub issue content was not available") {
+		t.Fatalf("ambiguities = %+v", compiled.Brief.Ambiguities)
+	}
+}
+
+func containsPath(paths []PathRef, want string) bool {
+	for _, path := range paths {
+		if path.Path == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsNote(notes []Note, want string) bool {
+	for _, note := range notes {
+		if strings.Contains(note.Text, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/planning/extract.go
+++ b/internal/planning/extract.go
@@ -1,0 +1,240 @@
+package planning
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	markdownHeadingPattern  = regexp.MustCompile(`^#{1,6}\s+(.+)$`)
+	markdownFencePattern    = regexp.MustCompile("^(```|~~~)")
+	markdownCheckboxPattern = regexp.MustCompile(`^[-*]\s+\[(?: |x|X)\]\s+(.+)$`)
+	markdownBulletPattern   = regexp.MustCompile(`^(?:[-*]|\d+\.)\s+(.+)$`)
+	explicitNoPattern       = regexp.MustCompile(`(?i)\b(?:do not|don't|must not|should not|avoid)\b`)
+	pathPattern             = regexp.MustCompile(`(?m)(?:^|[\s(` + "`" + `])((?:/)?[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)+(?:\.[A-Za-z0-9._-]+)?(?::\d+(?:-\d+)?)?)`)
+)
+
+type extractedSource struct {
+	background  []string
+	constraints []string
+	acceptance  []string
+	validation  []string
+	followUp    []string
+	paths       []string
+}
+
+func extractSource(text string) extractedSource {
+	cleanText := normalizeNewlines(text)
+	lines := strings.Split(cleanText, "\n")
+
+	var out extractedSource
+	inFence := false
+	section := ""
+	var paragraph []string
+	generalBackgroundUsed := 0
+
+	flushParagraph := func() {
+		if len(paragraph) == 0 {
+			return
+		}
+		text := normalizeWhitespace(strings.Join(paragraph, " "))
+		paragraph = nil
+		if text == "" {
+			return
+		}
+		switch section {
+		case "acceptance":
+			out.acceptance = append(out.acceptance, text)
+		case "constraints":
+			out.constraints = append(out.constraints, text)
+		case "validation":
+			out.validation = append(out.validation, text)
+		case "followup":
+			out.followUp = append(out.followUp, text)
+		case "background":
+			out.background = append(out.background, text)
+		default:
+			if explicitNoPattern.MatchString(text) {
+				out.constraints = append(out.constraints, text)
+				return
+			}
+			if generalBackgroundUsed < 2 {
+				out.background = append(out.background, text)
+				generalBackgroundUsed++
+			}
+		}
+	}
+
+	for _, rawLine := range lines {
+		line := strings.TrimRight(rawLine, "\r")
+		trimmed := strings.TrimSpace(line)
+
+		if markdownFencePattern.MatchString(trimmed) {
+			flushParagraph()
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			continue
+		}
+		if trimmed == "" {
+			flushParagraph()
+			continue
+		}
+		if strings.HasPrefix(trimmed, ">") {
+			flushParagraph()
+			continue
+		}
+		if matches := markdownHeadingPattern.FindStringSubmatch(trimmed); matches != nil {
+			flushParagraph()
+			section = classifyHeading(matches[1])
+			continue
+		}
+		if matches := markdownCheckboxPattern.FindStringSubmatch(trimmed); matches != nil {
+			flushParagraph()
+			item := cleanListItem(matches[1])
+			if item == "" {
+				continue
+			}
+			switch section {
+			case "constraints":
+				out.constraints = append(out.constraints, item)
+			case "validation":
+				out.validation = append(out.validation, item)
+			case "followup":
+				out.followUp = append(out.followUp, item)
+			default:
+				out.acceptance = append(out.acceptance, item)
+			}
+			continue
+		}
+		if matches := markdownBulletPattern.FindStringSubmatch(trimmed); matches != nil {
+			flushParagraph()
+			item := cleanListItem(matches[1])
+			if item == "" {
+				continue
+			}
+			switch section {
+			case "acceptance":
+				out.acceptance = append(out.acceptance, item)
+			case "constraints":
+				out.constraints = append(out.constraints, item)
+			case "validation":
+				out.validation = append(out.validation, item)
+			case "followup":
+				out.followUp = append(out.followUp, item)
+			case "background":
+				out.background = append(out.background, item)
+			default:
+				if explicitNoPattern.MatchString(item) {
+					out.constraints = append(out.constraints, item)
+				}
+			}
+			continue
+		}
+		paragraph = append(paragraph, trimmed)
+	}
+	flushParagraph()
+
+	for _, match := range pathPattern.FindAllStringSubmatch(stripQuotedAndFenced(cleanText), -1) {
+		candidate := strings.TrimSpace(strings.Trim(match[1], ".,:;()[]{}"))
+		if candidate == "" || strings.Contains(candidate, "://") {
+			continue
+		}
+		out.paths = append(out.paths, candidate)
+	}
+
+	out.background = uniqueStrings(out.background)
+	out.constraints = uniqueStrings(out.constraints)
+	out.acceptance = uniqueStrings(out.acceptance)
+	out.validation = uniqueStrings(out.validation)
+	out.followUp = uniqueStrings(out.followUp)
+	out.paths = uniqueStrings(out.paths)
+	return out
+}
+
+func classifyHeading(heading string) string {
+	normalized := strings.ToLower(normalizeWhitespace(heading))
+	switch {
+	case strings.Contains(normalized, "acceptance"):
+		return "acceptance"
+	case strings.Contains(normalized, "constraint"):
+		return "constraints"
+	case strings.Contains(normalized, "non-goal"), strings.Contains(normalized, "non goal"):
+		return "constraints"
+	case strings.Contains(normalized, "validation"):
+		return "validation"
+	case strings.Contains(normalized, "test plan"):
+		return "validation"
+	case strings.Contains(normalized, "follow-up"), strings.Contains(normalized, "follow up"):
+		return "followup"
+	case strings.Contains(normalized, "background"),
+		strings.Contains(normalized, "summary"),
+		strings.Contains(normalized, "context"),
+		strings.Contains(normalized, "outcome"),
+		strings.Contains(normalized, "scope"),
+		strings.Contains(normalized, "goal"),
+		strings.Contains(normalized, "implementation note"):
+		return "background"
+	default:
+		return ""
+	}
+}
+
+func stripQuotedAndFenced(text string) string {
+	lines := strings.Split(normalizeNewlines(text), "\n")
+	inFence := false
+	var kept []string
+	for _, raw := range lines {
+		line := strings.TrimRight(raw, "\r")
+		trimmed := strings.TrimSpace(line)
+		if markdownFencePattern.MatchString(trimmed) {
+			inFence = !inFence
+			continue
+		}
+		if inFence || strings.HasPrefix(trimmed, ">") {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.Join(kept, "\n")
+}
+
+func cleanListItem(text string) string {
+	text = normalizeWhitespace(text)
+	text = strings.Trim(text, ".,; ")
+	return text
+}
+
+func normalizeWhitespace(text string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(text)), " ")
+}
+
+func normalizeNewlines(text string) string {
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+	return text
+}
+
+func uniqueStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		normalized := strings.ToLower(normalizeWhitespace(value))
+		if normalized == "" {
+			continue
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		out = append(out, normalizeWhitespace(value))
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/planning/helpers.go
+++ b/internal/planning/helpers.go
@@ -1,0 +1,82 @@
+package planning
+
+import (
+	"fmt"
+	"strings"
+
+	ghapi "github.com/rtzll/rascal/internal/github"
+)
+
+func ManualPromptSource(text string) Source {
+	return Source{
+		Kind:  SourceKindManualPrompt,
+		Label: "Manual prompt",
+		Text:  strings.TrimSpace(text),
+	}
+}
+
+func IssueSource(title, body, url string) Source {
+	return Source{
+		Kind:  SourceKindGitHubIssue,
+		Label: "GitHub issue",
+		URL:   strings.TrimSpace(url),
+		Text:  strings.TrimSpace(ghapi.IssueTaskFromIssue(title, body)),
+	}
+}
+
+func ReferenceSource(label, text string) Source {
+	return Source{
+		Kind:  SourceKindReference,
+		Label: strings.TrimSpace(label),
+		Text:  strings.TrimSpace(text),
+	}
+}
+
+func ContextSource(label, text string) Source {
+	return Source{
+		Kind:  SourceKindTriggerContext,
+		Label: strings.TrimSpace(label),
+		Text:  strings.TrimSpace(text),
+	}
+}
+
+func PRCommentSource(body, author string) Source {
+	return Source{
+		Kind:   SourceKindGitHubPRComment,
+		Label:  "PR comment",
+		Author: strings.TrimSpace(author),
+		Text:   strings.TrimSpace(body),
+	}
+}
+
+func PRReviewSource(body, state, author string) Source {
+	body = strings.TrimSpace(body)
+	if body == "" && strings.TrimSpace(state) != "" {
+		body = fmt.Sprintf("Review state: %s", strings.TrimSpace(state))
+	}
+	return Source{
+		Kind:   SourceKindGitHubPRReview,
+		Label:  "PR review",
+		Author: strings.TrimSpace(author),
+		Text:   body,
+	}
+}
+
+func PRReviewCommentSource(body, location, author string) Source {
+	return Source{
+		Kind:     SourceKindGitHubPRReviewNote,
+		Label:    "PR review comment",
+		Author:   strings.TrimSpace(author),
+		Location: strings.TrimSpace(location),
+		Text:     strings.TrimSpace(body),
+	}
+}
+
+func PRReviewThreadSource(text, location string) Source {
+	return Source{
+		Kind:     SourceKindGitHubPRThread,
+		Label:    "PR review thread",
+		Location: strings.TrimSpace(location),
+		Text:     strings.TrimSpace(text),
+	}
+}

--- a/internal/planning/render.go
+++ b/internal/planning/render.go
@@ -1,0 +1,159 @@
+package planning
+
+import (
+	"fmt"
+	"strings"
+)
+
+type RenderOptions struct {
+	IncludeProvenance bool
+	Title             string
+}
+
+func RenderMarkdown(brief RunBrief, opts RenderOptions) string {
+	title := strings.TrimSpace(opts.Title)
+	if title == "" {
+		title = "Run Brief"
+	}
+
+	var b strings.Builder
+	_, _ = fmt.Fprintf(&b, "# %s\n\n", title)
+	_, _ = fmt.Fprintf(&b, "- Version: `%s`\n", firstNonEmpty(brief.Version, SchemaVersion))
+	_, _ = fmt.Fprintf(&b, "- Trigger: `%s`\n", brief.Trigger)
+
+	writeFieldSection(&b, "Primary Objective", brief.PrimaryObjective, opts.IncludeProvenance)
+	writeFieldSection(&b, "Background Summary", brief.BackgroundSummary, opts.IncludeProvenance)
+	writeItemSection(&b, "Constraints", brief.Constraints, opts.IncludeProvenance)
+	writeItemSection(&b, "Acceptance Criteria", brief.AcceptanceCriteria, opts.IncludeProvenance)
+	writePathSection(&b, "Relevant Files", brief.RelevantFiles, opts.IncludeProvenance)
+	writeItemSection(&b, "Validation", brief.Validation, opts.IncludeProvenance)
+	writeItemSection(&b, "Follow-Up", brief.FollowUp, opts.IncludeProvenance)
+	writeNoteSection(&b, "Ambiguities", brief.Ambiguities, opts.IncludeProvenance)
+	writeNoteSection(&b, "Assumptions", brief.Assumptions, opts.IncludeProvenance)
+
+	if len(brief.Sources) > 0 {
+		b.WriteString("\n## Sources\n\n")
+		for _, source := range brief.Sources {
+			line := fmt.Sprintf("- `%s`: `%s`", source.ID, source.Kind)
+			if source.Label != "" {
+				line += " - " + source.Label
+			}
+			if source.Location != "" {
+				line += fmt.Sprintf(" (%s)", source.Location)
+			}
+			if source.URL != "" {
+				line += fmt.Sprintf(" [%s](%s)", source.URL, source.URL)
+			}
+			b.WriteString(line + "\n")
+		}
+	}
+
+	return strings.TrimSpace(b.String()) + "\n"
+}
+
+func RenderSourceSummary(input Input) string {
+	summaries := Summaries(input)
+	if len(summaries) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("## Raw Source Summary\n\n")
+	for _, summary := range summaries {
+		line := fmt.Sprintf("- `%s`: `%s`", summary.ID, summary.Kind)
+		if summary.Label != "" {
+			line += " - " + summary.Label
+		}
+		if summary.Location != "" {
+			line += fmt.Sprintf(" (%s)", summary.Location)
+		}
+		if summary.Preview != "" {
+			line += fmt.Sprintf("\n  %s", summary.Preview)
+		}
+		b.WriteString(line + "\n")
+	}
+	return strings.TrimSpace(b.String()) + "\n"
+}
+
+func writeFieldSection(b *strings.Builder, title string, field Field, includeProvenance bool) {
+	if strings.TrimSpace(field.Text) == "" {
+		return
+	}
+	_, _ = fmt.Fprintf(b, "\n## %s\n\n%s", title, strings.TrimSpace(field.Text))
+	if includeProvenance {
+		writeProvenance(b, field.SourceIDs, field.Derivation)
+	}
+	b.WriteString("\n")
+}
+
+func writeItemSection(b *strings.Builder, title string, items []Item, includeProvenance bool) {
+	if len(items) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintf(b, "\n## %s\n\n", title)
+	for _, item := range items {
+		line := "- " + strings.TrimSpace(item.Text)
+		if includeProvenance {
+			line += provenanceSuffix(item.SourceIDs, item.Derivation)
+		}
+		b.WriteString(line + "\n")
+	}
+}
+
+func writePathSection(b *strings.Builder, title string, items []PathRef, includeProvenance bool) {
+	if len(items) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintf(b, "\n## %s\n\n", title)
+	for _, item := range items {
+		line := "- `" + strings.TrimSpace(item.Path) + "`"
+		if includeProvenance {
+			line += provenanceSuffix(item.SourceIDs, item.Derivation)
+		}
+		b.WriteString(line + "\n")
+	}
+}
+
+func writeNoteSection(b *strings.Builder, title string, items []Note, includeProvenance bool) {
+	if len(items) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintf(b, "\n## %s\n\n", title)
+	for _, item := range items {
+		line := "- " + strings.TrimSpace(item.Text)
+		if includeProvenance {
+			line += provenanceSuffix(item.SourceIDs, item.Derivation)
+		}
+		b.WriteString(line + "\n")
+	}
+}
+
+func writeProvenance(b *strings.Builder, sourceIDs []string, derivation string) {
+	suffix := provenanceSuffix(sourceIDs, derivation)
+	if suffix == "" {
+		return
+	}
+	b.WriteString("\n" + strings.TrimSpace(strings.TrimPrefix(suffix, " ")) + "\n")
+}
+
+func provenanceSuffix(sourceIDs []string, derivation string) string {
+	var details []string
+	if len(sourceIDs) > 0 {
+		details = append(details, "source: "+strings.Join(sourceIDs, ", "))
+	}
+	if strings.TrimSpace(derivation) != "" {
+		details = append(details, strings.TrimSpace(derivation))
+	}
+	if len(details) == 0 {
+		return ""
+	}
+	return " _(" + strings.Join(details, "; ") + ")_"
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/internal/planning/types.go
+++ b/internal/planning/types.go
@@ -1,0 +1,100 @@
+package planning
+
+import "github.com/rtzll/rascal/internal/runtrigger"
+
+const SchemaVersion = "v1"
+
+type SourceKind string
+
+const (
+	SourceKindManualPrompt       SourceKind = "manual_prompt"
+	SourceKindGitHubIssue        SourceKind = "github_issue"
+	SourceKindGitHubPRComment    SourceKind = "github_pr_comment"
+	SourceKindGitHubPRReview     SourceKind = "github_pr_review"
+	SourceKindGitHubPRReviewNote SourceKind = "github_pr_review_comment"
+	SourceKindGitHubPRThread     SourceKind = "github_pr_review_thread"
+	SourceKindTriggerContext     SourceKind = "trigger_context"
+	SourceKindReference          SourceKind = "reference"
+)
+
+type Input struct {
+	Version     string          `json:"version"`
+	Trigger     runtrigger.Name `json:"trigger"`
+	Repo        string          `json:"repo,omitempty"`
+	Instruction string          `json:"instruction,omitempty"`
+	Context     string          `json:"context,omitempty"`
+	IssueNumber int             `json:"issue_number,omitempty"`
+	PRNumber    int             `json:"pr_number,omitempty"`
+	Sources     []Source        `json:"sources,omitempty"`
+}
+
+type Source struct {
+	ID       string     `json:"id,omitempty"`
+	Kind     SourceKind `json:"kind"`
+	Label    string     `json:"label,omitempty"`
+	URL      string     `json:"url,omitempty"`
+	Author   string     `json:"author,omitempty"`
+	Location string     `json:"location,omitempty"`
+	Text     string     `json:"text,omitempty"`
+}
+
+type RunBrief struct {
+	Version            string          `json:"version"`
+	Trigger            runtrigger.Name `json:"trigger"`
+	PrimaryObjective   Field           `json:"primary_objective"`
+	BackgroundSummary  Field           `json:"background_summary,omitempty"`
+	Constraints        []Item          `json:"constraints,omitempty"`
+	AcceptanceCriteria []Item          `json:"acceptance_criteria,omitempty"`
+	RelevantFiles      []PathRef       `json:"relevant_files,omitempty"`
+	Validation         []Item          `json:"validation,omitempty"`
+	FollowUp           []Item          `json:"follow_up,omitempty"`
+	Ambiguities        []Note          `json:"ambiguities,omitempty"`
+	Assumptions        []Note          `json:"assumptions,omitempty"`
+	Sources            []SourceRef     `json:"sources,omitempty"`
+}
+
+type Field struct {
+	Text       string   `json:"text,omitempty"`
+	SourceIDs  []string `json:"source_ids,omitempty"`
+	Derivation string   `json:"derivation,omitempty"`
+}
+
+type Item struct {
+	Text       string   `json:"text"`
+	SourceIDs  []string `json:"source_ids,omitempty"`
+	Derivation string   `json:"derivation,omitempty"`
+}
+
+type PathRef struct {
+	Path       string   `json:"path"`
+	SourceIDs  []string `json:"source_ids,omitempty"`
+	Derivation string   `json:"derivation,omitempty"`
+}
+
+type Note struct {
+	Text       string   `json:"text"`
+	SourceIDs  []string `json:"source_ids,omitempty"`
+	Derivation string   `json:"derivation,omitempty"`
+}
+
+type SourceRef struct {
+	ID       string     `json:"id"`
+	Kind     SourceKind `json:"kind"`
+	Label    string     `json:"label,omitempty"`
+	URL      string     `json:"url,omitempty"`
+	Location string     `json:"location,omitempty"`
+}
+
+type SourceSummary struct {
+	ID       string     `json:"id"`
+	Kind     SourceKind `json:"kind"`
+	Label    string     `json:"label,omitempty"`
+	URL      string     `json:"url,omitempty"`
+	Location string     `json:"location,omitempty"`
+	Preview  string     `json:"preview,omitempty"`
+}
+
+type Compiled struct {
+	Input Input    `json:"input"`
+	Brief RunBrief `json:"brief"`
+}


### PR DESCRIPTION
Add deterministic run-brief compilation, artifact persistence, and CLI dry-run
inspection so backend prompts execute against a normalized execution contract.

<details><summary>Agent Details</summary>

<pre><code>
    __( O)&gt;  ● resuming · codex gpt-5.4
   \____)    20260314_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: &#34;/usr/local/bin/codex&#34;
Model: gpt-5.4
Reasoning effort: high
Skip git check: false
Prompt length: 13409 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Suggestion

The user has 7 extensions with 16 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
Consider asking if they&#39;d like to disable some extensions to improve tool selection accuracy.

# Response Guidelines

Use Markdown formatting for all responses.

Human: &lt;info-msg&gt;
It is currently 2026-03-15 16:18:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

&lt;/info-msg&gt;
# Rascal Run Instructions

Run ID: run_7930e4e7314a9eac
Task ID: rtzll/rascal#162
Repository: rtzll/rascal
Issue: #162

## Task

feat(planning): compile trigger input into a structured run brief before agent execution

Related: #119

## Summary
Rascal currently accepts manual task text and GitHub-triggered feedback, then passes that input into run artifacts without a first-class planning layer that normalizes intent.

This issue adds a deterministic run-brief compiler that turns issue bodies, PR comments, review comments, and manual prompts into a structured execution brief the backend can follow more reliably.

## Outcome
Every run begins with a normalized `run-brief` artifact that captures the objective, constraints, acceptance criteria, relevant files, validation expectations, and follow-up context in a backend-neutral format.

## Goals
- Improve first-pass run quality by clarifying ambiguous trigger input.
- Separate raw trigger content from the normalized brief the agent should execute against.
- Make planning decisions inspectable in run artifacts.
- Keep the system deterministic and compatible with both supported backends.
- Compose cleanly with the context-pack work in #119.

## Non-goals
- Letting the model freely rewrite the user’s intent.
- Building a generic ticket-planning product.
- Implementing semantic search or repo-wide retrieval in this issue.
- Solving multi-agent orchestration here.

## Scope
Implement V1 run-brief compilation with the following pieces.

1. Input normalization
- Support the current Rascal trigger classes, including:
  - manual CLI/API task text
  - issue label / issue edit flows
  - PR comment feedback
  - PR review feedback
  - PR review comment feedback
- Normalize raw inputs into a shared intermediate model.
- Preserve original source text in artifacts for traceability.

2. Run brief schema
- Add explicit artifacts such as:
  - `run-brief.json`
  - `run-brief.md`
- The brief should capture at least:
  - primary objective
  - background/context summary
  - constraints and instructions
  - acceptance criteria
  - likely target files or paths when directly inferable
  - requested validation or follow-up behavior
  - unresolved ambiguities or assumptions
- Keep the schema compact and inspectable.

3. Deterministic extraction rules
- Add a deterministic extraction pass that can identify common structure from GitHub input, such as:
  - checkbox lists
  - fenced code blocks
  - quoted prior feedback
  - inline file/path references
  - explicit &#34;do not&#34; constraints
- Strip noise that should not dominate the brief, while preserving it in source artifacts.
- Avoid hidden prompt magic in V1.

4. Ambiguity handling
- If the trigger input is too vague, record that explicitly in the brief.
- Add conservative fallback behavior such as:
  - continue with a minimal brief and explicit assumptions
  - optionally fail fast for configuration-controlled trigger classes later
- The brief should never pretend the request was clearer than it was.

5. Dry-run visibility
- Add a CLI/debug path to inspect the compiled brief without running the backend, for example:
  - `rascal run --dry-run-brief`
  - `rascal brief issue OWNER/REPO#123`
- The output should show both the normalized brief and the raw source summary.

6. Prompt assembly integration
- Thread the compiled brief into the existing run artifact generation and prompt assembly flow.
- Keep backend-specific prompt formatting separate from the brief compiler itself.
- The backend should receive the normalized brief as the primary execution contract.

## Suggested implementation approach
1. Add a small internal planning package.
- Separate source loading, normalization, extraction, and rendering.
- Model a stable `RunBrief` type with explicit provenance.

2. Keep extraction heuristics shallow and deterministic.
- Prefer regex/tokenization/markdown-structure parsing over opaque model-based rewriting.
- If later model-assisted planning is added, it should layer on top of this deterministic base.

3. Preserve provenance.
- Each field in the brief should be traceable to a raw source or a deterministic derivation.
- Ambiguous derived fields should carry an explanation.

4. Integrate cleanly with #119.
- The run brief describes what needs to be done.
- The context pack describes what repo guidance should accompany it.
- Do not collapse the two concerns into one artifact.

5. Make failures explicit.
- If source loading from GitHub fails, surface that as a planning error with a clear reason.
- Avoid silently compiling partial briefs that look authoritative.

## Acceptance criteria
- Rascal can compile raw trigger input into a normalized run brief for all current trigger classes.
- The brief is persisted as explicit JSON and Markdown artifacts in the run directory.
- The compiled brief preserves provenance and ambiguity notes.
- Operators can inspect the brief without starting a backend run.
- Backend prompt assembly uses the run brief as a first-class input.
- Tests cover manual tasks, issue-driven runs, PR feedback runs, ambiguity handling, and artifact rendering.

## Suggested test plan
- Unit tests for markdown extraction and path/reference detection.
- Unit tests for trigger-specific brief compilation.
- Integration tests for issue/comment/review payloads producing stable `run-brief.json` output.
- Regression tests for noisy GitHub comments that include quoted text or code fences.
- CLI tests for dry-run brief inspection.

## Implementation notes
- The brief compiler should clarify intent, not invent it.
- Keep the initial schema small enough that humans will actually read it during debugging.
- A dependable deterministic planner is more valuable here than a clever but unstable one.


## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run `make lint` and `make test` before finishing if those targets exist.
- If one of those commands does not exist or cannot run, explain exactly why and run the closest equivalent checks instead.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label &#39;rascal&#39; on issue #162

# Rascal Run Instructions

Run ID: run_8eb3f7257e3d893c
Task ID: rtzll/rascal#162
Repository: rtzll/rascal
Issue: #162

## Task

feat(planning): compile trigger input into a structured run brief before agent execution

Related: #119

## Summary
Rascal currently accepts manual task text and GitHub-triggered feedback, then passes that input into run artifacts without a first-class planning layer that normalizes intent.

This issue adds a deterministic run-brief compiler that turns issue bodies, PR comments, review comments, and manual prompts into a structured execution brief the backend can follow more reliably.

## Outcome
Every run begins with a normalized `run-brief` artifact that captures the objective, constraints, acceptance criteria, relevant files, validation expectations, and follow-up context in a backend-neutral format.

## Goals
- Improve first-pass run quality by clarifying ambiguous trigger input.
- Separate raw trigger content from the normalized brief the agent should execute against.
- Make planning decisions inspectable in run artifacts.
- Keep the system deterministic and compatible with both supported backends.
- Compose cleanly with the context-pack work in #119.

## Non-goals
- Letting the model freely rewrite the user’s intent.
- Building a generic ticket-planning product.
- Implementing semantic search or repo-wide retrieval in this issue.
- Solving multi-agent orchestration here.

## Scope
Implement V1 run-brief compilation with the following pieces.

1. Input normalization
- Support the current Rascal trigger classes, including:
  - manual CLI/API task text
  - issue label / issue edit flows
  - PR comment feedback
  - PR review feedback
  - PR review comment feedback
- Normalize raw inputs into a shared intermediate model.
- Preserve original source text in artifacts for traceability.

2. Run brief schema
- Add explicit artifacts such as:
  - `run-brief.json`
  - `run-brief.md`
- The brief should capture at least:
  - primary objective
  - background/context summary
  - constraints and instructions
  - acceptance criteria
  - likely target files or paths when directly inferable
  - requested validation or follow-up behavior
  - unresolved ambiguities or assumptions
- Keep the schema compact and inspectable.

3. Deterministic extraction rules
- Add a deterministic extraction pass that can identify common structure from GitHub input, such as:
  - checkbox lists
  - fenced code blocks
  - quoted prior feedback
  - inline file/path references
  - explicit &#34;do not&#34; constraints
- Strip noise that should not dominate the brief, while preserving it in source artifacts.
- Avoid hidden prompt magic in V1.

4. Ambiguity handling
- If the trigger input is too vague, record that explicitly in the brief.
- Add conservative fallback behavior such as:
  - continue with a minimal brief and explicit assumptions
  - optionally fail fast for configuration-controlled trigger classes later
- The brief should never pretend the request was clearer than it was.

5. Dry-run visibility
- Add a CLI/debug path to inspect the compiled brief without running the backend, for example:
  - `rascal run --dry-run-brief`
  - `rascal brief issue OWNER/REPO#123`
- The output should show both the normalized brief and the raw source summary.

6. Prompt assembly integration
- Thread the compiled brief into the existing run artifact generation and prompt assembly flow.
- Keep backend-specific prompt formatting separate from the brief compiler itself.
- The backend should receive the normalized brief as the primary execution contract.

## Suggested implementation approach
1. Add a small internal planning package.
- Separate source loading, normalization, extraction, and rendering.
- Model a stable `RunBrief` type with explicit provenance.

2. Keep extraction heuristics shallow and deterministic.
- Prefer regex/tokenization/markdown-structure parsing over opaque model-based rewriting.
- If later model-assisted planning is added, it should layer on top of this deterministic base.

3. Preserve provenance.
- Each field in the brief should be traceable to a raw source or a deterministic derivation.
- Ambiguous derived fields should carry an explanation.

4. Integrate cleanly with #119.
- The run brief describes what needs to be done.
- The context pack describes what repo guidance should accompany it.
- Do not collapse the two concerns into one artifact.

5. Make failures explicit.
- If source loading from GitHub fails, surface that as a planning error with a clear reason.
- Avoid silently compiling partial briefs that look authoritative.

## Acceptance criteria
- Rascal can compile raw trigger input into a normalized run brief for all current trigger classes.
- The brief is persisted as explicit JSON and Markdown artifacts in the run directory.
- The compiled brief preserves provenance and ambiguity notes.
- Operators can inspect the brief without starting a backend run.
- Backend prompt assembly uses the run brief as a first-class input.
- Tests cover manual tasks, issue-driven runs, PR feedback runs, ambiguity handling, and artifact rendering.

## Suggested test plan
- Unit tests for markdown extraction and path/reference detection.
- Unit tests for trigger-specific brief compilation.
- Integration tests for issue/comment/review payloads producing stable `run-brief.json` output.
- Regression tests for noisy GitHub comments that include quoted text or code fences.
- CLI tests for dry-run brief inspection.

## Implementation notes
- The brief compiler should clarify intent, not invent it.
- Keep the initial schema small enough that humans will actually read it during debugging.
- A dependable deterministic planner is more valuable here than a clever but unstable one.


## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run `make lint` and `make test` before finishing if those targets exist.
- If one of those commands does not exist or cannot run, explain exactly why and run the closest equivalent checks instead.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label &#39;rascal&#39; on issue #162


Assistant: 
Image files: 0
============================
{&#34;type&#34;:&#34;message&#34;,&#34;message&#34;:{&#34;id&#34;:null,&#34;role&#34;:&#34;assistant&#34;,&#34;created&#34;:1773592895,&#34;content&#34;:[{&#34;type&#34;:&#34;text&#34;,&#34;text&#34;:&#34;I’m implementing the run-brief compiler and threading it through the existing run flow. First I’m mapping the current trigger, artifact, and prompt-assembly code so the change stays minimal and lands in the right seams.\n\nI’ve located the main seams: CLI run entrypoints in `cmd/rascal`, webhook-triggered run creation in `cmd/rascald`, and artifact/prompt setup under `internal/worker`. Next I’m reading those paths closely to see where raw trigger text currently flows straight into execution.\n\nThe current path is straightforward: `RunRequest` stores only `Instruction` and `Context`, then `writeRunFiles` emits `context.json` plus `instructions.md`. I’m reading those constructors now so I can introduce a first-class brief without widening the surface more than necessary.\n\nI have enough context to outline the implementation shape:\n\n1. Add `internal/planning` with a compact `RunBrief` schema, normalized source model, shallow markdown/path extraction, JSON/Markdown rendering, and a compiler from trigger input to brief.\n2. Extend `RunRequest` and run-file generation to persist `run-brief.json` and `run-brief.md`, while keeping existing `instruction/context` fields for compatibility.\n3. Compile briefs at creation sites: manual CLI/API runs, issue-backed runs, and webhook PR feedback flows, with source provenance and explicit ambiguity notes.\n4. Thread the brief into prompt assembly by making `instructions.md` render from the compiled brief rather than raw instruction/context text.\n5. Add dry-run inspection on the CLI, most likely `rascal run --dry-run-brief` for manual and `--issue` flows, plus tests around compilation, rendering, and CLI output.\n6. Finish with repo checks and the required `/rascal-meta/commit_message.txt`.\n\nI’m moving into the planning package and run-creation edits now.\n\nI’m at the point of adding the new planning layer and artifact writers. The next edits create the compiler package, then I’ll wire it into run creation and the CLI dry-run path.\n\nThe compiler package is in place. I’m wiring it into the orchestrator now so every run gets a compiled brief and the existing `instructions.md` starts rendering from that normalized brief instead of raw task text alone.\n\nI’ve finished the server-side brief compilation path. The remaining major piece is the operator-facing inspection flow in `rascal run --dry-run-brief`, then I’ll add tests around both the compiler and the new artifacts.\n\nThe run flow and CLI dry-run wiring are in place. I’m formatting and compiling next to catch integration mistakes before I add the test coverage this feature needs.\n\nThe first compile pass didn’t surface output, which usually means it’s still chewing through the full package graph. I’m narrowing to targeted package builds now so I can get actionable errors faster instead of waiting on the whole repo.\n\nThe code compiles across the touched packages now. I’m adding focused tests for the new compiler behavior, artifact writing, and the CLI dry-run path before I run the full repo checks.\n\nI’ve got focused tests passing on the new code paths. The last step is the repo-level verification the task asked for: `make lint` and `make test`, then I’ll write the conventional commit message file.\n\nImplemented a deterministic planning layer and threaded it through run creation.\n\n- Added `internal/planning` to normalize trigger input, extract shallow markdown structure, detect file/path references, record ambiguities/assumptions, and render JSON/Markdown briefs in [`internal/planning/compile.go`](/work/repo/internal/planning/compile.go#L13) and related files.\n- Every run now writes `trigger-input.json`, `run-brief.json`, and `run-brief.md`, and `instructions.md` is rendered from the normalized brief before agent execution in [`internal/orchestrator/runs.go`](/work/repo/internal/orchestrator/runs.go#L16).\n- API/manual runs, issue-backed runs, and webhook PR feedback flows now compile richer source-aware briefs before queuing runs in [`internal/orchestrator/api.go`](/work/repo/internal/orchestrator/api.go#L48) and [`internal/orchestrator/webhook.go`](/work/repo/internal/orchestrator/webhook.go#L96).\n- Added operator inspection endpoints plus `rascal run --dry-run-brief` in [`cmd/rascal/main.go`](/work/repo/cmd/rascal/main.go#L900), and updated the run help snapshot at [`cmd/rascal/testdata/help/run.golden`](/work/repo/cmd/rascal/testdata/help/run.golden).\n\nTests were added/updated in [`internal/planning/compile_test.go`](/work/repo/internal/planning/compile_test.go), [`cmd/rascal/main_test.go`](/work/repo/cmd/rascal/main_test.go), and [`cmd/rascald/main_test.go`](/work/repo/cmd/rascald/main_test.go). Verification passed with `make lint` and `make test`.\n\nThe required commit message was written to [`/rascal-meta/commit_message.txt`](/rascal-meta/commit_message.txt).&#34;}],&#34;metadata&#34;:{&#34;userVisible&#34;:true,&#34;agentVisible&#34;:true}}}
{&#34;type&#34;:&#34;complete&#34;,&#34;total_tokens&#34;:11364737}
</code></pre>

</details>

Closes #162

---

Rascal run `run_8eb3f7257e3d893c` completed in 22m 59s · 11.36M tokens