### PR TITLE
feat(goose): add persistent instructions file

### DIFF
--- a/cmd/rascal-runner/main_test.go
+++ b/cmd/rascal-runner/main_test.go
@@ -265,6 +265,9 @@ func TestLoadConfig(t *testing.T) {
 	if cfg.TaskSession.RuntimeSessionID != "" {
 		t.Fatalf("expected default agent session name empty, got %q", cfg.TaskSession.RuntimeSessionID)
 	}
+	if cfg.PersistentInstructionsPath != filepath.Join("/rascal-meta", "persistent_instructions.md") {
+		t.Fatalf("expected default persistent instructions path, got %q", cfg.PersistentInstructionsPath)
+	}
 }
 
 func TestLoadConfigRespectsDirectoryOverrides(t *testing.T) {
@@ -303,6 +306,9 @@ func TestLoadConfigRespectsDirectoryOverrides(t *testing.T) {
 	if cfg.GoosePathRoot != filepath.Join(metaDir, "goose") {
 		t.Fatalf("goose path root = %q, want %q", cfg.GoosePathRoot, filepath.Join(metaDir, "goose"))
 	}
+	if cfg.PersistentInstructionsPath != filepath.Join(metaDir, "persistent_instructions.md") {
+		t.Fatalf("persistent instructions path = %q, want %q", cfg.PersistentInstructionsPath, filepath.Join(metaDir, "persistent_instructions.md"))
+	}
 }
 
 func TestLoadConfigRespectsTaskSessionEnv(t *testing.T) {
@@ -338,6 +344,23 @@ func TestLoadConfigRespectsTaskSessionEnv(t *testing.T) {
 	}
 	if cfg.GoosePathRoot != "/rascal-goose-session" {
 		t.Fatalf("GoosePathRoot = %q, want /rascal-goose-session", cfg.GoosePathRoot)
+	}
+}
+
+func TestLoadConfigRespectsPersistentInstructionsOverride(t *testing.T) {
+	overridePath := filepath.Join(t.TempDir(), "custom-persistent.md")
+	t.Setenv("RASCAL_RUN_ID", "run_persistent_override")
+	t.Setenv("RASCAL_TASK_ID", "task_persistent_override")
+	t.Setenv("RASCAL_REPO", "owner/repo")
+	t.Setenv("GH_TOKEN", "token")
+	t.Setenv("GOOSE_MOIM_MESSAGE_FILE", overridePath)
+
+	cfg, err := worker.LoadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig returned error: %v", err)
+	}
+	if cfg.PersistentInstructionsPath != overridePath {
+		t.Fatalf("PersistentInstructionsPath = %q, want %q", cfg.PersistentInstructionsPath, overridePath)
 	}
 }
 

--- a/cmd/rascald/main_test.go
+++ b/cmd/rascald/main_test.go
@@ -82,6 +82,22 @@ func TestInstructionTextNonPRRunOmitsGitContext(t *testing.T) {
 	}
 }
 
+func TestPersistentInstructionTextContainsDurableGuardrails(t *testing.T) {
+	got := orchestrator.PersistentInstructionText(state.Run{})
+
+	for _, want := range []string{
+		"# Rascal Persistent Instructions",
+		"Do not ask for interactive input.",
+		"Do not overwrite, revert, or discard user changes you did not make unless the task explicitly requires it.",
+		"Run `make lint` and `make test` before finishing if those targets exist.",
+		"/rascal-meta/commit_message.txt",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("orchestrator.PersistentInstructionText() missing %q\nfull text:\n%s", want, got)
+		}
+	}
+}
+
 func TestWriteRunFilesWritesTypedContextJSON(t *testing.T) {
 	s := newTestServer(t, &fakeRunner{})
 	runDir := t.TempDir()
@@ -125,6 +141,21 @@ func TestWriteRunFilesWritesTypedContextJSON(t *testing.T) {
 	}
 	if got != want {
 		t.Fatalf("context.json mismatch: got %#v want %#v", got, want)
+	}
+
+	persistentData, err := os.ReadFile(filepath.Join(runDir, "persistent_instructions.md"))
+	if err != nil {
+		t.Fatalf("ReadFile(persistent_instructions.md) error = %v", err)
+	}
+	persistentText := string(persistentData)
+	for _, want := range []string{
+		"# Rascal Persistent Instructions",
+		"Do not ask for interactive input.",
+		"/rascal-meta/commit_message.txt",
+	} {
+		if !strings.Contains(persistentText, want) {
+			t.Fatalf("persistent instructions missing %q\nfull text:\n%s", want, persistentText)
+		}
 	}
 }
 

--- a/internal/orchestrator/runs.go
+++ b/internal/orchestrator/runs.go
@@ -171,6 +171,10 @@ func (s *Server) WriteRunFiles(run state.Run) (err error) {
 	if err := os.WriteFile(filepath.Join(run.RunDir, "instructions.md"), []byte(instructions), 0o644); err != nil {
 		return fmt.Errorf("write run instructions: %w", err)
 	}
+	persistentInstructions := PersistentInstructionText(run)
+	if err := os.WriteFile(filepath.Join(run.RunDir, "persistent_instructions.md"), []byte(persistentInstructions), 0o644); err != nil {
+		return fmt.Errorf("write persistent run instructions: %w", err)
+	}
 
 	logLine := fmt.Sprintf("[%s] queued run=%s task=%s trigger=%s\n", time.Now().UTC().Format(time.RFC3339), run.ID, run.TaskID, run.Trigger)
 	f, err := os.OpenFile(filepath.Join(run.RunDir, "runner.log"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
@@ -270,7 +274,6 @@ Repository: %s
 - If you rewrite history, you must run ` + "`git push --force-with-lease origin HEAD:" + strings.TrimSpace(run.HeadBranch) + "`" + `.
 - Otherwise run ` + "`git push origin HEAD:" + strings.TrimSpace(run.HeadBranch) + "`" + `.
 - Do not push to any other branch.
-- Before finishing, ensure the remote branch is updated and the working tree is clean.
 `)
 		if requiresAgentManagedPublish(run) {
 			b.WriteString(`
@@ -280,17 +283,6 @@ Repository: %s
 		b.WriteString(`
 `)
 	}
-	b.WriteString(`
-## Constraints
-
-- Do not ask for interactive input.
-- Do not require MCP tools.
-- Keep changes minimal and scoped to the requested task.
-- Run ` + "`make lint`" + ` and ` + "`make test`" + ` before finishing if those targets exist.
-- If one of those commands does not exist or cannot run, explain exactly why and run the closest equivalent checks instead.
-- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
-- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.
-`)
 	if strings.TrimSpace(run.Context) != "" {
 		b.WriteString(`
 ## Additional Context
@@ -301,6 +293,28 @@ Repository: %s
 `)
 	}
 	return b.String()
+}
+
+func PersistentInstructionText(run state.Run) string {
+	_ = run
+
+	return `# Rascal Persistent Instructions
+
+- Do not ask for interactive input.
+- Do not require MCP tools.
+- Keep changes minimal and scoped to the requested task.
+- Do not overwrite, revert, or discard user changes you did not make unless the task explicitly requires it.
+- Use the repository's existing patterns and conventions.
+- Prefer the repository's documented workflow over inventing a new one.
+- If the repository provides verification commands, run the relevant ones before finishing.
+- Run ` + "`make lint`" + ` and ` + "`make test`" + ` before finishing if those targets exist.
+- If one of those commands does not exist or cannot run, explain exactly why and run the closest equivalent checks instead.
+- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
+- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.
+- If working with GitHub branches or pull requests, only push to the designated Rascal branch for this run.
+- If you must rewrite published history, prefer ` + "`git push --force-with-lease`" + ` over ` + "`git push --force`" + `.
+- Before finishing, ensure the working tree is clean unless the task explicitly requires uncommitted output.
+`
 }
 
 func shouldIncludeGitContext(run state.Run) bool {

--- a/internal/runner/docker.go
+++ b/internal/runner/docker.go
@@ -38,6 +38,7 @@ const (
 	containerClaudeStateDir   = "/rascal-meta/claude"
 	containerClaudeSessionDir = "/rascal-claude-session"
 	containerContextJSONPath  = "/rascal-meta/context.json"
+	containerGooseMOIMPath    = "/rascal-meta/persistent_instructions.md"
 )
 
 func (l DockerRunner) StartDetached(ctx context.Context, spec Spec) (handle ExecutionHandle, err error) {
@@ -129,6 +130,7 @@ func (l DockerRunner) StartDetached(ctx context.Context, spec Spec) (handle Exec
 	}
 	if agentRuntime.Harness() == runtime.HarnessGoose {
 		envPairs["GOOSE_PATH_ROOT"] = goosePathRoot
+		envPairs["GOOSE_MOIM_MESSAGE_FILE"] = containerGooseMOIMPath
 		envPairs["GOOSE_MODE"] = "auto"
 		envPairs["GOOSE_DISABLE_KEYRING"] = "1"
 		envPairs["GOOSE_DISABLE_SESSION_NAMING"] = "true"

--- a/internal/runner/docker_test.go
+++ b/internal/runner/docker_test.go
@@ -232,6 +232,9 @@ exit 0
 	if !strings.Contains(call, "-e GOOSE_PATH_ROOT=/rascal-goose-session") {
 		t.Fatalf("expected persistent goose path root env, got:\n%s", call)
 	}
+	if !strings.Contains(call, "-e GOOSE_MOIM_MESSAGE_FILE=/rascal-meta/persistent_instructions.md") {
+		t.Fatalf("expected goose persistent instructions env, got:\n%s", call)
+	}
 	if !strings.Contains(call, "-e RASCAL_TASK_SESSION_MODE=pr-only") {
 		t.Fatalf("expected session mode env, got:\n%s", call)
 	}
@@ -309,6 +312,9 @@ exit 0
 	if !strings.Contains(call, "-e GOOSE_PATH_ROOT=/rascal-meta/goose") {
 		t.Fatalf("expected run-scoped goose path root env, got:\n%s", call)
 	}
+	if !strings.Contains(call, "-e GOOSE_MOIM_MESSAGE_FILE=/rascal-meta/persistent_instructions.md") {
+		t.Fatalf("expected goose persistent instructions env, got:\n%s", call)
+	}
 	if strings.Contains(call, ":/rascal-goose-session") {
 		t.Fatalf("did not expect persistent session mount when resume disabled, got:\n%s", call)
 	}
@@ -374,6 +380,9 @@ exit 0
 	}
 	if !strings.Contains(call, sessionDir+":/rascal-codex-session") {
 		t.Fatalf("expected task session mount, got:\n%s", call)
+	}
+	if strings.Contains(call, "-e GOOSE_MOIM_MESSAGE_FILE=") {
+		t.Fatalf("did not expect goose persistent instructions env for codex backend, got:\n%s", call)
 	}
 	if strings.Contains(call, "-e GOOSE_PROVIDER=") {
 		t.Fatalf("did not expect goose env for codex backend, got:\n%s", call)

--- a/internal/worker/config.go
+++ b/internal/worker/config.go
@@ -24,15 +24,16 @@ type Config struct {
 	Trigger     runtrigger.Name
 	GitHubToken string
 
-	MetaDir          string
-	WorkRoot         string
-	RepoDir          string
-	GooseLogPath     string
-	MetaPath         string
-	InstructionsPath string
-	CommitMsgPath    string
-	AgentOutputPath  string
-	PRBodyPath       string
+	MetaDir                    string
+	WorkRoot                   string
+	RepoDir                    string
+	GooseLogPath               string
+	MetaPath                   string
+	InstructionsPath           string
+	PersistentInstructionsPath string
+	CommitMsgPath              string
+	AgentOutputPath            string
+	PRBodyPath                 string
 
 	GooseDebug   bool
 	AgentRuntime runtime.Runtime
@@ -126,31 +127,33 @@ func LoadConfig() (Config, error) {
 	goosePathRoot := firstNonEmptyValue(strings.TrimSpace(os.Getenv("GOOSE_PATH_ROOT")), filepath.Join(metaDir, "goose"))
 	codexHome := firstNonEmptyValue(strings.TrimSpace(os.Getenv("CODEX_HOME")), filepath.Join(metaDir, "codex"))
 	claudeConfigDir := firstNonEmptyValue(strings.TrimSpace(os.Getenv("CLAUDE_CONFIG_DIR")), filepath.Join(metaDir, "claude"))
+	persistentInstructionsPath := firstNonEmptyValue(strings.TrimSpace(os.Getenv("GOOSE_MOIM_MESSAGE_FILE")), filepath.Join(metaDir, defaultPersistentInstructionsFile))
 
 	return Config{
-		RunID:            runID,
-		TaskID:           taskID,
-		Instruction:      strings.TrimSpace(os.Getenv("RASCAL_INSTRUCTION")),
-		Repo:             repo,
-		BaseBranch:       baseBranch,
-		HeadBranch:       headBranch,
-		IssueNumber:      issueNumber,
-		Trigger:          trigger,
-		GitHubToken:      ghToken,
-		MetaDir:          metaDir,
-		WorkRoot:         workRoot,
-		RepoDir:          repoDir,
-		GooseLogPath:     filepath.Join(metaDir, defaultAgentLogFile),
-		MetaPath:         filepath.Join(metaDir, defaultMetaFile),
-		InstructionsPath: filepath.Join(metaDir, defaultInstructionsFile),
-		CommitMsgPath:    filepath.Join(metaDir, defaultCommitMsgFile),
-		AgentOutputPath:  filepath.Join(metaDir, defaultAgentOutputFile),
-		PRBodyPath:       filepath.Join(metaDir, defaultPRBodyFile),
-		GooseDebug:       debug,
-		AgentRuntime:     agentRuntime,
-		GoosePathRoot:    goosePathRoot,
-		CodexHome:        codexHome,
-		ClaudeConfigDir:  claudeConfigDir,
+		RunID:                      runID,
+		TaskID:                     taskID,
+		Instruction:                strings.TrimSpace(os.Getenv("RASCAL_INSTRUCTION")),
+		Repo:                       repo,
+		BaseBranch:                 baseBranch,
+		HeadBranch:                 headBranch,
+		IssueNumber:                issueNumber,
+		Trigger:                    trigger,
+		GitHubToken:                ghToken,
+		MetaDir:                    metaDir,
+		WorkRoot:                   workRoot,
+		RepoDir:                    repoDir,
+		GooseLogPath:               filepath.Join(metaDir, defaultAgentLogFile),
+		MetaPath:                   filepath.Join(metaDir, defaultMetaFile),
+		InstructionsPath:           filepath.Join(metaDir, defaultInstructionsFile),
+		PersistentInstructionsPath: persistentInstructionsPath,
+		CommitMsgPath:              filepath.Join(metaDir, defaultCommitMsgFile),
+		AgentOutputPath:            filepath.Join(metaDir, defaultAgentOutputFile),
+		PRBodyPath:                 filepath.Join(metaDir, defaultPRBodyFile),
+		GooseDebug:                 debug,
+		AgentRuntime:               agentRuntime,
+		GoosePathRoot:              goosePathRoot,
+		CodexHome:                  codexHome,
+		ClaudeConfigDir:            claudeConfigDir,
 		TaskSession: runner.TaskSessionSpec{
 			Mode:             agentSessionMode,
 			Resume:           agentSessionResume,
@@ -211,15 +214,45 @@ func ensureInstructions(cfg Config) error {
 	}
 	body := fmt.Sprintf(`# Rascal Instructions
 
+Repository: %s
 Task ID: %s
 Trigger: %s
 
-Follow the repository instructions and implement the requested task.
-Keep changes minimal, run `+"`make lint`"+` and `+"`make test`"+` before finishing if those targets exist, and summarize what changed.
-If one of those commands does not exist or cannot run, explain exactly why and run the closest equivalent checks instead.
-`, cfg.TaskID, cfg.Trigger)
+## Task
+
+%s
+`, cfg.Repo, cfg.TaskID, cfg.Trigger, firstNonEmptyValue(cfg.Instruction, "Follow the repository instructions and implement the requested task."))
 	if err := os.WriteFile(cfg.InstructionsPath, []byte(body), 0o644); err != nil {
 		return fmt.Errorf("write default instructions: %w", err)
+	}
+	return nil
+}
+
+func ensurePersistentInstructions(cfg Config) error {
+	if _, err := os.Stat(cfg.PersistentInstructionsPath); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat persistent instructions: %w", err)
+	}
+	body := `# Rascal Persistent Instructions
+
+- Do not ask for interactive input.
+- Do not require MCP tools.
+- Keep changes minimal and scoped to the requested task.
+- Do not overwrite, revert, or discard user changes you did not make unless the task explicitly requires it.
+- Use the repository's existing patterns and conventions.
+- Prefer the repository's documented workflow over inventing a new one.
+- If the repository provides verification commands, run the relevant ones before finishing.
+- Run ` + "`make lint`" + ` and ` + "`make test`" + ` before finishing if those targets exist.
+- If one of those commands does not exist or cannot run, explain exactly why and run the closest equivalent checks instead.
+- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
+- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.
+- If working with GitHub branches or pull requests, only push to the designated Rascal branch for this run.
+- If you must rewrite published history, prefer ` + "`git push --force-with-lease`" + ` over ` + "`git push --force`" + `.
+- Before finishing, ensure the working tree is clean unless the task explicitly requires uncommitted output.
+`
+	if err := os.WriteFile(cfg.PersistentInstructionsPath, []byte(body), 0o644); err != nil {
+		return fmt.Errorf("write default persistent instructions: %w", err)
 	}
 	return nil
 }

--- a/internal/worker/config_test.go
+++ b/internal/worker/config_test.go
@@ -1,0 +1,33 @@
+package worker
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEnsurePersistentInstructionsWritesFallbackWhenMissing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "persistent_instructions.md")
+	cfg := Config{PersistentInstructionsPath: path}
+
+	if err := ensurePersistentInstructions(cfg); err != nil {
+		t.Fatalf("ensurePersistentInstructions returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read persistent instructions: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		"# Rascal Persistent Instructions",
+		"Do not ask for interactive input.",
+		"Do not overwrite, revert, or discard user changes you did not make unless the task explicitly requires it.",
+		"/rascal-meta/commit_message.txt",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("persistent instructions missing %q\nfull text:\n%s", want, text)
+		}
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -17,19 +17,20 @@ import (
 )
 
 const (
-	defaultMetaDir          = "/rascal-meta"
-	defaultWorkRoot         = "/work"
-	defaultRepoDirName      = "repo"
-	defaultAgentLogFile     = "agent.ndjson"
-	defaultMetaFile         = "meta.json"
-	defaultInstructionsFile = "instructions.md"
-	defaultCommitMsgFile    = "commit_message.txt"
-	defaultAgentOutputFile  = "agent_output.txt"
-	defaultPRBodyFile       = "pr_body.md"
-	defaultPRLabel          = "rascal"
-	defaultCodexAuthFile    = "auth.json"
-	defaultCodexSessionDir  = "sessions"
-	defaultClaudeOAuthFile  = "oauth_token"
+	defaultMetaDir                    = "/rascal-meta"
+	defaultWorkRoot                   = "/work"
+	defaultRepoDirName                = "repo"
+	defaultAgentLogFile               = "agent.ndjson"
+	defaultMetaFile                   = "meta.json"
+	defaultInstructionsFile           = "instructions.md"
+	defaultPersistentInstructionsFile = "persistent_instructions.md"
+	defaultCommitMsgFile              = "commit_message.txt"
+	defaultAgentOutputFile            = "agent_output.txt"
+	defaultPRBodyFile                 = "pr_body.md"
+	defaultPRLabel                    = "rascal"
+	defaultCodexAuthFile              = "auth.json"
+	defaultCodexSessionDir            = "sessions"
+	defaultClaudeOAuthFile            = "oauth_token"
 )
 
 var (
@@ -155,7 +156,10 @@ func RunWithExecutor(ex CommandExecutor) error {
 	}
 
 	if err := RunStage("prepare_instructions", func() error {
-		return ensureInstructions(cfg)
+		if err := ensureInstructions(cfg); err != nil {
+			return err
+		}
+		return ensurePersistentInstructions(cfg)
 	}); err != nil {
 		return fail(err)
 	}


### PR DESCRIPTION
Split Rascal's Goose prompt into task-scoped and persistent instruction files.
Wire GOOSE_MOIM_MESSAGE_FILE for Goose runs and add worker fallback coverage.

<details><summary>Agent Details</summary>

<pre><code>
    __( O)&gt;  ● new session · codex gpt-5.4
   \____)    20260317_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: &#34;/usr/local/bin/codex&#34;
Model: gpt-5.4
Reasoning effort: high
Skip git check: false
Prompt length: 7691 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Suggestion

The user has 7 extensions with 16 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
Consider asking if they&#39;d like to disable some extensions to improve tool selection accuracy.

# Response Guidelines

Use Markdown formatting for all responses.

Human: &lt;info-msg&gt;
It is currently 2026-03-17 21:19:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

&lt;/info-msg&gt;
# Rascal Run Instructions

Run ID: run_7b1b342899f5742b
Task ID: rtzll/rascal#179
Repository: rtzll/rascal
Issue: #179

## Task

Add Goose persistent instructions via GOOSE_MOIM_MESSAGE_FILE

# Add Goose persistent instructions via `GOOSE_MOIM_MESSAGE_FILE`

## Summary

Rascal currently gives Goose one main prompt file, `instructions.md`, plus `context.json`.
That works, but it means all of Rascals guardrails, git policy, validation policy, and output expectations live in a prompt that can be compacted or deprioritized over a long run.

Goose supports a separate persistent-instructions channel via `GOOSE_MOIM_MESSAGE_FILE`.
We should start using that and split Rascals prompt into:

- `instructions.md`: task-specific request and one-off run context
- `persistent_instructions.md`: always-on guardrails Goose should keep re-reading during the run

## Why

- Better reliability on long runs and after compaction
- Cleaner prompt design: task request vs durable policy
- Smaller task prompt, less repetition
- Sets up later work on repo-level hints/skills/recipes without stuffing everything into one file

## Current state

- The run dir is already mounted into the container as `/rascal-meta`.
- Rascal already writes `context.json` and `instructions.md` into the run dir.
- Goose env vars are assembled in the Docker launcher.
- All current constraints live in `InstructionText(run)`.

Relevant code:

- `internal/runner/docker.go`
- `internal/orchestrator/runs.go`
- `internal/worker/config.go`
- `internal/worker/worker.go`

## Proposed implementation

### 1. Pass `GOOSE_MOIM_MESSAGE_FILE` for Goose runs

In `internal/runner/docker.go`, add:

- `GOOSE_MOIM_MESSAGE_FILE=/rascal-meta/persistent_instructions.md`

This is enough for Goose to load the file, because the run dir is already mounted at `/rascal-meta`.

### 2. Write `persistent_instructions.md` as part of run file generation

In `internal/orchestrator/runs.go`:

- extend `WriteRunFiles(run)` to also write `persistent_instructions.md` into `run.RunDir`
- add a helper like `PersistentInstructionText(run)`

Keep `InstructionText(run)` focused on the actual task and short-lived context.

### 3. Add a worker-side fallback

The worker already has a fallback path for `instructions.md` when the file does not exist.

Do the same for the persistent file so standalone runner behavior remains sane:

- add `PersistentInstructionsPath` to `worker.Config`
- add a filename constant next to `instructions.md`
- add `ensurePersistentInstructions(cfg)`
- call it during the prepare-instructions stage, or create a dedicated `prepare_persistent_instructions` stage

### 4. Split the current prompt content intentionally

Do not just duplicate the current prompt into two files.

Use this split:

- `instructions.md`
- task statement
- issue/PR identifiers
- per-run context from trigger body/review comment/etc.
- optional branch metadata if it is useful for the task itself

- `persistent_instructions.md`
- no interactive input
- git safety rules
- validation/test expectations
- commit message file expectations
- “do not overwrite user changes”
- “keep changes scoped”
- any other durable house rules that should survive compaction

### 5. Add tests

At minimum:

- add a `WriteRunFiles` test that asserts `persistent_instructions.md` is written
- add a Docker launcher test that asserts `GOOSE_MOIM_MESSAGE_FILE=/rascal-meta/persistent_instructions.md` is passed for Goose runs
- add or adjust worker tests for the new config path / fallback creation if needed

Likely touch points:

- `cmd/rascald/main_test.go`
- `internal/runner/docker_test.go`
- `cmd/rascal-runner/main_test.go` or worker tests if a new fallback helper is added

## Prompt split sketch

This is a sketch, not a final wording requirement. The key point is the separation of concerns.

### `instructions.md` sketch

```md
# Rascal Task

Run ID: &lt;run_id&gt;
Task ID: &lt;task_id&gt;
Repository: &lt;owner/repo&gt;
Issue: #&lt;n&gt;      // when present
Pull Request: #&lt;n&gt; // when present

## Task

&lt;actual user request goes here&gt;

## Additional Context

&lt;review comment / issue body / trigger-specific context goes here&gt;
```

### `persistent_instructions.md` sketch

```md
# Rascal Persistent Instructions

- Do not ask for interactive input.
- Keep changes minimal and scoped to the requested task.
- Do not overwrite or revert user changes you did not make unless the task explicitly requires it.
- Use the repositorys existing patterns and conventions.
- If the repo provides verification commands, run the relevant ones before finishing.
- Prefer the repos documented workflow over inventing a new one.
- If you make changes, write `/rascal-meta/commit_message.txt` with a conventional-commit title on the first line.
- You may add a commit body after a blank line.
- If working with GitHub branches/PRs, only push to the designated Rascal branch for this run.
- Before finishing, ensure the working tree is clean unless the task explicitly requires uncommitted output.
- If a requested check cannot run, explain exactly why and run the closest useful alternative.
```

## Suggested content migration from current `InstructionText(run)`

Move these into `persistent_instructions.md`:

- `Do not ask for interactive input.`
- `Keep changes minimal and scoped to the requested task.`
- `Run make lint and make test before finishing if those targets exist.`
- `If one of those commands does not exist or cannot run, explain exactly why and run the closest equivalent checks instead.`
- `If you make changes, write /rascal-meta/commit_message.txt ...`

Keep these in `instructions.md`:

- the actual task text
- current issue/PR ids
- additional context from the trigger
- run-specific Git metadata if it materially helps the task

## Acceptance criteria

- Goose receives `GOOSE_MOIM_MESSAGE_FILE=/rascal-meta/persistent_instructions.md` for Goose runs
- Rascal writes `persistent_instructions.md` into the run dir before execution
- The worker can create a fallback persistent file if it is missing
- The task prompt is shorter and focused on the request itself
- Durable guardrails move to `persistent_instructions.md`
- Tests cover file creation and env propagation

## Nice follow-up, not required for this issue

- After this lands, revisit `.goosehints`, `AGENTS.md`, repo skills, and recipes as separate context channels rather than overloading either prompt file.


## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run `make lint` and `make test` before finishing if those targets exist.
- If one of those commands does not exist or cannot run, explain exactly why and run the closest equivalent checks instead.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label &#39;rascal&#39; on issue #179


Assistant: 
Image files: 0
============================
{&#34;type&#34;:&#34;message&#34;,&#34;message&#34;:{&#34;id&#34;:null,&#34;role&#34;:&#34;assistant&#34;,&#34;created&#34;:1773782830,&#34;content&#34;:[{&#34;type&#34;:&#34;text&#34;,&#34;text&#34;:&#34;I’m updating the task plan with the explicit requirements, then I’ll inspect the prompt-generation, Docker env, and worker fallback code paths to apply the split cleanly.\n\nI’ve located the prompt assembly and the main test surfaces. Next I’m reading the relevant files to preserve current behavior while separating the durable instructions from the task prompt.\n\nThe current worker only guarantees `instructions.md`; it doesn’t know about a persistent file yet. I’m checking the agent launch paths now so the fallback and Docker env wiring match how Goose is actually invoked.\n\nI’ve got the split mapped: the run prompt can shrink to task, identifiers, optional git context, and trigger context; the durable policy belongs in a separate file and a worker fallback. I’m editing those three areas together so the text, env wiring, and tests stay aligned.\n\nI’m applying the code changes now: writing the persistent prompt file, wiring Goose to read it, and teaching the worker to backfill it when the file is missing. After that I’ll add the focused tests around each touchpoint.\n\nI’ve finished the functional changes. I’m adding tests now for three things: run file creation, Goose env propagation, and the worker’s persistent-file path/fallback behavior.\n\nThe code and tests are in place. I’m formatting and running the focused Go test set first so I can catch any split-related regressions before broader validation.\n\nThe focused test run is in progress after pulling dependencies. I already confirmed the repo has `make lint` and `make test` targets, so I’ll run those once the targeted package tests are green or I’ve fixed any failures.\n\nThe initial `go test` is still compiling dependencies with no failures yet. I’m waiting for it to settle before widening to the repo-level `make` targets.\n\nRepo-level validation is running now with `make lint` and `make test`. Both start with `sqlc generate`, so I’m waiting on the full results before I do the final cleanup and commit message file.\n\nThe implementation and validation are green. I’m writing the required `/rascal-meta/commit_message.txt` now, then I’ll do one last status check so the final summary reflects the exact workspace state.\n\nSplit Goose prompting into task-scoped and persistent channels.\n\nIn [internal/orchestrator/runs.go](/work/repo/internal/orchestrator/runs.go), `WriteRunFiles` now writes `persistent_instructions.md` alongside `instructions.md`, and `InstructionText` was trimmed down to the task, IDs, git context, and trigger context. Durable guardrails moved into `PersistentInstructionText`. In [internal/runner/docker.go](/work/repo/internal/runner/docker.go), Goose runs now receive `GOOSE_MOIM_MESSAGE_FILE=/rascal-meta/persistent_instructions.md`. In [internal/worker/config.go](/work/repo/internal/worker/config.go) and [internal/worker/worker.go](/work/repo/internal/worker/worker.go), the worker now tracks `PersistentInstructionsPath`, honors `GOOSE_MOIM_MESSAGE_FILE`, and creates a fallback persistent file when it is missing.\n\nTests were added or updated in [cmd/rascald/main_test.go](/work/repo/cmd/rascald/main_test.go), [internal/runner/docker_test.go](/work/repo/internal/runner/docker_test.go), [cmd/rascal-runner/main_test.go](/work/repo/cmd/rascal-runner/main_test.go), and [internal/worker/config_test.go](/work/repo/internal/worker/config_test.go). I ran `go test ./cmd/rascald ./cmd/rascal-runner ./internal/runner ./internal/worker`, `make lint`, and `make test`; all passed. The required commit message file was written to `/rascal-meta/commit_message.txt`.&#34;}],&#34;metadata&#34;:{&#34;userVisible&#34;:true,&#34;agentVisible&#34;:true}}}
{&#34;type&#34;:&#34;complete&#34;,&#34;total_tokens&#34;:2204777}
</code></pre>

</details>

Closes #179

---

Rascal run `run_7b1b342899f5742b` completed in 7m 28s · 2.20M tokens