### PR TITLE
feat(review): add PR review handoff metadata

### DIFF
--- a/cmd/rascal-runner/main_test.go
+++ b/cmd/rascal-runner/main_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/rtzll/rascal/internal/reviewhandoff"
 	"github.com/rtzll/rascal/internal/runner"
 	"github.com/rtzll/rascal/internal/runtime"
 	"github.com/rtzll/rascal/internal/runtrigger"
@@ -1224,6 +1225,15 @@ func TestRunEndToEndWithFakeCommands(t *testing.T) {
 			t.Fatalf("mkdir %s: %v", dir, err)
 		}
 	}
+	if err := os.MkdirAll(filepath.Join(repoDir, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir repo git dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(repoDir, ".github"), 0o755); err != nil {
+		t.Fatalf("mkdir codeowners dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, ".github", "CODEOWNERS"), []byte("/internal/worker/ @octo/reviewers\n"), 0o644); err != nil {
+		t.Fatalf("write CODEOWNERS: %v", err)
+	}
 
 	writeExe(t, filepath.Join(binDir, "git"), fmt.Sprintf(`#!/usr/bin/env bash
 set -eu
@@ -1246,7 +1256,15 @@ case "$cmd" in
     mkdir -p "$target/.git"
     exit 0
     ;;
+  diff)
+    printf '12\t1\tinternal/worker/worker.go\n3\t0\tinternal/worker/worker_test.go\n'
+    exit 0
+    ;;
   fetch|pull|checkout|add|commit|push)
+    exit 0
+    ;;
+  log)
+    printf 'Alice <alice@users.noreply.github.com>\nAlice <alice@users.noreply.github.com>\n'
     exit 0
     ;;
   status)
@@ -1390,6 +1408,107 @@ printf '{"event":"message","usage":{"total_tokens":321}}'"\n"
 	}
 	if !strings.Contains(prBody, "Rascal run `run_fake` completed in ") || !strings.Contains(prBody, "· 321 tokens") {
 		t.Fatalf("expected token summary in pr body:\n%s", prBody)
+	}
+	if !strings.Contains(prBody, "## Review Handoff") || !strings.Contains(prBody, reviewhandoff.PRSectionStartMarker) {
+		t.Fatalf("expected review handoff section in pr body:\n%s", prBody)
+	}
+
+	report, ok, err := reviewhandoff.ReadReport(metaDir)
+	if err != nil {
+		t.Fatalf("read review handoff: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected persisted review handoff artifact")
+	}
+	if len(report.SuggestedReviewers) == 0 || report.SuggestedReviewers[0].Reviewer != "@octo/reviewers" {
+		t.Fatalf("unexpected reviewer suggestions: %#v", report.SuggestedReviewers)
+	}
+}
+
+func TestRunWithExecutorUpdatesExistingPRReviewHandoffIdempotently(t *testing.T) {
+	metaDir := filepath.Join(t.TempDir(), "meta")
+	workRoot := filepath.Join(t.TempDir(), "work")
+	repoDir := filepath.Join(workRoot, "repo")
+	if err := os.MkdirAll(filepath.Join(repoDir, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir repo git dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(repoDir, ".github"), 0o755); err != nil {
+		t.Fatalf("mkdir codeowners dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, ".github", "CODEOWNERS"), []byte("/internal/worker/ @octo/reviewers\n"), 0o644); err != nil {
+		t.Fatalf("write CODEOWNERS: %v", err)
+	}
+
+	t.Setenv("RASCAL_RUN_ID", "run_existing_pr")
+	t.Setenv("RASCAL_TASK_ID", "task_existing_pr")
+	t.Setenv("RASCAL_REPO", "owner/repo")
+	t.Setenv("GH_TOKEN", "token")
+	t.Setenv("RASCAL_INSTRUCTION", "Refresh review handoff")
+	t.Setenv("RASCAL_AGENT_RUNTIME", "goose")
+	t.Setenv("RASCAL_META_DIR", metaDir)
+	t.Setenv("RASCAL_WORK_ROOT", workRoot)
+	t.Setenv("RASCAL_REPO_DIR", repoDir)
+
+	var editedBodies []string
+	ex := fakeExecutor{
+		combinedFn: func(_ string, _ []string, name string, args ...string) (string, error) {
+			switch {
+			case name == "gh" && len(args) >= 2 && args[0] == "api" && args[1] == "user":
+				return `{"login":"rascalbot"}`, nil
+			case name == "gh" && len(args) >= 2 && args[0] == "pr" && args[1] == "view":
+				return `{"number":88,"url":"https://github.com/owner/repo/pull/88","body":"Existing intro\n\n` + reviewhandoff.PRSectionStartMarker + `\n## Review Handoff\n- stale\n` + reviewhandoff.PRSectionEndMarker + `\n\n---\n\nFooter"}`, nil
+			case name == "gh" && len(args) >= 2 && args[0] == "pr" && args[1] == "edit":
+				bodyPath := ""
+				for i := 0; i < len(args)-1; i++ {
+					if args[i] == "--body-file" {
+						bodyPath = args[i+1]
+					}
+				}
+				if bodyPath == "" {
+					t.Fatalf("missing --body-file in gh pr edit args: %v", args)
+				}
+				data, err := os.ReadFile(bodyPath)
+				if err != nil {
+					t.Fatalf("read body file: %v", err)
+				}
+				editedBodies = append(editedBodies, string(data))
+				return "", nil
+			case name == "git" && len(args) >= 2 && args[0] == "status" && args[1] == "--porcelain":
+				return " M internal/worker/worker.go\n", nil
+			case name == "git" && len(args) >= 4 && args[0] == "rev-list" && args[1] == "--left-right" && args[2] == "--count":
+				return "0 1", nil
+			case name == "git" && len(args) >= 2 && args[0] == "rev-parse" && args[1] == "HEAD":
+				return "0123456789abcdef0123456789abcdef01234567", nil
+			case name == "git" && len(args) >= 2 && args[0] == "diff" && args[1] == "--numstat":
+				return "10\t2\tinternal/worker/worker.go\n", nil
+			case name == "git" && len(args) >= 2 && args[0] == "log":
+				return "Alice <alice@users.noreply.github.com>\nAlice <alice@users.noreply.github.com>\n", nil
+			default:
+				return "", nil
+			}
+		},
+		runFn: func(_ string, _ []string, stdout, _ io.Writer, name string, _ ...string) error {
+			if name != "goose" {
+				return nil
+			}
+			if _, err := io.WriteString(stdout, `{"event":"message","usage":{"total_tokens":55}}`+"\n"); err != nil {
+				return fmt.Errorf("write fake goose log: %w", err)
+			}
+			return nil
+		},
+	}
+
+	if err := worker.RunWithExecutor(ex); err != nil {
+		t.Fatalf("runWithExecutor returned error: %v", err)
+	}
+	if len(editedBodies) != 1 {
+		t.Fatalf("expected exactly one PR body update, got %d", len(editedBodies))
+	}
+	if strings.Count(editedBodies[0], reviewhandoff.PRSectionStartMarker) != 1 {
+		t.Fatalf("expected one managed review handoff section, got:\n%s", editedBodies[0])
+	}
+	if !strings.Contains(editedBodies[0], "Footer") {
+		t.Fatalf("expected footer to be preserved, got:\n%s", editedBodies[0])
 	}
 }
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/rtzll/rascal/internal/runtime"
+	"github.com/rtzll/rascal/internal/reviewhandoff"
 	"github.com/rtzll/rascal/internal/runtrigger"
 	"github.com/rtzll/rascal/internal/state"
 )
@@ -50,7 +51,8 @@ type CreateIssueTaskRequest struct {
 }
 
 type RunResponse struct {
-	Run state.Run `json:"run" toml:"run"`
+	Run           state.Run             `json:"run" toml:"run"`
+	ReviewHandoff *reviewhandoff.Report `json:"review_handoff,omitempty" toml:"review_handoff,omitempty"`
 }
 
 type RunsResponse struct {

--- a/internal/orchestrator/api.go
+++ b/internal/orchestrator/api.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rtzll/rascal/internal/api"
 	ghapi "github.com/rtzll/rascal/internal/github"
 	"github.com/rtzll/rascal/internal/logs"
+	"github.com/rtzll/rascal/internal/reviewhandoff"
 	"github.com/rtzll/rascal/internal/runtrigger"
 	"github.com/rtzll/rascal/internal/state"
 )
@@ -631,7 +632,16 @@ func (s *Server) HandleGetRun(w http.ResponseWriter, runID string) {
 		http.Error(w, "run not found", http.StatusNotFound)
 		return
 	}
-	writeJSON(w, http.StatusOK, api.RunResponse{Run: run})
+	report, found, err := reviewhandoff.ReadReport(run.RunDir)
+	if err != nil {
+		http.Error(w, "failed to load review handoff", http.StatusInternalServerError)
+		return
+	}
+	resp := api.RunResponse{Run: run}
+	if found {
+		resp.ReviewHandoff = &report
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 func (s *Server) HandleCancelRun(w http.ResponseWriter, runID string) {

--- a/internal/orchestrator/api_reviewhandoff_test.go
+++ b/internal/orchestrator/api_reviewhandoff_test.go
@@ -1,0 +1,72 @@
+package orchestrator
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/rtzll/rascal/internal/api"
+	"github.com/rtzll/rascal/internal/config"
+	"github.com/rtzll/rascal/internal/reviewhandoff"
+	"github.com/rtzll/rascal/internal/runtime"
+	"github.com/rtzll/rascal/internal/state"
+)
+
+func TestHandleGetRunIncludesReviewHandoff(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "state.db")
+	store, err := state.New(statePath, 20)
+	if err != nil {
+		t.Fatalf("open state store: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Fatalf("close state store: %v", err)
+		}
+	})
+
+	runDir := filepath.Join(t.TempDir(), "run")
+	if err := reviewhandoff.WriteArtifacts(runDir, reviewhandoff.Analyze(reviewhandoff.Input{
+		BaseRef: "main",
+		HeadRef: "HEAD",
+		ChangedFiles: []reviewhandoff.ChangedFile{
+			{Path: "internal/worker/worker.go"},
+			{Path: "internal/worker/worker_test.go"},
+		},
+	})); err != nil {
+		t.Fatalf("write review handoff: %v", err)
+	}
+
+	run, err := store.AddRun(state.CreateRunInput{
+		ID:           "run_review_handoff",
+		TaskID:       "task_review_handoff",
+		Repo:         "owner/repo",
+		Instruction:  "Add review handoff",
+		AgentRuntime: runtime.RuntimeGooseCodex,
+		BaseBranch:   "main",
+		HeadBranch:   "rascal/run_review_handoff",
+		RunDir:       runDir,
+	})
+	if err != nil {
+		t.Fatalf("add run: %v", err)
+	}
+
+	srv := NewServer(config.ServerConfig{}, store, nil, nil, nil, nil, "test-instance")
+	rec := httptest.NewRecorder()
+	srv.HandleGetRun(rec, run.ID)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	var resp api.RunResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.ReviewHandoff == nil {
+		t.Fatalf("expected review handoff payload, got nil")
+	}
+	if resp.ReviewHandoff.Risk.Level == "" {
+		t.Fatalf("expected risk level in payload, got %#v", resp.ReviewHandoff)
+	}
+}

--- a/internal/reviewhandoff/reviewhandoff.go
+++ b/internal/reviewhandoff/reviewhandoff.go
@@ -1,0 +1,739 @@
+package reviewhandoff
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const (
+	ArtifactJSONFile = "review-handoff.json"
+	ArtifactMDFile   = "review-handoff.md"
+
+	PRSectionStartMarker = "<!-- rascal:review-handoff:start -->"
+	PRSectionEndMarker   = "<!-- rascal:review-handoff:end -->"
+)
+
+var (
+	whitespacePattern  = regexp.MustCompile(`\s+`)
+	reviewerEmailRegex = regexp.MustCompile(`(?i)(?:\d+\+)?([a-z0-9][a-z0-9-]*)@users\.noreply\.github\.com`)
+	reviewerNameRegex  = regexp.MustCompile(`^@?[a-z0-9][a-z0-9-]*$`)
+	reviewerTeamRegex  = regexp.MustCompile(`^@?[a-z0-9][a-z0-9-]*/[a-z0-9][a-z0-9._-]*$`)
+)
+
+type ChangedFile struct {
+	Path    string `json:"path"`
+	Added   int    `json:"added,omitempty"`
+	Deleted int    `json:"deleted,omitempty"`
+}
+
+type HistoryTouch struct {
+	Path     string
+	Reviewer string
+}
+
+type Input struct {
+	BaseRef           string
+	HeadRef           string
+	ChangedFiles      []ChangedFile
+	Codeowners        string
+	History           []HistoryTouch
+	ExcludedReviewers []string
+}
+
+type Report struct {
+	SuggestedReviewers []ReviewerSuggestion `json:"suggested_reviewers,omitempty"`
+	ReviewerSummary    string               `json:"reviewer_summary"`
+	Risk               Risk                 `json:"risk"`
+	ChangedPaths       ChangedPathSummary   `json:"changed_paths"`
+	NotableSignals     []string             `json:"notable_signals,omitempty"`
+}
+
+type ReviewerSuggestion struct {
+	Reviewer   string   `json:"reviewer"`
+	Confidence string   `json:"confidence"`
+	Reasons    []string `json:"reasons"`
+}
+
+type Risk struct {
+	Level   string   `json:"level"`
+	Score   int      `json:"score"`
+	Reasons []string `json:"reasons"`
+}
+
+type ChangedPathSummary struct {
+	BaseRef               string   `json:"base_ref,omitempty"`
+	HeadRef               string   `json:"head_ref,omitempty"`
+	FilesChanged          int      `json:"files_changed"`
+	DirectoriesChanged    int      `json:"directories_changed"`
+	Areas                 []string `json:"areas,omitempty"`
+	SamplePaths           []string `json:"sample_paths,omitempty"`
+	TestFilesChanged      bool     `json:"test_files_changed"`
+	ProductionCodeChanged bool     `json:"production_code_changed"`
+}
+
+type reviewerCandidate struct {
+	reviewer        string
+	confidenceRank  int
+	codeownersPaths map[string]struct{}
+	historyPaths    map[string]struct{}
+	historyTouches  int
+}
+
+type codeownersRule struct {
+	owners []string
+	regex  *regexp.Regexp
+}
+
+func Analyze(input Input) Report {
+	changed := normalizeChangedFiles(input.ChangedFiles)
+	summary := buildChangedPathSummary(input.BaseRef, input.HeadRef, changed)
+	risk, signals := classifyRisk(changed, summary)
+	reviewers, reviewerSummary := suggestReviewers(changed, input.Codeowners, input.History, input.ExcludedReviewers)
+	return Report{
+		SuggestedReviewers: reviewers,
+		ReviewerSummary:    reviewerSummary,
+		Risk:               risk,
+		ChangedPaths:       summary,
+		NotableSignals:     signals,
+	}
+}
+
+func ArtifactPaths(dir string) (jsonPath, markdownPath string) {
+	root := strings.TrimSpace(dir)
+	return filepath.Join(root, ArtifactJSONFile), filepath.Join(root, ArtifactMDFile)
+}
+
+func WriteArtifacts(dir string, report Report) error {
+	jsonPath, markdownPath := ArtifactPaths(dir)
+	if err := os.MkdirAll(strings.TrimSpace(dir), 0o755); err != nil {
+		return fmt.Errorf("create review handoff directory: %w", err)
+	}
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode review handoff json: %w", err)
+	}
+	if err := os.WriteFile(jsonPath, data, 0o644); err != nil {
+		return fmt.Errorf("write review handoff json: %w", err)
+	}
+	if err := os.WriteFile(markdownPath, []byte(RenderMarkdown(report)), 0o644); err != nil {
+		return fmt.Errorf("write review handoff markdown: %w", err)
+	}
+	return nil
+}
+
+func ReadReport(dir string) (Report, bool, error) {
+	jsonPath, _ := ArtifactPaths(dir)
+	data, err := os.ReadFile(jsonPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Report{}, false, nil
+		}
+		return Report{}, false, fmt.Errorf("read review handoff json: %w", err)
+	}
+	var report Report
+	if err := json.Unmarshal(data, &report); err != nil {
+		return Report{}, false, fmt.Errorf("decode review handoff json: %w", err)
+	}
+	return report, true, nil
+}
+
+func RenderMarkdown(report Report) string {
+	lines := []string{
+		"# Review Handoff",
+		"",
+		fmt.Sprintf("- Risk: `%s` (score %d)", report.Risk.Level, report.Risk.Score),
+		fmt.Sprintf("- Reviewer routing: %s", report.ReviewerSummary),
+		fmt.Sprintf("- Changed paths: %d files across %d directories", report.ChangedPaths.FilesChanged, report.ChangedPaths.DirectoriesChanged),
+	}
+	if len(report.ChangedPaths.Areas) > 0 {
+		lines = append(lines, fmt.Sprintf("- Areas: %s", strings.Join(backtickJoin(report.ChangedPaths.Areas), ", ")))
+	}
+	lines = append(lines, "")
+	lines = append(lines, "## Suggested Reviewers", "")
+	if len(report.SuggestedReviewers) == 0 {
+		lines = append(lines, "- None")
+	} else {
+		for _, reviewer := range report.SuggestedReviewers {
+			lines = append(lines, fmt.Sprintf("- %s (%s): %s", reviewer.Reviewer, reviewer.Confidence, strings.Join(reviewer.Reasons, "; ")))
+		}
+	}
+	lines = append(lines, "", "## Risk Reasons", "")
+	for _, reason := range report.Risk.Reasons {
+		lines = append(lines, "- "+reason)
+	}
+	lines = append(lines, "", "## Signals", "")
+	for _, signal := range report.NotableSignals {
+		lines = append(lines, "- "+signal)
+	}
+	if len(report.ChangedPaths.SamplePaths) > 0 {
+		lines = append(lines, "", "## Sample Paths", "")
+		for _, path := range report.ChangedPaths.SamplePaths {
+			lines = append(lines, "- `"+path+"`")
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func RenderPRSection(report Report) string {
+	reviewerSummary := report.ReviewerSummary
+	if len(report.SuggestedReviewers) > 0 {
+		names := make([]string, 0, len(report.SuggestedReviewers))
+		for _, reviewer := range report.SuggestedReviewers {
+			names = append(names, reviewer.Reviewer)
+		}
+		reviewerSummary = strings.Join(names, ", ")
+	}
+
+	signals := report.NotableSignals
+	if len(signals) > 3 {
+		signals = signals[:3]
+	}
+	lines := []string{
+		PRSectionStartMarker,
+		"## Review Handoff",
+		fmt.Sprintf("- Risk: `%s` (score %d)", report.Risk.Level, report.Risk.Score),
+		fmt.Sprintf("- Suggested reviewers: %s", reviewerSummary),
+		fmt.Sprintf("- Changed paths: %d files across %d directories", report.ChangedPaths.FilesChanged, report.ChangedPaths.DirectoriesChanged),
+	}
+	if len(report.ChangedPaths.Areas) > 0 {
+		lines = append(lines, fmt.Sprintf("- Areas: %s", strings.Join(backtickJoin(report.ChangedPaths.Areas), ", ")))
+	}
+	if len(signals) > 0 {
+		lines = append(lines, fmt.Sprintf("- Signals: %s", strings.Join(signals, "; ")))
+	}
+	lines = append(lines, PRSectionEndMarker)
+	return strings.Join(lines, "\n")
+}
+
+func UpsertPRSection(body string, report Report) string {
+	return UpsertManagedSection(body, RenderPRSection(report))
+}
+
+func UpsertManagedSection(body, section string) string {
+	body = strings.TrimSpace(body)
+	section = strings.TrimSpace(section)
+	if section == "" {
+		return body
+	}
+
+	start := strings.Index(body, PRSectionStartMarker)
+	end := strings.Index(body, PRSectionEndMarker)
+	if start >= 0 && end >= start {
+		end += len(PRSectionEndMarker)
+		updated := strings.TrimSpace(body[:start])
+		tail := strings.TrimSpace(body[end:])
+		switch {
+		case updated == "" && tail == "":
+			return section
+		case updated == "":
+			return strings.TrimSpace(section + "\n\n" + tail)
+		case tail == "":
+			return strings.TrimSpace(updated + "\n\n" + section)
+		default:
+			return strings.TrimSpace(updated + "\n\n" + section + "\n\n" + tail)
+		}
+	}
+
+	footerMarker := "\n\n---\n\n"
+	if idx := strings.Index(body, footerMarker); idx >= 0 {
+		head := strings.TrimSpace(body[:idx])
+		footer := strings.TrimSpace(body[idx+len(footerMarker):])
+		if head == "" {
+			return strings.TrimSpace(section + footerMarker + footer)
+		}
+		return strings.TrimSpace(head + "\n\n" + section + footerMarker + footer)
+	}
+	if body == "" {
+		return section
+	}
+	return strings.TrimSpace(body + "\n\n" + section)
+}
+
+func normalizeChangedFiles(files []ChangedFile) []ChangedFile {
+	seen := make(map[string]ChangedFile)
+	for _, file := range files {
+		path := cleanPath(file.Path)
+		if path == "" {
+			continue
+		}
+		current := seen[path]
+		current.Path = path
+		current.Added += max(file.Added, 0)
+		current.Deleted += max(file.Deleted, 0)
+		seen[path] = current
+	}
+	out := make([]ChangedFile, 0, len(seen))
+	for _, file := range seen {
+		out = append(out, file)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+	return out
+}
+
+func buildChangedPathSummary(baseRef, headRef string, changed []ChangedFile) ChangedPathSummary {
+	dirs := make(map[string]struct{})
+	areas := make(map[string]struct{})
+	samplePaths := make([]string, 0, len(changed))
+	testFilesChanged := false
+	productionCodeChanged := false
+	for _, file := range changed {
+		dir := filepath.ToSlash(filepath.Dir(file.Path))
+		if dir == "." {
+			dir = "."
+		}
+		dirs[dir] = struct{}{}
+		areas[topLevelArea(file.Path)] = struct{}{}
+		if len(samplePaths) < 8 {
+			samplePaths = append(samplePaths, file.Path)
+		}
+		if isTestPath(file.Path) {
+			testFilesChanged = true
+		}
+		if isProductionCodePath(file.Path) {
+			productionCodeChanged = true
+		}
+	}
+	areaList := make([]string, 0, len(areas))
+	for area := range areas {
+		areaList = append(areaList, area)
+	}
+	sort.Strings(areaList)
+	return ChangedPathSummary{
+		BaseRef:               strings.TrimSpace(baseRef),
+		HeadRef:               strings.TrimSpace(headRef),
+		FilesChanged:          len(changed),
+		DirectoriesChanged:    len(dirs),
+		Areas:                 areaList,
+		SamplePaths:           samplePaths,
+		TestFilesChanged:      testFilesChanged,
+		ProductionCodeChanged: productionCodeChanged,
+	}
+}
+
+func classifyRisk(changed []ChangedFile, summary ChangedPathSummary) (Risk, []string) {
+	score := 0
+	reasons := make([]string, 0, 6)
+	signals := make([]string, 0, 6)
+
+	addReason := func(points int, reason string) {
+		if points > 0 {
+			score += points
+		}
+		reasons = append(reasons, reason)
+	}
+
+	filesChanged := summary.FilesChanged
+	switch {
+	case filesChanged >= 12:
+		addReason(2, fmt.Sprintf("Large diff touching %d files.", filesChanged))
+	case filesChanged >= 5:
+		addReason(1, fmt.Sprintf("Diff touches %d files.", filesChanged))
+	default:
+		addReason(0, fmt.Sprintf("Diff touches %d files.", filesChanged))
+	}
+
+	switch {
+	case summary.DirectoriesChanged >= 5:
+		addReason(2, fmt.Sprintf("Cross-cutting change across %d directories.", summary.DirectoriesChanged))
+	case summary.DirectoriesChanged >= 3:
+		addReason(1, fmt.Sprintf("Change spans %d directories.", summary.DirectoriesChanged))
+	}
+
+	configPaths := collectMatchingPaths(changed, isConfigOrRuntimePath, 3)
+	if len(configPaths) > 0 {
+		addReason(2, fmt.Sprintf("Config/deploy/runtime files changed: %s.", strings.Join(backtickJoin(configPaths), ", ")))
+		signals = append(signals, "Config/deploy/runtime files changed")
+	}
+
+	sensitivePaths := collectMatchingPaths(changed, isSensitivePath, 3)
+	if len(sensitivePaths) > 0 {
+		addReason(2, fmt.Sprintf("Infra or security-sensitive paths changed: %s.", strings.Join(backtickJoin(sensitivePaths), ", ")))
+		signals = append(signals, "Infra/security-sensitive paths changed")
+	}
+
+	if summary.ProductionCodeChanged && !summary.TestFilesChanged {
+		addReason(2, "Production code changed without test updates.")
+		signals = append(signals, "Tests not changed")
+	} else if summary.TestFilesChanged {
+		signals = append(signals, "Tests changed")
+	}
+
+	if len(summary.Areas) >= 3 {
+		signals = append(signals, fmt.Sprintf("Cross-cutting diff across %s", strings.Join(backtickJoin(summary.Areas[:min(len(summary.Areas), 3)]), ", ")))
+	}
+	if summary.ProductionCodeChanged {
+		signals = append(signals, "Production code changed")
+	}
+
+	level := "low"
+	switch {
+	case score >= 5:
+		level = "high"
+	case score >= 2:
+		level = "medium"
+	}
+
+	if len(reasons) == 0 {
+		reasons = append(reasons, "No elevated risk signals detected.")
+	}
+	return Risk{
+		Level:   level,
+		Score:   score,
+		Reasons: reasons,
+	}, uniqueStrings(signals)
+}
+
+func suggestReviewers(changed []ChangedFile, codeowners string, history []HistoryTouch, excluded []string) ([]ReviewerSuggestion, string) {
+	excludedSet := make(map[string]struct{}, len(excluded))
+	for _, reviewer := range excluded {
+		if normalized := normalizeReviewer(reviewer); normalized != "" {
+			excludedSet[normalized] = struct{}{}
+		}
+	}
+
+	candidates := make(map[string]*reviewerCandidate)
+	if strings.TrimSpace(codeowners) != "" {
+		rules := parseCODEOWNERS(codeowners)
+		for _, file := range changed {
+			for _, reviewer := range matchCODEOWNERS(rules, file.Path) {
+				normalized := normalizeReviewer(reviewer)
+				if normalized == "" {
+					continue
+				}
+				if _, skip := excludedSet[normalized]; skip {
+					continue
+				}
+				candidate := ensureCandidate(candidates, normalized)
+				candidate.confidenceRank = max(candidate.confidenceRank, 2)
+				candidate.codeownersPaths[file.Path] = struct{}{}
+			}
+		}
+	}
+
+	for _, touch := range history {
+		path := cleanPath(touch.Path)
+		if path == "" {
+			continue
+		}
+		normalized := normalizeReviewer(touch.Reviewer)
+		if normalized == "" {
+			continue
+		}
+		if _, skip := excludedSet[normalized]; skip {
+			continue
+		}
+		candidate := ensureCandidate(candidates, normalized)
+		candidate.confidenceRank = max(candidate.confidenceRank, 1)
+		candidate.historyPaths[path] = struct{}{}
+		candidate.historyTouches++
+	}
+
+	ordered := make([]*reviewerCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if len(candidate.codeownersPaths) == 0 && len(candidate.historyPaths) == 0 {
+			continue
+		}
+		ordered = append(ordered, candidate)
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		left := ordered[i]
+		right := ordered[j]
+		if left.confidenceRank != right.confidenceRank {
+			return left.confidenceRank > right.confidenceRank
+		}
+		if len(left.codeownersPaths) != len(right.codeownersPaths) {
+			return len(left.codeownersPaths) > len(right.codeownersPaths)
+		}
+		if len(left.historyPaths) != len(right.historyPaths) {
+			return len(left.historyPaths) > len(right.historyPaths)
+		}
+		if left.historyTouches != right.historyTouches {
+			return left.historyTouches > right.historyTouches
+		}
+		return left.reviewer < right.reviewer
+	})
+
+	if len(ordered) == 0 {
+		return nil, "No high-confidence reviewer suggestion from CODEOWNERS or Git history."
+	}
+	if len(ordered) > 3 {
+		ordered = ordered[:3]
+	}
+
+	out := make([]ReviewerSuggestion, 0, len(ordered))
+	for _, candidate := range ordered {
+		reasons := make([]string, 0, 2)
+		confidence := "medium"
+		if len(candidate.codeownersPaths) > 0 {
+			reasons = append(reasons, fmt.Sprintf("CODEOWNERS matched %d changed path(s)", len(candidate.codeownersPaths)))
+			confidence = "high"
+		}
+		if len(candidate.historyPaths) > 0 {
+			reasons = append(reasons, fmt.Sprintf("recent git history touched %d changed file(s)", len(candidate.historyPaths)))
+		}
+		out = append(out, ReviewerSuggestion{
+			Reviewer:   candidate.reviewer,
+			Confidence: confidence,
+			Reasons:    reasons,
+		})
+	}
+
+	return out, fmt.Sprintf("%d reviewer suggestion(s) from deterministic repo-local signals.", len(out))
+}
+
+func ensureCandidate(candidates map[string]*reviewerCandidate, reviewer string) *reviewerCandidate {
+	if current, ok := candidates[reviewer]; ok {
+		return current
+	}
+	current := &reviewerCandidate{
+		reviewer:        reviewer,
+		codeownersPaths: make(map[string]struct{}),
+		historyPaths:    make(map[string]struct{}),
+	}
+	candidates[reviewer] = current
+	return current
+}
+
+func parseCODEOWNERS(body string) []codeownersRule {
+	lines := strings.Split(body, "\n")
+	out := make([]codeownersRule, 0)
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		owners := make([]string, 0, len(fields)-1)
+		for _, field := range fields[1:] {
+			if strings.HasPrefix(field, "#") {
+				break
+			}
+			owners = append(owners, field)
+		}
+		if len(owners) == 0 {
+			continue
+		}
+		regex, err := compileCODEOWNERSPattern(fields[0])
+		if err != nil {
+			continue
+		}
+		out = append(out, codeownersRule{owners: owners, regex: regex})
+	}
+	return out
+}
+
+func matchCODEOWNERS(rules []codeownersRule, path string) []string {
+	path = cleanPath(path)
+	if path == "" {
+		return nil
+	}
+	var owners []string
+	for _, rule := range rules {
+		if rule.regex.MatchString(path) {
+			owners = rule.owners
+		}
+	}
+	return owners
+}
+
+func compileCODEOWNERSPattern(pattern string) (*regexp.Regexp, error) {
+	pattern = strings.TrimSpace(pattern)
+	if pattern == "" {
+		return nil, fmt.Errorf("empty pattern")
+	}
+	rootAnchored := strings.HasPrefix(pattern, "/")
+	pattern = strings.TrimPrefix(pattern, "/")
+	if strings.HasSuffix(pattern, "/") {
+		pattern += "**"
+	}
+	var builder strings.Builder
+	if rootAnchored {
+		builder.WriteString("^")
+	} else {
+		builder.WriteString("(^|.*/)")
+	}
+	for i := 0; i < len(pattern); {
+		switch {
+		case i+1 < len(pattern) && pattern[i:i+2] == "**":
+			builder.WriteString(".*")
+			i += 2
+		case pattern[i] == '*':
+			builder.WriteString(`[^/]*`)
+			i++
+		case pattern[i] == '?':
+			builder.WriteString(`[^/]`)
+			i++
+		default:
+			builder.WriteString(regexp.QuoteMeta(string(pattern[i])))
+			i++
+		}
+	}
+	builder.WriteString("$")
+	compiled, err := regexp.Compile(builder.String())
+	if err != nil {
+		return nil, fmt.Errorf("compile CODEOWNERS pattern %q: %w", pattern, err)
+	}
+	return compiled, nil
+}
+
+func normalizeReviewer(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if matches := reviewerEmailRegex.FindStringSubmatch(strings.ToLower(raw)); len(matches) == 2 {
+		return "@" + matches[1]
+	}
+	if i := strings.Index(raw, "<"); i >= 0 {
+		if j := strings.Index(raw[i:], ">"); j > 0 {
+			if normalized := normalizeReviewer(raw[i+1 : i+j]); normalized != "" {
+				return normalized
+			}
+		}
+	}
+	raw = strings.TrimPrefix(raw, "@")
+	raw = strings.ToLower(raw)
+	if reviewerTeamRegex.MatchString(raw) || reviewerNameRegex.MatchString(raw) {
+		return "@" + raw
+	}
+	return ""
+}
+
+func cleanPath(path string) string {
+	path = filepath.ToSlash(strings.TrimSpace(path))
+	path = strings.TrimPrefix(path, "./")
+	return strings.Trim(path, "/")
+}
+
+func topLevelArea(path string) string {
+	path = cleanPath(path)
+	if path == "" {
+		return "."
+	}
+	parts := strings.Split(path, "/")
+	return parts[0]
+}
+
+func isTestPath(path string) bool {
+	path = cleanPath(path)
+	lower := strings.ToLower(path)
+	if strings.HasSuffix(lower, "_test.go") {
+		return true
+	}
+	parts := strings.Split(lower, "/")
+	for _, part := range parts {
+		if part == "test" || part == "tests" || part == "__tests__" {
+			return true
+		}
+	}
+	return false
+}
+
+func isProductionCodePath(path string) bool {
+	path = cleanPath(path)
+	if path == "" || isTestPath(path) {
+		return false
+	}
+	lower := strings.ToLower(path)
+	switch {
+	case strings.HasPrefix(lower, "docs/"):
+		return false
+	case strings.HasSuffix(lower, ".md"), strings.HasSuffix(lower, ".txt"), strings.HasSuffix(lower, ".rst"):
+		return false
+	default:
+		return true
+	}
+}
+
+func isConfigOrRuntimePath(path string) bool {
+	lower := strings.ToLower(cleanPath(path))
+	switch {
+	case strings.HasPrefix(lower, ".github/workflows/"):
+		return true
+	case strings.HasPrefix(lower, "deploy/"), strings.HasPrefix(lower, "runner/"):
+		return true
+	case strings.Contains(lower, "dockerfile"), strings.HasSuffix(lower, ".service"), strings.HasSuffix(lower, ".yaml"), strings.HasSuffix(lower, ".yml"), strings.HasSuffix(lower, ".toml"), strings.HasSuffix(lower, ".json"), strings.HasSuffix(lower, ".sql"):
+		return true
+	default:
+		return false
+	}
+}
+
+func isSensitivePath(path string) bool {
+	lower := strings.ToLower(cleanPath(path))
+	switch {
+	case strings.HasPrefix(lower, "internal/credentials/"):
+		return true
+	case strings.HasPrefix(lower, "internal/deploy/"):
+		return true
+	case strings.HasPrefix(lower, "internal/remote/"):
+		return true
+	case strings.HasPrefix(lower, "internal/runner/"):
+		return true
+	case strings.HasPrefix(lower, "cmd/rascald/"):
+		return true
+	default:
+		return false
+	}
+}
+
+func collectMatchingPaths(changed []ChangedFile, match func(string) bool, limit int) []string {
+	out := make([]string, 0, limit)
+	for _, file := range changed {
+		if !match(file.Path) {
+			continue
+		}
+		out = append(out, file.Path)
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out
+}
+
+func backtickJoin(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		out = append(out, "`"+value+"`")
+	}
+	return out
+}
+
+func uniqueStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = whitespacePattern.ReplaceAllString(strings.TrimSpace(value), " ")
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/reviewhandoff/reviewhandoff_test.go
+++ b/internal/reviewhandoff/reviewhandoff_test.go
@@ -1,0 +1,106 @@
+package reviewhandoff
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAnalyzePrefersCODEOWNERSAndHistorySignals(t *testing.T) {
+	report := Analyze(Input{
+		BaseRef: "main",
+		HeadRef: "HEAD",
+		ChangedFiles: []ChangedFile{
+			{Path: "internal/worker/worker.go"},
+			{Path: "internal/worker/worker_test.go"},
+		},
+		Codeowners: "*.go @lang-team\n/internal/worker/ @octo/reviewers\n",
+		History: []HistoryTouch{
+			{Path: "internal/worker/worker.go", Reviewer: "12345+alice@users.noreply.github.com"},
+			{Path: "internal/worker/worker_test.go", Reviewer: "alice@users.noreply.github.com"},
+		},
+	})
+
+	if len(report.SuggestedReviewers) < 2 {
+		t.Fatalf("expected reviewer suggestions, got %#v", report.SuggestedReviewers)
+	}
+	if report.SuggestedReviewers[0].Reviewer != "@octo/reviewers" {
+		t.Fatalf("first reviewer = %q, want CODEOWNERS match", report.SuggestedReviewers[0].Reviewer)
+	}
+	if !strings.Contains(strings.Join(report.SuggestedReviewers[0].Reasons, " "), "CODEOWNERS") {
+		t.Fatalf("expected CODEOWNERS explanation, got %#v", report.SuggestedReviewers[0].Reasons)
+	}
+	foundHistory := false
+	for _, reviewer := range report.SuggestedReviewers {
+		if reviewer.Reviewer == "@alice" {
+			foundHistory = true
+		}
+	}
+	if !foundHistory {
+		t.Fatalf("expected git history suggestion, got %#v", report.SuggestedReviewers)
+	}
+}
+
+func TestAnalyzeNoReviewerFallback(t *testing.T) {
+	report := Analyze(Input{
+		BaseRef: "main",
+		HeadRef: "HEAD",
+		ChangedFiles: []ChangedFile{
+			{Path: "docs/architecture.md"},
+		},
+	})
+
+	if len(report.SuggestedReviewers) != 0 {
+		t.Fatalf("expected no reviewers, got %#v", report.SuggestedReviewers)
+	}
+	if !strings.Contains(report.ReviewerSummary, "No high-confidence reviewer suggestion") {
+		t.Fatalf("unexpected reviewer summary: %q", report.ReviewerSummary)
+	}
+}
+
+func TestAnalyzeClassifiesHighRiskWhenProdChangesSkipTests(t *testing.T) {
+	report := Analyze(Input{
+		BaseRef: "main",
+		HeadRef: "HEAD",
+		ChangedFiles: []ChangedFile{
+			{Path: "cmd/rascald/main.go"},
+			{Path: "internal/credentials/broker.go"},
+			{Path: ".github/workflows/ci.yml"},
+			{Path: "deploy/systemd/rascal@.service"},
+			{Path: "internal/worker/worker.go"},
+		},
+	})
+
+	if report.Risk.Level != "high" {
+		t.Fatalf("risk level = %q, want high (report=%#v)", report.Risk.Level, report)
+	}
+	if !strings.Contains(strings.Join(report.Risk.Reasons, " "), "without test updates") {
+		t.Fatalf("expected missing test reason, got %#v", report.Risk.Reasons)
+	}
+	if !strings.Contains(strings.Join(report.NotableSignals, " "), "Config/deploy/runtime") {
+		t.Fatalf("expected config/runtime signal, got %#v", report.NotableSignals)
+	}
+}
+
+func TestUpsertPRSectionIsIdempotent(t *testing.T) {
+	report := Analyze(Input{
+		BaseRef: "main",
+		HeadRef: "HEAD",
+		ChangedFiles: []ChangedFile{
+			{Path: "internal/worker/worker.go"},
+			{Path: "internal/worker/worker_test.go"},
+		},
+	})
+
+	original := "Existing body\n\n---\n\nFooter"
+	once := UpsertPRSection(original, report)
+	twice := UpsertPRSection(once, report)
+	if once != twice {
+		t.Fatalf("expected stable PR section update\nonce:\n%s\n\ntwice:\n%s", once, twice)
+	}
+	if strings.Count(once, PRSectionStartMarker) != 1 {
+		t.Fatalf("expected exactly one managed section, got:\n%s", once)
+	}
+	if !strings.Contains(once, "\n\n---\n\nFooter") {
+		t.Fatalf("expected footer to be preserved, got:\n%s", once)
+	}
+}

--- a/internal/runsummary/runsummary.go
+++ b/internal/runsummary/runsummary.go
@@ -111,19 +111,26 @@ func renderAgentDetailsSection(gooseOutput string) string {
 	)
 }
 
-func BuildPRBody(runID, commitBody, gooseOutput, runDuration, closesSection string) string {
+func BuildPRBody(runID, commitBody, gooseOutput, runDuration, closesSection string, extraSections ...string) string {
 	gooseSection := renderAgentDetailsSection(gooseOutput)
+	extraBody := strings.TrimSpace(strings.Join(extraSections, "\n\n"))
+	footer := ""
 	if usage, ok := ExtractTokenUsage(gooseOutput); ok {
-		body := ""
-		if strings.TrimSpace(commitBody) != "" {
-			body = commitBody + "\n\n"
-		}
-		body += gooseSection + closesSection + "\n\n---\n\n" + fmt.Sprintf(
+		footer = fmt.Sprintf(
 			"Rascal run `%s` completed in %s · %s tokens",
 			runID,
 			runDuration,
 			formatTokenCount(usage.TotalTokens),
 		)
+		body := ""
+		if strings.TrimSpace(commitBody) != "" {
+			body = commitBody + "\n\n"
+		}
+		body += gooseSection + closesSection
+		if extraBody != "" {
+			body += "\n\n" + extraBody
+		}
+		body += "\n\n---\n\n" + footer
 		return body
 	}
 
@@ -131,7 +138,11 @@ func BuildPRBody(runID, commitBody, gooseOutput, runDuration, closesSection stri
 	if strings.TrimSpace(commitBody) != "" {
 		body = commitBody + "\n\n" + body
 	}
-	body += "\n\n" + gooseSection + closesSection + "\n\n---\n\n" + fmt.Sprintf("Rascal run took %s", runDuration)
+	body += "\n\n" + gooseSection + closesSection
+	if extraBody != "" {
+		body += "\n\n" + extraBody
+	}
+	body += "\n\n---\n\n" + fmt.Sprintf("Rascal run took %s", runDuration)
 	return body
 }
 

--- a/internal/runsummary/runsummary_test.go
+++ b/internal/runsummary/runsummary_test.go
@@ -207,6 +207,23 @@ func TestBuildPRBody(t *testing.T) {
 			t.Fatalf("expected a single outer details close tag:\n%s", body)
 		}
 	})
+
+	t.Run("includes extra review handoff section before footer", func(t *testing.T) {
+		body := BuildPRBody(
+			"run_4",
+			"",
+			`{"usage":{"total_tokens":321}}`,
+			"9s",
+			"",
+			"## Review Handoff\n- Risk: `medium`",
+		)
+		if !strings.Contains(body, "## Review Handoff") {
+			t.Fatalf("missing extra section:\n%s", body)
+		}
+		if !strings.Contains(body, "## Review Handoff\n- Risk: `medium`\n\n---\n\nRascal run `run_4` completed") {
+			t.Fatalf("expected extra section before footer:\n%s", body)
+		}
+	})
 }
 
 func TestBuildCompletionComment(t *testing.T) {

--- a/internal/worker/config.go
+++ b/internal/worker/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	CommitMsgPath    string
 	AgentOutputPath  string
 	PRBodyPath       string
+	ReviewHandoffDir string
 
 	GooseDebug   bool
 	AgentRuntime runtime.Runtime
@@ -146,6 +147,7 @@ func LoadConfig() (Config, error) {
 		CommitMsgPath:    filepath.Join(metaDir, defaultCommitMsgFile),
 		AgentOutputPath:  filepath.Join(metaDir, defaultAgentOutputFile),
 		PRBodyPath:       filepath.Join(metaDir, defaultPRBodyFile),
+		ReviewHandoffDir: metaDir,
 		GooseDebug:       debug,
 		AgentRuntime:     agentRuntime,
 		GoosePathRoot:    goosePathRoot,

--- a/internal/worker/review_handoff.go
+++ b/internal/worker/review_handoff.go
@@ -1,0 +1,136 @@
+package worker
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/rtzll/rascal/internal/reviewhandoff"
+)
+
+func buildReviewHandoff(ex CommandExecutor, cfg Config, excludeReviewer string) (reviewhandoff.Report, error) {
+	changedFiles, err := loadChangedFiles(ex, cfg)
+	if err != nil {
+		return reviewhandoff.Report{}, err
+	}
+
+	codeowners, err := loadCODEOWNERS(cfg.RepoDir)
+	if err != nil {
+		return reviewhandoff.Report{}, err
+	}
+
+	history, err := loadHistoryTouches(ex, cfg, changedFiles)
+	if err != nil {
+		return reviewhandoff.Report{}, err
+	}
+
+	report := reviewhandoff.Analyze(reviewhandoff.Input{
+		BaseRef:           cfg.BaseBranch,
+		HeadRef:           "HEAD",
+		ChangedFiles:      changedFiles,
+		Codeowners:        codeowners,
+		History:           history,
+		ExcludedReviewers: []string{excludeReviewer},
+	})
+	if err := reviewhandoff.WriteArtifacts(cfg.MetaDir, report); err != nil {
+		return reviewhandoff.Report{}, fmt.Errorf("write review handoff artifacts: %w", err)
+	}
+	return report, nil
+}
+
+func loadChangedFiles(ex CommandExecutor, cfg Config) ([]reviewhandoff.ChangedFile, error) {
+	out, err := runCommand(ex, cfg.RepoDir, nil, "git", "diff", "--numstat", cfg.BaseBranch+"...HEAD")
+	if err != nil {
+		return nil, fmt.Errorf("git diff --numstat %s...HEAD: %w", cfg.BaseBranch, err)
+	}
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	changed := make([]reviewhandoff.ChangedFile, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		added := parseNumstatCount(fields[0])
+		deleted := parseNumstatCount(fields[1])
+		path := normalizeNumstatPath(fields[2:])
+		if path == "" {
+			continue
+		}
+		changed = append(changed, reviewhandoff.ChangedFile{
+			Path:    path,
+			Added:   added,
+			Deleted: deleted,
+		})
+	}
+	return changed, nil
+}
+
+func loadCODEOWNERS(repoDir string) (string, error) {
+	for _, candidate := range []string{
+		filepath.Join(repoDir, ".github", "CODEOWNERS"),
+		filepath.Join(repoDir, "CODEOWNERS"),
+		filepath.Join(repoDir, "docs", "CODEOWNERS"),
+	} {
+		data, err := os.ReadFile(candidate)
+		if err == nil {
+			return string(data), nil
+		}
+		if err != nil && !os.IsNotExist(err) {
+			return "", fmt.Errorf("read CODEOWNERS: %w", err)
+		}
+	}
+	return "", nil
+}
+
+func loadHistoryTouches(ex CommandExecutor, cfg Config, changed []reviewhandoff.ChangedFile) ([]reviewhandoff.HistoryTouch, error) {
+	touches := make([]reviewhandoff.HistoryTouch, 0)
+	for _, file := range changed {
+		out, err := runCommand(ex, cfg.RepoDir, nil, "git", "log", "-n", "12", "--format=%an <%ae>%n%cn <%ce>", "--", file.Path)
+		if err != nil {
+			return nil, fmt.Errorf("git log history for %s: %w", file.Path, err)
+		}
+		for _, line := range strings.Split(out, "\n") {
+			reviewer := strings.TrimSpace(line)
+			if reviewer == "" {
+				continue
+			}
+			touches = append(touches, reviewhandoff.HistoryTouch{
+				Path:     file.Path,
+				Reviewer: reviewer,
+			})
+		}
+	}
+	return touches, nil
+}
+
+func parseNumstatCount(raw string) int {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "-" {
+		return 0
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func normalizeNumstatPath(parts []string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	path := strings.TrimSpace(parts[len(parts)-1])
+	if strings.Contains(path, "=>") {
+		if idx := strings.LastIndex(path, "=>"); idx >= 0 {
+			path = path[idx+2:]
+		}
+	}
+	path = strings.Trim(path, "{} ")
+	return strings.TrimSpace(path)
+}

--- a/internal/worker/support.go
+++ b/internal/worker/support.go
@@ -138,7 +138,7 @@ func firstNonEmptyLine(s string) string {
 }
 
 func loadPRView(ex CommandExecutor, cfg Config) (prView, bool, error) {
-	out, err := runCommand(ex, cfg.RepoDir, nil, "gh", "pr", "view", cfg.HeadBranch, "--repo", cfg.Repo, "--json", "number,url")
+	out, err := runCommand(ex, cfg.RepoDir, nil, "gh", "pr", "view", cfg.HeadBranch, "--repo", cfg.Repo, "--json", "number,url,body")
 	if err != nil {
 		return prView{}, false, nil
 	}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rtzll/rascal/internal/reviewhandoff"
 	"github.com/rtzll/rascal/internal/runner"
 	"github.com/rtzll/rascal/internal/runsummary"
 )
@@ -44,6 +45,7 @@ var (
 type prView struct {
 	Number int    `json:"number"`
 	URL    string `json:"url"`
+	Body   string `json:"body"`
 }
 
 type CommandExecutor interface {
@@ -285,6 +287,17 @@ func RunWithExecutor(ex CommandExecutor) error {
 
 	var view prView
 	var found bool
+	var handoff reviewhandoff.Report
+	if err := RunStage("review_handoff", func() error {
+		var err error
+		handoff, err = buildReviewHandoff(ex, cfg, authorName)
+		if err != nil {
+			return fmt.Errorf("build review handoff: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return fail(err)
+	}
 	if err := RunStage("load_pr", func() error {
 		var err error
 		view, found, err = loadPRView(ex, cfg)
@@ -304,7 +317,7 @@ func RunWithExecutor(ex CommandExecutor) error {
 				closesSection = fmt.Sprintf("\n\nCloses #%d", cfg.IssueNumber)
 			}
 			runDuration := runsummary.FormatDuration(int64(time.Since(started).Seconds()))
-			body := runsummary.BuildPRBody(cfg.RunID, commitBody, agentOutput, runDuration, closesSection)
+			body := runsummary.BuildPRBody(cfg.RunID, commitBody, agentOutput, runDuration, closesSection, reviewhandoff.RenderPRSection(handoff))
 			if err := os.WriteFile(cfg.PRBodyPath, []byte(body), 0o644); err != nil {
 				return fmt.Errorf("write pr body: %w", err)
 			}
@@ -333,6 +346,26 @@ func RunWithExecutor(ex CommandExecutor) error {
 						}
 					}
 				}
+			}
+			return nil
+		}); err != nil {
+			return fail(err)
+		}
+	} else {
+		if err := RunStage("pr_update_handoff", func() error {
+			body := reviewhandoff.UpsertPRSection(view.Body, handoff)
+			if strings.TrimSpace(body) == strings.TrimSpace(view.Body) {
+				return nil
+			}
+			if err := os.WriteFile(cfg.PRBodyPath, []byte(body), 0o644); err != nil {
+				return fmt.Errorf("write updated pr body: %w", err)
+			}
+			if _, err := runCommand(ex, cfg.RepoDir, nil, "gh", "pr", "edit",
+				strconv.Itoa(view.Number),
+				"--repo", cfg.Repo,
+				"--body-file", cfg.PRBodyPath,
+			); err != nil {
+				return fmt.Errorf("gh pr edit failed: %w", err)
 			}
 			return nil
 		}); err != nil {


### PR DESCRIPTION
Persist deterministic review handoff artifacts for PR handoff, surface them in
run API output, and keep a managed PR-body section updated with reviewer hints
and risk signals.

<details><summary>Agent Details</summary>

<pre><code>
    __( O)&gt;  ● resuming · codex gpt-5.4
   \____)    20260314_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: &#34;/usr/local/bin/codex&#34;
Model: gpt-5.4
Reasoning effort: high
Skip git check: false
Prompt length: 12599 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Suggestion

The user has 7 extensions with 16 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
Consider asking if they&#39;d like to disable some extensions to improve tool selection accuracy.

# Response Guidelines

Use Markdown formatting for all responses.

Human: &lt;info-msg&gt;
It is currently 2026-03-15 17:47:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

&lt;/info-msg&gt;
# Rascal Run Instructions

Run ID: run_abc074584e7e4c55
Task ID: rtzll/rascal#163
Repository: rtzll/rascal
Issue: #163

## Task

feat(review): add reviewer routing hints and diff risk signals for Rascal PR handoff

## Summary
Rascal can already create or update PRs and move runs into a `review` state, but the handoff to humans is still thin. It does not help prioritize risky diffs, suggest likely reviewers, or distinguish changes that deserve extra attention.

This issue adds a lightweight review-handoff layer that computes routing hints and risk signals when Rascal opens or updates a PR.

## Outcome
When a run reaches PR handoff, Rascal can attach reviewer suggestions, risk metadata, and review-priority signals so the human review step is faster and better targeted.

## Goals
- Improve the quality of the human handoff without turning Rascal into a noisy review bot.
- Surface high-risk changes explicitly.
- Suggest likely reviewers using repository-local signals.
- Keep everything explainable, inspectable, and GitHub-native.
- Preserve conservative defaults and avoid surprise reviewer spam.

## Non-goals
- Building a full inbox product with calendars, timezones, or org graphs.
- Auto-approving or auto-merging PRs.
- Replacing CODEOWNERS or branch protection.
- Emitting large volumes of AI-generated inline review comments.

## Scope
Implement V1 review-handoff support with the following behavior.

1. Review handoff artifact
- Persist explicit handoff metadata in the run directory, for example:
  - `review-handoff.json`
  - `review-handoff.md`
- Include at least:
  - suggested reviewers
  - risk score or risk level
  - reasons for the risk classification
  - changed path summary
  - notable signals such as tests changed or not changed

2. Reviewer suggestion heuristics
- Suggest reviewers from a small, deterministic set of signals such as:
  - CODEOWNERS matches when available
  - recent file-touch history within the repo
  - previous PR author/reviewer activity for the same area
- Keep the heuristics explainable and stable.
- If no high-confidence suggestion exists, record that explicitly instead of guessing.

3. Risk classification
- Compute a compact risk classification such as `low`, `medium`, `high`.
- V1 signals may include:
  - number of files changed
  - number of directories or packages touched
  - presence of config/deploy/runtime files
  - changes in security-sensitive or infra-sensitive paths
  - missing test deltas for production code changes
  - cross-cutting changes spanning multiple areas
- Keep the scoring heuristic simple and visible in the artifact.

4. GitHub presentation
- Add the handoff summary to the PR body or completion comment in a concise way.
- Optionally add conservative labels such as:
  - `rascal:risk-high`
  - `rascal:needs-review`
- Do not request reviewers automatically in V1 unless explicitly configured.
- Start with suggestions and metadata, not side effects.

5. CLI/API visibility
- Expose handoff metadata through API/JSON output and optionally a CLI view command.
- Operators should be able to inspect why Rascal considered a change risky.

6. Notification hygiene
- Ensure handoff metadata updates are idempotent when Rascal revises an existing PR.
- Avoid posting duplicate comments or churning labels on every follow-up run.

## Suggested implementation approach
1. Add a small review-handoff package.
- Separate reviewer suggestion, risk scoring, artifact rendering, and GitHub presentation.
- Keep the scorer independent from backend-specific execution details.

2. Start with repo-local deterministic signals only.
- Prefer CODEOWNERS and git history over external services.
- If CODEOWNERS parsing is absent today, add a narrow parser sufficient for reviewer discovery.

3. Keep side effects opt-in.
- Suggest reviewers first.
- Automatic reviewer requests can be a follow-up once confidence and ergonomics are proven.

4. Make idempotency explicit.
- Reuse the existing notification-marker pattern or its successor.
- PR body sections or comments should be updateable rather than appended repeatedly.

5. Keep the risk model intentionally small.
- The point is prioritization, not perfect prediction.
- A transparent heuristic is preferable to an opaque score.

## Acceptance criteria
- Rascal produces explicit review-handoff artifacts when a run reaches PR handoff.
- Reviewer suggestions use deterministic repo-local signals and include explanation.
- Rascal assigns a compact risk classification with visible reasons.
- GitHub presentation is concise and idempotent.
- The feature works for newly created PRs and existing PR updates.
- Tests cover CODEOWNERS/history suggestion paths, risk scoring, presentation idempotency, and no-suggestion fallback.

## Suggested test plan
- Unit tests for CODEOWNERS matching and reviewer suggestion ranking.
- Unit tests for risk classification heuristics.
- Integration tests for PR-body or comment updates without duplication.
- Regression tests for follow-up runs that revise the same PR and preserve stable handoff metadata.
- API/CLI tests for handoff artifact visibility.

## Implementation notes
- This should make review easier, not louder.
- Keep reviewer suggestions advisory until the heuristics earn operator trust.
- High-signal handoff metadata is much more valuable here than broad automation.


## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run `make lint` and `make test` before finishing if those targets exist.
- If one of those commands does not exist or cannot run, explain exactly why and run the closest equivalent checks instead.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label &#39;rascal&#39; on issue #163

# Rascal Run Instructions

Run ID: run_aa349cb78d8c9c4a
Task ID: rtzll/rascal#163
Repository: rtzll/rascal
Issue: #163

## Task

feat(review): add reviewer routing hints and diff risk signals for Rascal PR handoff

## Summary
Rascal can already create or update PRs and move runs into a `review` state, but the handoff to humans is still thin. It does not help prioritize risky diffs, suggest likely reviewers, or distinguish changes that deserve extra attention.

This issue adds a lightweight review-handoff layer that computes routing hints and risk signals when Rascal opens or updates a PR.

## Outcome
When a run reaches PR handoff, Rascal can attach reviewer suggestions, risk metadata, and review-priority signals so the human review step is faster and better targeted.

## Goals
- Improve the quality of the human handoff without turning Rascal into a noisy review bot.
- Surface high-risk changes explicitly.
- Suggest likely reviewers using repository-local signals.
- Keep everything explainable, inspectable, and GitHub-native.
- Preserve conservative defaults and avoid surprise reviewer spam.

## Non-goals
- Building a full inbox product with calendars, timezones, or org graphs.
- Auto-approving or auto-merging PRs.
- Replacing CODEOWNERS or branch protection.
- Emitting large volumes of AI-generated inline review comments.

## Scope
Implement V1 review-handoff support with the following behavior.

1. Review handoff artifact
- Persist explicit handoff metadata in the run directory, for example:
  - `review-handoff.json`
  - `review-handoff.md`
- Include at least:
  - suggested reviewers
  - risk score or risk level
  - reasons for the risk classification
  - changed path summary
  - notable signals such as tests changed or not changed

2. Reviewer suggestion heuristics
- Suggest reviewers from a small, deterministic set of signals such as:
  - CODEOWNERS matches when available
  - recent file-touch history within the repo
  - previous PR author/reviewer activity for the same area
- Keep the heuristics explainable and stable.
- If no high-confidence suggestion exists, record that explicitly instead of guessing.

3. Risk classification
- Compute a compact risk classification such as `low`, `medium`, `high`.
- V1 signals may include:
  - number of files changed
  - number of directories or packages touched
  - presence of config/deploy/runtime files
  - changes in security-sensitive or infra-sensitive paths
  - missing test deltas for production code changes
  - cross-cutting changes spanning multiple areas
- Keep the scoring heuristic simple and visible in the artifact.

4. GitHub presentation
- Add the handoff summary to the PR body or completion comment in a concise way.
- Optionally add conservative labels such as:
  - `rascal:risk-high`
  - `rascal:needs-review`
- Do not request reviewers automatically in V1 unless explicitly configured.
- Start with suggestions and metadata, not side effects.

5. CLI/API visibility
- Expose handoff metadata through API/JSON output and optionally a CLI view command.
- Operators should be able to inspect why Rascal considered a change risky.

6. Notification hygiene
- Ensure handoff metadata updates are idempotent when Rascal revises an existing PR.
- Avoid posting duplicate comments or churning labels on every follow-up run.

## Suggested implementation approach
1. Add a small review-handoff package.
- Separate reviewer suggestion, risk scoring, artifact rendering, and GitHub presentation.
- Keep the scorer independent from backend-specific execution details.

2. Start with repo-local deterministic signals only.
- Prefer CODEOWNERS and git history over external services.
- If CODEOWNERS parsing is absent today, add a narrow parser sufficient for reviewer discovery.

3. Keep side effects opt-in.
- Suggest reviewers first.
- Automatic reviewer requests can be a follow-up once confidence and ergonomics are proven.

4. Make idempotency explicit.
- Reuse the existing notification-marker pattern or its successor.
- PR body sections or comments should be updateable rather than appended repeatedly.

5. Keep the risk model intentionally small.
- The point is prioritization, not perfect prediction.
- A transparent heuristic is preferable to an opaque score.

## Acceptance criteria
- Rascal produces explicit review-handoff artifacts when a run reaches PR handoff.
- Reviewer suggestions use deterministic repo-local signals and include explanation.
- Rascal assigns a compact risk classification with visible reasons.
- GitHub presentation is concise and idempotent.
- The feature works for newly created PRs and existing PR updates.
- Tests cover CODEOWNERS/history suggestion paths, risk scoring, presentation idempotency, and no-suggestion fallback.

## Suggested test plan
- Unit tests for CODEOWNERS matching and reviewer suggestion ranking.
- Unit tests for risk classification heuristics.
- Integration tests for PR-body or comment updates without duplication.
- Regression tests for follow-up runs that revise the same PR and preserve stable handoff metadata.
- API/CLI tests for handoff artifact visibility.

## Implementation notes
- This should make review easier, not louder.
- Keep reviewer suggestions advisory until the heuristics earn operator trust.
- High-signal handoff metadata is much more valuable here than broad automation.


## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run `make lint` and `make test` before finishing if those targets exist.
- If one of those commands does not exist or cannot run, explain exactly why and run the closest equivalent checks instead.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label &#39;rascal&#39; on issue #163


Assistant: 
Image files: 0
============================
{&#34;type&#34;:&#34;message&#34;,&#34;message&#34;:{&#34;id&#34;:null,&#34;role&#34;:&#34;assistant&#34;,&#34;created&#34;:1773597977,&#34;content&#34;:[{&#34;type&#34;:&#34;text&#34;,&#34;text&#34;:&#34;I’m tracing the existing PR handoff path first so I can add review metadata where the run already persists artifacts and updates GitHub, then I’ll keep the change set tight around those integration points.\n\nI found the likely seams: PR body/completion rendering in `internal/runsummary`, notification idempotency in `internal/orchestrator/notifications.go`, and run finalization in `internal/worker/worker.go`. I’m reading those now to wire the new handoff artifact into the existing review transition instead of inventing a second path.\n\nThe runner side is simpler than expected: it already owns diff creation, PR body generation, and writes repo-local meta files into the run directory. I’m checking whether I can compute reviewer/risk signals entirely from local git state there, then expose the resulting artifact from the server without adding new persisted DB state.\n\nI have the implementation shape now. I’m going with a small pure `reviewhandoff` package for scoring/rendering, using repo-local git/CODEOWNERS data from the worker to write `review-handoff.json` and `review-handoff.md`, then exposing that JSON on `GET /v1/runs/{id}` and updating a single managed PR-body section in place for idempotency.\n\nI’m starting the code edits now. The main changes are a new `internal/reviewhandoff` package, a worker-side collector/writer for git-derived handoff data, and a small API extension so the stored handoff JSON is inspectable after the run completes.\n\nI’ve got the first pass in place, but there are a few details to tighten before verification: CODEOWNERS team handles need proper normalization, the PR body helper needs a cleaner insert path for the managed section, and I still need the focused tests for existing-PR updates and API visibility.\n\nThe remaining work is mechanical now: formatting, compile/test passes, then any cleanup from failures. After that I’ll run the required `make lint` and `make test`, and write the commit message file.\n\nI’ve finished the targeted tests. Next I’m running the repo’s required validation exactly as requested: `make lint` and `make test`.\n\nBoth `make` targets are still in dependency/download work. I’m waiting them through rather than substituting a narrower check, because the task explicitly asked for the real targets when present.\n\n`make lint` and `make test` are both still inside `sqlc`/tool bootstrap work. They aren’t hung; they’re just duplicating the `codegen` prerequisite in parallel, so I’m letting them finish and then I’ll report the actual target results.\n\nThe parallel `make` run turned out to be counterproductive: both targets are compiling the same large `sqlc` dependency tree at once. I’m collapsing that into a sequential run now so validation finishes instead of burning CPU on duplicated work.\n\n`make lint` found two real issues, both straightforward `wrapcheck` complaints. I’m patching those exact lines and then rerunning lint.\n\nThe implementation is complete and validation is green. I’m writing the required conventional commit message file now, then I’ll summarize the exact user-visible changes and the verification results.\n\nImplemented the review handoff layer end to end.\n\nA new [reviewhandoff package](/work/repo/internal/reviewhandoff/reviewhandoff.go#L13) now computes deterministic reviewer hints from CODEOWNERS and recent git history, assigns a visible `low`/`medium`/`high` risk score with reasons, renders both `review-handoff.json` and `review-handoff.md`, and manages a single PR-body handoff section idempotently. The worker now builds and persists that metadata during PR handoff, includes it on new PR bodies, and updates the same managed section on existing PRs instead of appending duplicates ([worker integration](/work/repo/internal/worker/worker.go#L274), [git/CODEOWNERS collection](/work/repo/internal/worker/review_handoff.go#L13), [PR body support](/work/repo/internal/runsummary/runsummary.go#L114)). I kept reviewer suggestions advisory only; there are no automatic reviewer requests or label side effects in this change.\n\nRun inspection now exposes the handoff metadata through `GET /v1/runs/{id}` via the `review_handoff` JSON field ([API response type](/work/repo/internal/api/types.go#L50), [handler](/work/repo/internal/orchestrator/api.go#L622)). I added focused tests for reviewer heuristics, risk scoring, PR-body idempotency, worker artifact generation/update behavior, and API visibility ([reviewhandoff tests](/work/repo/internal/reviewhandoff/reviewhandoff_test.go), [worker tests](/work/repo/cmd/rascal-runner/main_test.go), [API test](/work/repo/internal/orchestrator/api_reviewhandoff_test.go)). Validation passed with `make lint` and `make test`. I also wrote [/rascal-meta/commit_message.txt](/rascal-meta/commit_message.txt).&#34;}],&#34;metadata&#34;:{&#34;userVisible&#34;:true,&#34;agentVisible&#34;:true}}}
{&#34;type&#34;:&#34;complete&#34;,&#34;total_tokens&#34;:10469236}
</code></pre>

</details>

Closes #163

---

Rascal run `run_aa349cb78d8c9c4a` completed in 19m 18s · 10.47M tokens