### PR TITLE
fix(codex): report per-run token usage from session events

### DIFF
--- a/cmd/rascal-runner/main_test.go
+++ b/cmd/rascal-runner/main_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/rtzll/rascal/internal/runner"
+	"github.com/rtzll/rascal/internal/runsummary"
 	"github.com/rtzll/rascal/internal/runtime"
 	"github.com/rtzll/rascal/internal/runtrigger"
 	"github.com/rtzll/rascal/internal/worker"
@@ -785,7 +786,11 @@ func TestRunCodexFreshSession(t *testing.T) {
 			if err := os.WriteFile(cfg.AgentOutputPath, []byte("final codex response"), 0o644); err != nil {
 				t.Fatalf("write agent output: %v", err)
 			}
-			if err := os.WriteFile(sessionPath, []byte(`{"type":"session_meta","payload":{"id":"session-123"}}`+"\n"), 0o644); err != nil {
+			sessionData := strings.Join([]string{
+				`{"type":"session_meta","payload":{"id":"session-123"}}`,
+				`{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":120,"cached_input_tokens":40,"output_tokens":30,"reasoning_output_tokens":10,"total_tokens":150},"total_token_usage":{"input_tokens":120,"cached_input_tokens":40,"output_tokens":30,"reasoning_output_tokens":10,"total_tokens":150}}}}`,
+			}, "\n") + "\n"
+			if err := os.WriteFile(sessionPath, []byte(sessionData), 0o644); err != nil {
 				t.Fatalf("write codex session: %v", err)
 			}
 			if _, err := io.WriteString(stdout, `{"type":"message"}`+"\n"); err != nil {
@@ -823,6 +828,19 @@ func TestRunCodexFreshSession(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(codexHome, "auth.json")); err != nil {
 		t.Fatalf("expected codex auth copied into home: %v", err)
 	}
+	usage, ok, err := runsummary.ReadRecordedTokenUsage(filepath.Join(root, runsummary.RecordedTokenUsageFile))
+	if err != nil {
+		t.Fatalf("read recorded token usage: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected recorded token usage")
+	}
+	if usage.TotalTokens != 150 {
+		t.Fatalf("total_tokens = %d, want 150", usage.TotalTokens)
+	}
+	if usage.CachedInputTokens == nil || *usage.CachedInputTokens != 40 {
+		t.Fatalf("cached_input_tokens = %v, want 40", usage.CachedInputTokens)
+	}
 }
 
 func TestRunCodexResumeSession(t *testing.T) {
@@ -855,6 +873,13 @@ func TestRunCodexResumeSession(t *testing.T) {
 	if err := os.WriteFile(cfg.InstructionsPath, []byte("continue"), 0o644); err != nil {
 		t.Fatalf("write instructions: %v", err)
 	}
+	initialSessionData := strings.Join([]string{
+		`{"type":"session_meta","payload":{"id":"session-abc"}}`,
+		`{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":80,"cached_input_tokens":20,"output_tokens":20,"reasoning_output_tokens":5,"total_tokens":100}}}}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(sessionPath, []byte(initialSessionData), 0o644); err != nil {
+		t.Fatalf("write initial codex session: %v", err)
+	}
 
 	var gotArgs []string
 	ex := fakeExecutor{
@@ -866,8 +891,17 @@ func TestRunCodexResumeSession(t *testing.T) {
 			if err := os.WriteFile(cfg.AgentOutputPath, []byte("continued"), 0o644); err != nil {
 				t.Fatalf("write agent output: %v", err)
 			}
-			if err := os.WriteFile(sessionPath, []byte(`{"type":"session_meta","payload":{"id":"session-abc"}}`+"\n"), 0o644); err != nil {
-				t.Fatalf("write codex session: %v", err)
+			sessionFile, err := os.OpenFile(sessionPath, os.O_APPEND|os.O_WRONLY, 0o644)
+			if err != nil {
+				t.Fatalf("open codex session: %v", err)
+			}
+			defer func() {
+				if closeErr := sessionFile.Close(); closeErr != nil {
+					t.Fatalf("close codex session: %v", closeErr)
+				}
+			}()
+			if _, err := io.WriteString(sessionFile, `{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":35,"cached_input_tokens":10,"output_tokens":15,"reasoning_output_tokens":3,"total_tokens":50},"total_token_usage":{"input_tokens":115,"cached_input_tokens":30,"output_tokens":35,"reasoning_output_tokens":8,"total_tokens":150}}}}`+"\n"); err != nil {
+				t.Fatalf("append codex session: %v", err)
 			}
 			if _, err := io.WriteString(stdout, `{"type":"message"}`+"\n"); err != nil {
 				return fmt.Errorf("write fake codex output: %w", err)
@@ -891,6 +925,74 @@ func TestRunCodexResumeSession(t *testing.T) {
 	}
 	if strings.Contains(argsText, "workspace-write") {
 		t.Fatalf("did not expect explicit sandbox arg on resume, got %q", argsText)
+	}
+	usage, ok, err := runsummary.ReadRecordedTokenUsage(filepath.Join(root, runsummary.RecordedTokenUsageFile))
+	if err != nil {
+		t.Fatalf("read recorded token usage: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected recorded token usage")
+	}
+	if usage.TotalTokens != 50 {
+		t.Fatalf("total_tokens = %d, want 50", usage.TotalTokens)
+	}
+	if usage.InputTokens == nil || *usage.InputTokens != 35 {
+		t.Fatalf("input_tokens = %v, want 35", usage.InputTokens)
+	}
+}
+
+func TestRunCodexSkipsRecordedUsageWhenSessionUsageInvalid(t *testing.T) {
+	root := t.TempDir()
+	codexHome := filepath.Join(root, "codex-home")
+	sessionPath := filepath.Join(codexHome, "sessions", "2026", "03", "session.jsonl")
+	cfg := worker.Config{
+		RepoDir:          root,
+		MetaDir:          root,
+		InstructionsPath: filepath.Join(root, "instructions.md"),
+		GooseLogPath:     filepath.Join(root, "agent.ndjson"),
+		AgentOutputPath:  filepath.Join(root, "agent_output.txt"),
+		CodexHome:        codexHome,
+		AgentRuntime:     runtime.RuntimeCodex,
+	}
+	if err := os.MkdirAll(filepath.Dir(sessionPath), 0o755); err != nil {
+		t.Fatalf("mkdir codex sessions: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "codex"), 0o755); err != nil {
+		t.Fatalf("mkdir codex auth dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "codex", "auth.json"), []byte(`{"token":"test"}`), 0o600); err != nil {
+		t.Fatalf("write codex auth: %v", err)
+	}
+	if err := os.WriteFile(cfg.InstructionsPath, []byte("do thing"), 0o644); err != nil {
+		t.Fatalf("write instructions: %v", err)
+	}
+
+	ex := fakeExecutor{
+		runWithInputFn: func(_ string, _ []string, _ io.Reader, stdout, _ io.Writer, name string, args ...string) error {
+			if err := os.WriteFile(cfg.AgentOutputPath, []byte("final codex response"), 0o644); err != nil {
+				t.Fatalf("write agent output: %v", err)
+			}
+			sessionData := strings.Join([]string{
+				`{"type":"session_meta","payload":{"id":"session-123"}}`,
+				`{"type":"event_msg","payload":{"type":"token_count","info":`,
+			}, "\n")
+			if err := os.WriteFile(sessionPath, []byte(sessionData), 0o644); err != nil {
+				t.Fatalf("write codex session: %v", err)
+			}
+			if _, err := io.WriteString(stdout, `{"type":"message"}`+"\n"); err != nil {
+				return fmt.Errorf("write fake codex output: %w", err)
+			}
+			return nil
+		},
+	}
+
+	if _, _, err := worker.RunCodex(ex, cfg); err != nil {
+		t.Fatalf("runCodex returned error: %v", err)
+	}
+	if _, ok, err := runsummary.ReadRecordedTokenUsage(filepath.Join(root, runsummary.RecordedTokenUsageFile)); err != nil {
+		t.Fatalf("read recorded token usage: %v", err)
+	} else if ok {
+		t.Fatal("did not expect recorded token usage")
 	}
 }
 

--- a/cmd/rascald/main_test.go
+++ b/cmd/rascald/main_test.go
@@ -25,10 +25,15 @@ import (
 	ghapi "github.com/rtzll/rascal/internal/github"
 	"github.com/rtzll/rascal/internal/orchestrator"
 	"github.com/rtzll/rascal/internal/runner"
+	"github.com/rtzll/rascal/internal/runsummary"
 	agentrt "github.com/rtzll/rascal/internal/runtime"
 	"github.com/rtzll/rascal/internal/runtrigger"
 	"github.com/rtzll/rascal/internal/state"
 )
+
+func int64Ptr(v int64) *int64 {
+	return &v
+}
 
 func TestInstructionTextPRGitContext(t *testing.T) {
 	run := state.Run{
@@ -3047,6 +3052,98 @@ func TestExecuteRunPersistsStructuredRunTokenUsage(t *testing.T) {
 	}
 	if !strings.Contains(usage.RawUsageJSON, `"reasoning_tokens":10`) {
 		t.Fatalf("expected raw usage json, got %q", usage.RawUsageJSON)
+	}
+}
+
+func TestExecuteRunPersistsRecordedCodexRunTokenUsage(t *testing.T) {
+	t.Parallel()
+	launcher := &fakeRunner{
+		res: fakeRunResult{
+			HeadSHA: "0123456789abcdef0123456789abcdef01234567",
+		},
+	}
+	s := newTestServer(t, launcher)
+	defer waitForServerIdle(t, s)
+
+	run, err := s.Store.AddRun(state.CreateRunInput{
+		ID:           "run_codex_token_usage",
+		TaskID:       "owner/repo#99",
+		Repo:         "owner/repo",
+		Instruction:  "Capture codex token usage",
+		BaseBranch:   "main",
+		HeadBranch:   "rascal/pr-99",
+		Trigger:      "issue_label",
+		RunDir:       t.TempDir(),
+		AgentRuntime: agentrt.RuntimeCodex,
+	})
+	if err != nil {
+		t.Fatalf("add run: %v", err)
+	}
+	if err := runsummary.WriteRecordedTokenUsage(filepath.Join(run.RunDir, runsummary.RecordedTokenUsageFile), runsummary.TokenUsage{
+		Provider:              "openai",
+		Model:                 "gpt-5-codex",
+		TotalTokens:           150,
+		InputTokens:           int64Ptr(120),
+		OutputTokens:          int64Ptr(30),
+		CachedInputTokens:     int64Ptr(40),
+		ReasoningOutputTokens: int64Ptr(10),
+		RawUsageJSON:          `{"total_tokens":150}`,
+	}); err != nil {
+		t.Fatalf("write recorded token usage: %v", err)
+	}
+
+	s.ExecuteRun(run.ID)
+
+	usage, ok := s.Store.GetRunTokenUsage(run.ID)
+	if !ok {
+		t.Fatalf("expected run token usage for %s", run.ID)
+	}
+	if usage.AgentRuntime != agentrt.RuntimeCodex {
+		t.Fatalf("backend = %q, want codex", usage.AgentRuntime)
+	}
+	if usage.Model != "gpt-5-codex" {
+		t.Fatalf("model = %q, want gpt-5-codex", usage.Model)
+	}
+	if usage.TotalTokens != 150 {
+		t.Fatalf("total_tokens = %d, want 150", usage.TotalTokens)
+	}
+	if usage.CachedInputTokens == nil || *usage.CachedInputTokens != 40 {
+		t.Fatalf("cached_input_tokens = %v, want 40", usage.CachedInputTokens)
+	}
+}
+
+func TestExecuteRunIgnoresInvalidRecordedCodexRunTokenUsage(t *testing.T) {
+	t.Parallel()
+	launcher := &fakeRunner{
+		res: fakeRunResult{
+			HeadSHA: "0123456789abcdef0123456789abcdef01234567",
+		},
+	}
+	s := newTestServer(t, launcher)
+	defer waitForServerIdle(t, s)
+
+	run, err := s.Store.AddRun(state.CreateRunInput{
+		ID:           "run_codex_token_usage_invalid",
+		TaskID:       "owner/repo#100",
+		Repo:         "owner/repo",
+		Instruction:  "Capture invalid codex token usage",
+		BaseBranch:   "main",
+		HeadBranch:   "rascal/pr-100",
+		Trigger:      "issue_label",
+		RunDir:       t.TempDir(),
+		AgentRuntime: agentrt.RuntimeCodex,
+	})
+	if err != nil {
+		t.Fatalf("add run: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(run.RunDir, runsummary.RecordedTokenUsageFile), []byte("{"), 0o644); err != nil {
+		t.Fatalf("write invalid recorded token usage: %v", err)
+	}
+
+	s.ExecuteRun(run.ID)
+
+	if _, ok := s.Store.GetRunTokenUsage(run.ID); ok {
+		t.Fatalf("did not expect persisted token usage for %s", run.ID)
 	}
 }
 

--- a/internal/orchestrator/notifications.go
+++ b/internal/orchestrator/notifications.go
@@ -530,6 +530,29 @@ func buildRunCompletionComment(run state.Run, target RunResponseTarget, repo str
 }
 
 func loadRunTokenUsage(run state.Run) (state.RunTokenUsage, bool, error) {
+	if run.AgentRuntime == runtime.RuntimeCodex {
+		usage, ok, err := runsummary.ReadRecordedTokenUsage(filepath.Join(strings.TrimSpace(run.RunDir), runsummary.RecordedTokenUsageFile))
+		if err != nil {
+			return state.RunTokenUsage{}, false, fmt.Errorf("read recorded codex token usage: %w", err)
+		}
+		if !ok {
+			return state.RunTokenUsage{}, false, nil
+		}
+		return state.RunTokenUsage{
+			RunID:                 run.ID,
+			AgentRuntime:          run.AgentRuntime,
+			Provider:              usage.Provider,
+			Model:                 usage.Model,
+			TotalTokens:           usage.TotalTokens,
+			InputTokens:           usage.InputTokens,
+			OutputTokens:          usage.OutputTokens,
+			CachedInputTokens:     usage.CachedInputTokens,
+			ReasoningOutputTokens: usage.ReasoningOutputTokens,
+			RawUsageJSON:          usage.RawUsageJSON,
+			CapturedAt:            time.Now().UTC(),
+		}, true, nil
+	}
+
 	agentPath, err := resolveRunAgentLogPath(run.RunDir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {

--- a/internal/runsummary/runsummary.go
+++ b/internal/runsummary/runsummary.go
@@ -111,9 +111,16 @@ func renderAgentDetailsSection(gooseOutput string) string {
 	)
 }
 
-func BuildPRBody(runID, commitBody, gooseOutput, runDuration, closesSection string) string {
+func BuildPRBody(runID, commitBody, gooseOutput, runDuration, closesSection string, totalTokens *int64) string {
 	gooseSection := renderAgentDetailsSection(gooseOutput)
-	if usage, ok := ExtractTokenUsage(gooseOutput); ok {
+	if (totalTokens != nil && *totalTokens > 0) || totalTokens == nil {
+		if totalTokens == nil {
+			if usage, ok := ExtractTokenUsage(gooseOutput); ok {
+				totalTokens = &usage.TotalTokens
+			}
+		}
+	}
+	if totalTokens != nil && *totalTokens > 0 {
 		body := ""
 		if strings.TrimSpace(commitBody) != "" {
 			body = commitBody + "\n\n"
@@ -122,7 +129,7 @@ func BuildPRBody(runID, commitBody, gooseOutput, runDuration, closesSection stri
 			"Rascal run `%s` completed in %s · %s tokens",
 			runID,
 			runDuration,
-			formatTokenCount(usage.TotalTokens),
+			formatTokenCount(*totalTokens),
 		)
 		return body
 	}
@@ -145,20 +152,7 @@ func BuildCompletionComment(in CompletionCommentInput) (string, error) {
 		closesSection = fmt.Sprintf("\n\nCloses #%d", in.IssueNumber)
 	}
 	runDuration := FormatDuration(in.DurationSeconds)
-	commentBody := BuildPRBody(in.RunID, commitBody, in.GooseOutput, runDuration, closesSection)
-	if in.TotalTokens != nil && *in.TotalTokens > 0 {
-		body := ""
-		if strings.TrimSpace(commitBody) != "" {
-			body = commitBody + "\n\n"
-		}
-		body += renderAgentDetailsSection(in.GooseOutput) + closesSection + "\n\n---\n\n" + fmt.Sprintf(
-			"Rascal run `%s` completed in %s · %s tokens",
-			in.RunID,
-			runDuration,
-			formatTokenCount(*in.TotalTokens),
-		)
-		commentBody = body
-	}
+	commentBody := BuildPRBody(in.RunID, commitBody, in.GooseOutput, runDuration, closesSection, in.TotalTokens)
 
 	requestedBy := strings.TrimSpace(in.RequestedBy)
 	if requestedBy == "" {

--- a/internal/runsummary/runsummary_test.go
+++ b/internal/runsummary/runsummary_test.go
@@ -101,6 +101,100 @@ func TestExtractTokenUsage(t *testing.T) {
 	})
 }
 
+func TestExtractCodexSessionUsage(t *testing.T) {
+	session := strings.Join([]string{
+		`{"type":"session_meta","payload":{"id":"session-123"}}`,
+		`{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":120,"cached_input_tokens":40,"output_tokens":30,"reasoning_output_tokens":10,"total_tokens":150}}}}`,
+		`{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":180,"cached_input_tokens":55,"output_tokens":45,"reasoning_output_tokens":12,"total_tokens":225}}}}`,
+	}, "\n")
+
+	usage, ok, err := ExtractCodexSessionUsage(session)
+	if err != nil {
+		t.Fatalf("ExtractCodexSessionUsage returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected codex session usage")
+	}
+	if usage.TotalTokens != 225 {
+		t.Fatalf("total_tokens = %d, want 225", usage.TotalTokens)
+	}
+	if usage.InputTokens == nil || *usage.InputTokens != 180 {
+		t.Fatalf("input_tokens = %v, want 180", usage.InputTokens)
+	}
+	if usage.CachedInputTokens == nil || *usage.CachedInputTokens != 55 {
+		t.Fatalf("cached_input_tokens = %v, want 55", usage.CachedInputTokens)
+	}
+}
+
+func TestExtractCodexSessionUsageDelta(t *testing.T) {
+	session := strings.Join([]string{
+		`{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":20,"cached_input_tokens":5,"output_tokens":4,"reasoning_output_tokens":1,"total_tokens":24}}}}`,
+		`{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":30,"cached_input_tokens":6,"output_tokens":5,"reasoning_output_tokens":2,"total_tokens":35}}}}`,
+	}, "\n")
+
+	usage, ok, err := ExtractCodexSessionUsageDelta(session)
+	if err != nil {
+		t.Fatalf("ExtractCodexSessionUsageDelta returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected codex session delta")
+	}
+	if usage.TotalTokens != 59 {
+		t.Fatalf("total_tokens = %d, want 59", usage.TotalTokens)
+	}
+	if usage.InputTokens == nil || *usage.InputTokens != 50 {
+		t.Fatalf("input_tokens = %v, want 50", usage.InputTokens)
+	}
+	if usage.CachedInputTokens == nil || *usage.CachedInputTokens != 11 {
+		t.Fatalf("cached_input_tokens = %v, want 11", usage.CachedInputTokens)
+	}
+	if usage.ReasoningOutputTokens == nil || *usage.ReasoningOutputTokens != 3 {
+		t.Fatalf("reasoning_output_tokens = %v, want 3", usage.ReasoningOutputTokens)
+	}
+}
+
+func TestSubtractTokenUsage(t *testing.T) {
+	inputTotal := int64(180)
+	outputTotal := int64(45)
+	cachedTotal := int64(55)
+	reasoningTotal := int64(12)
+	inputBase := int64(120)
+	outputBase := int64(30)
+	cachedBase := int64(40)
+	reasoningBase := int64(10)
+
+	usage, ok := SubtractTokenUsage(TokenUsage{
+		Provider:              "openai",
+		Model:                 "gpt-5-codex",
+		TotalTokens:           225,
+		InputTokens:           &inputTotal,
+		OutputTokens:          &outputTotal,
+		CachedInputTokens:     &cachedTotal,
+		ReasoningOutputTokens: &reasoningTotal,
+	}, TokenUsage{
+		TotalTokens:           150,
+		InputTokens:           &inputBase,
+		OutputTokens:          &outputBase,
+		CachedInputTokens:     &cachedBase,
+		ReasoningOutputTokens: &reasoningBase,
+	})
+	if !ok {
+		t.Fatal("expected usage subtraction")
+	}
+	if usage.TotalTokens != 75 {
+		t.Fatalf("total_tokens = %d, want 75", usage.TotalTokens)
+	}
+	if usage.InputTokens == nil || *usage.InputTokens != 60 {
+		t.Fatalf("input_tokens = %v, want 60", usage.InputTokens)
+	}
+	if usage.OutputTokens == nil || *usage.OutputTokens != 15 {
+		t.Fatalf("output_tokens = %v, want 15", usage.OutputTokens)
+	}
+	if usage.Provider != "openai" || usage.Model != "gpt-5-codex" {
+		t.Fatalf("unexpected provider/model: %+v", usage)
+	}
+}
+
 func TestFormatDuration(t *testing.T) {
 	cases := []struct {
 		seconds int64
@@ -149,6 +243,7 @@ func TestBuildPRBody(t *testing.T) {
 			`{"usage":{"total_tokens":123000}}`,
 			"1m 2s",
 			"",
+			nil,
 		)
 		if !strings.Contains(body, "<details><summary>Agent Details</summary>") {
 			t.Fatalf("missing agent details section:\n%s", body)
@@ -168,6 +263,7 @@ func TestBuildPRBody(t *testing.T) {
 			`{"event":"x"}`,
 			"8s",
 			"\n\nCloses #12",
+			nil,
 		)
 		if !strings.Contains(body, "<details><summary>Agent Details</summary>") {
 			t.Fatalf("missing agent details section:\n%s", body)
@@ -190,6 +286,7 @@ func TestBuildPRBody(t *testing.T) {
 			"issue body\n```go\nfmt.Println(\"hi\")\n```\n<details>raw</details>\n{\"usage\":{\"total_tokens\":321}}",
 			"9s",
 			"",
+			nil,
 		)
 		if !strings.Contains(body, "<details><summary>Agent Details</summary>") {
 			t.Fatalf("missing agent details section:\n%s", body)
@@ -207,6 +304,21 @@ func TestBuildPRBody(t *testing.T) {
 			t.Fatalf("expected a single outer details close tag:\n%s", body)
 		}
 	})
+}
+
+func TestBuildPRBodyPrefersExplicitTokenTotal(t *testing.T) {
+	total := int64(75)
+	body := BuildPRBody(
+		"run_explicit",
+		"",
+		`{"event":"x"}`,
+		"4s",
+		"",
+		&total,
+	)
+	if !strings.Contains(body, "Rascal run `run_explicit` completed in 4s · 75 tokens") {
+		t.Fatalf("missing explicit token summary:\n%s", body)
+	}
 }
 
 func TestBuildCompletionComment(t *testing.T) {

--- a/internal/runsummary/usage.go
+++ b/internal/runsummary/usage.go
@@ -5,19 +5,22 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 )
 
+const RecordedTokenUsageFile = "run_token_usage.json"
+
 type TokenUsage struct {
-	Provider              string
-	Model                 string
-	TotalTokens           int64
-	InputTokens           *int64
-	OutputTokens          *int64
-	CachedInputTokens     *int64
-	ReasoningOutputTokens *int64
-	RawUsageJSON          string
+	Provider              string `json:"provider,omitempty"`
+	Model                 string `json:"model,omitempty"`
+	TotalTokens           int64  `json:"total_tokens"`
+	InputTokens           *int64 `json:"input_tokens,omitempty"`
+	OutputTokens          *int64 `json:"output_tokens,omitempty"`
+	CachedInputTokens     *int64 `json:"cached_input_tokens,omitempty"`
+	ReasoningOutputTokens *int64 `json:"reasoning_output_tokens,omitempty"`
+	RawUsageJSON          string `json:"raw_usage_json,omitempty"`
 }
 
 type usageCandidate struct {
@@ -91,6 +94,152 @@ func ExtractTotalTokens(agentOutput string) (int64, bool) {
 	return usage.TotalTokens, true
 }
 
+func ExtractCodexSessionUsage(sessionJSONL string) (TokenUsage, bool, error) {
+	scanner := bufio.NewScanner(strings.NewReader(sessionJSONL))
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+
+	var (
+		best     TokenUsage
+		found    bool
+		firstErr error
+	)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || !strings.Contains(line, `"token_count"`) {
+			continue
+		}
+
+		usage, ok, err := extractCodexSessionUsageLine(line, "total_token_usage")
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if !ok {
+			continue
+		}
+		best = usage
+		found = true
+	}
+	if err := scanner.Err(); err != nil {
+		return TokenUsage{}, false, fmt.Errorf("scan codex session usage: %w", err)
+	}
+	if found {
+		return best, true, nil
+	}
+	if firstErr != nil {
+		return TokenUsage{}, false, firstErr
+	}
+	return TokenUsage{}, false, nil
+}
+
+func ExtractCodexSessionUsageDelta(sessionJSONL string) (TokenUsage, bool, error) {
+	scanner := bufio.NewScanner(strings.NewReader(sessionJSONL))
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+
+	var (
+		total    TokenUsage
+		found    bool
+		firstErr error
+	)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || !strings.Contains(line, `"token_count"`) {
+			continue
+		}
+
+		usage, ok, err := extractCodexSessionUsageLine(line, "last_token_usage")
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if !ok {
+			continue
+		}
+		total = addTokenUsage(total, usage)
+		found = true
+	}
+	if err := scanner.Err(); err != nil {
+		return TokenUsage{}, false, fmt.Errorf("scan codex session usage delta: %w", err)
+	}
+	if found {
+		return total, true, nil
+	}
+	if firstErr != nil {
+		return TokenUsage{}, false, firstErr
+	}
+	return TokenUsage{}, false, nil
+}
+
+func SubtractTokenUsage(total, baseline TokenUsage) (TokenUsage, bool) {
+	if total.TotalTokens < baseline.TotalTokens {
+		return TokenUsage{}, false
+	}
+
+	out := TokenUsage{
+		Provider:     firstNonEmptyString(total.Provider, baseline.Provider),
+		Model:        firstNonEmptyString(total.Model, baseline.Model),
+		TotalTokens:  total.TotalTokens - baseline.TotalTokens,
+		RawUsageJSON: total.RawUsageJSON,
+	}
+
+	if value, ok := subtractOptionalInt64(total.InputTokens, baseline.InputTokens); ok {
+		out.InputTokens = value
+	}
+	if value, ok := subtractOptionalInt64(total.OutputTokens, baseline.OutputTokens); ok {
+		out.OutputTokens = value
+	}
+	if value, ok := subtractOptionalInt64(total.CachedInputTokens, baseline.CachedInputTokens); ok {
+		out.CachedInputTokens = value
+	}
+	if value, ok := subtractOptionalInt64(total.ReasoningOutputTokens, baseline.ReasoningOutputTokens); ok {
+		out.ReasoningOutputTokens = value
+	}
+
+	if out.TotalTokens == 0 && out.InputTokens == nil && out.OutputTokens == nil &&
+		out.CachedInputTokens == nil && out.ReasoningOutputTokens == nil {
+		return TokenUsage{}, false
+	}
+	return out, true
+}
+
+func WriteRecordedTokenUsage(path string, usage TokenUsage) error {
+	data, err := json.MarshalIndent(usage, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode recorded token usage: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write recorded token usage: %w", err)
+	}
+	return nil
+}
+
+func ReadRecordedTokenUsage(path string) (TokenUsage, bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return TokenUsage{}, false, nil
+		}
+		return TokenUsage{}, false, fmt.Errorf("read recorded token usage: %w", err)
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		return TokenUsage{}, false, nil
+	}
+
+	var usage TokenUsage
+	if err := json.Unmarshal(data, &usage); err != nil {
+		return TokenUsage{}, false, fmt.Errorf("decode recorded token usage: %w", err)
+	}
+	if usage.TotalTokens <= 0 && usage.InputTokens == nil && usage.OutputTokens == nil &&
+		usage.CachedInputTokens == nil && usage.ReasoningOutputTokens == nil {
+		return TokenUsage{}, false, nil
+	}
+	return usage, true, nil
+}
+
 func extractUsageCandidate(root jsonObject) (usageCandidate, bool) {
 	rootPriority := 1
 	if isFinalUsageEvent(root) {
@@ -111,6 +260,89 @@ func extractUsageCandidate(root jsonObject) (usageCandidate, bool) {
 	}
 	usage.RawUsageJSON = marshalJSONCompact(root)
 	return usageCandidate{TokenUsage: usage, priority: rootPriority}, true
+}
+
+func extractCodexSessionUsageLine(line, usageKey string) (TokenUsage, bool, error) {
+	var root jsonObject
+	if err := decodeJSONObject([]byte(line), &root); err != nil {
+		return TokenUsage{}, false, fmt.Errorf("decode codex session event: %w", err)
+	}
+	if !isCodexSessionUsageEvent(root) {
+		return TokenUsage{}, false, nil
+	}
+
+	payload := readMap(root, "payload")
+	info := readMap(payload, "info")
+	if info == nil {
+		return TokenUsage{}, false, nil
+	}
+
+	usageMap := readMap(info, usageKey)
+	if usageMap == nil {
+		return TokenUsage{}, false, nil
+	}
+	usage, ok := parseUsageMap(usageMap)
+	if !ok {
+		return TokenUsage{}, false, nil
+	}
+	usage.RawUsageJSON = marshalJSONCompact(usageMap)
+	usage.Model = firstNonEmptyString(usage.Model, readString(root, "model"), readString(payload, "model"))
+	usage.Provider = firstNonEmptyString(usage.Provider, readString(root, "provider"), readString(payload, "provider"))
+	return usage, true, nil
+}
+
+func isCodexSessionUsageEvent(raw jsonObject) bool {
+	if strings.ToLower(readString(raw, "type")) != "event_msg" {
+		return false
+	}
+	payload := readMap(raw, "payload")
+	if payload == nil {
+		return false
+	}
+	return strings.EqualFold(readString(payload, "type"), "token_count")
+}
+
+func addTokenUsage(left, right TokenUsage) TokenUsage {
+	out := TokenUsage{
+		Provider:     firstNonEmptyString(right.Provider, left.Provider),
+		Model:        firstNonEmptyString(right.Model, left.Model),
+		TotalTokens:  left.TotalTokens + right.TotalTokens,
+		RawUsageJSON: right.RawUsageJSON,
+	}
+	out.InputTokens = addOptionalInt64(left.InputTokens, right.InputTokens)
+	out.OutputTokens = addOptionalInt64(left.OutputTokens, right.OutputTokens)
+	out.CachedInputTokens = addOptionalInt64(left.CachedInputTokens, right.CachedInputTokens)
+	out.ReasoningOutputTokens = addOptionalInt64(left.ReasoningOutputTokens, right.ReasoningOutputTokens)
+	return out
+}
+
+func addOptionalInt64(left, right *int64) *int64 {
+	if left == nil && right == nil {
+		return nil
+	}
+	sum := int64(0)
+	if left != nil {
+		sum += *left
+	}
+	if right != nil {
+		sum += *right
+	}
+	return &sum
+}
+
+func subtractOptionalInt64(total, baseline *int64) (*int64, bool) {
+	if total == nil {
+		return nil, false
+	}
+	if baseline == nil {
+		value := *total
+		return &value, true
+	}
+	if *total < *baseline {
+		return nil, false
+	}
+	value := *total - *baseline
+	return &value, true
 }
 
 func parseUsageMap(raw jsonObject) (TokenUsage, bool) {

--- a/internal/worker/agent_runtime.go
+++ b/internal/worker/agent_runtime.go
@@ -134,6 +134,11 @@ func RunCodex(ex CommandExecutor, cfg Config) (output string, sessionID string, 
 		return "", "", fmt.Errorf("ensure codex home: %w", err)
 	}
 
+	baseline, baselineErr := captureCodexUsageBaseline(cfg)
+	if baselineErr != nil {
+		log.Printf("[%s] codex token baseline warning: %v", nowUTC(), baselineErr)
+	}
+
 	instructions, err := os.ReadFile(cfg.InstructionsPath)
 	if err != nil {
 		return "", "", fmt.Errorf("read instructions: %w", err)
@@ -165,6 +170,7 @@ func RunCodex(ex CommandExecutor, cfg Config) (output string, sessionID string, 
 		if discoverErr != nil {
 			log.Printf("[%s] codex session discovery warning: %v", nowUTC(), discoverErr)
 		}
+		recordCodexRunTokenUsage(cfg, baseline, sessionID)
 		return "", sessionID, fmt.Errorf("codex run failed: %w", err)
 	}
 
@@ -172,6 +178,7 @@ func RunCodex(ex CommandExecutor, cfg Config) (output string, sessionID string, 
 	if err != nil {
 		return "", "", fmt.Errorf("discover codex session: %w", err)
 	}
+	recordCodexRunTokenUsage(cfg, baseline, sessionID)
 
 	output, err = loadAgentOutput(cfg.AgentOutputPath, cfg.GooseLogPath, "codex")
 	if err != nil {

--- a/internal/worker/codex_usage.go
+++ b/internal/worker/codex_usage.go
@@ -1,0 +1,149 @@
+package worker
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/rtzll/rascal/internal/runsummary"
+)
+
+type codexUsageBaseline struct {
+	sessionPath string
+	offset      int64
+	usage       runsummary.TokenUsage
+	hasUsage    bool
+}
+
+func captureCodexUsageBaseline(cfg Config) (codexUsageBaseline, error) {
+	sessionPath, err := resolveCodexSessionPath(cfg.CodexHome, configuredRuntimeSessionID(cfg))
+	if err != nil {
+		return codexUsageBaseline{}, err
+	}
+	if strings.TrimSpace(sessionPath) == "" {
+		return codexUsageBaseline{}, nil
+	}
+
+	info, err := os.Stat(sessionPath)
+	if err != nil {
+		return codexUsageBaseline{}, fmt.Errorf("stat codex session file: %w", err)
+	}
+
+	baseline := codexUsageBaseline{
+		sessionPath: sessionPath,
+		offset:      info.Size(),
+	}
+
+	data, err := os.ReadFile(sessionPath)
+	if err != nil {
+		return baseline, fmt.Errorf("read codex session file: %w", err)
+	}
+	usage, ok, err := runsummary.ExtractCodexSessionUsage(string(data))
+	if err != nil {
+		return baseline, fmt.Errorf("extract codex session baseline usage: %w", err)
+	}
+	if ok {
+		baseline.usage = usage
+		baseline.hasUsage = true
+	}
+	return baseline, nil
+}
+
+func recordCodexRunTokenUsage(cfg Config, baseline codexUsageBaseline, sessionID string) {
+	usage, ok, err := loadCodexRunTokenUsage(cfg, baseline, sessionID)
+	if err != nil {
+		log.Printf("[%s] codex token usage capture warning: %v", nowUTC(), err)
+		return
+	}
+	if !ok {
+		return
+	}
+	if err := runsummary.WriteRecordedTokenUsage(filepath.Join(cfg.MetaDir, runsummary.RecordedTokenUsageFile), usage); err != nil {
+		log.Printf("[%s] codex token usage persist warning: %v", nowUTC(), err)
+	}
+}
+
+func loadCodexRunTokenUsage(cfg Config, baseline codexUsageBaseline, sessionID string) (runsummary.TokenUsage, bool, error) {
+	sessionPath, err := resolveCodexSessionPath(cfg.CodexHome, sessionID)
+	if err != nil {
+		return runsummary.TokenUsage{}, false, err
+	}
+	if strings.TrimSpace(sessionPath) == "" {
+		return runsummary.TokenUsage{}, false, nil
+	}
+
+	data, err := os.ReadFile(sessionPath)
+	if err != nil {
+		return runsummary.TokenUsage{}, false, fmt.Errorf("read codex session file: %w", err)
+	}
+
+	finalUsage, finalOK, finalErr := runsummary.ExtractCodexSessionUsage(string(data))
+
+	offset := baseline.offset
+	if samePath(sessionPath, baseline.sessionPath) && offset > int64(len(data)) {
+		offset = int64(len(data))
+	}
+	if offset > 0 && samePath(sessionPath, baseline.sessionPath) {
+		if deltaUsage, ok, err := runsummary.ExtractCodexSessionUsageDelta(string(data[offset:])); ok {
+			if finalOK {
+				deltaUsage.Provider = firstNonEmptyValue(deltaUsage.Provider, finalUsage.Provider)
+				deltaUsage.Model = firstNonEmptyValue(deltaUsage.Model, finalUsage.Model)
+			}
+			return deltaUsage, true, nil
+		} else if err != nil {
+			finalErr = err
+		}
+	} else if offset == 0 {
+		if deltaUsage, ok, err := runsummary.ExtractCodexSessionUsageDelta(string(data)); ok {
+			if finalOK {
+				deltaUsage.Provider = firstNonEmptyValue(deltaUsage.Provider, finalUsage.Provider)
+				deltaUsage.Model = firstNonEmptyValue(deltaUsage.Model, finalUsage.Model)
+			}
+			return deltaUsage, true, nil
+		} else if err != nil {
+			finalErr = err
+		}
+	}
+
+	if finalOK {
+		if baseline.hasUsage {
+			if deltaUsage, ok := runsummary.SubtractTokenUsage(finalUsage, baseline.usage); ok {
+				return deltaUsage, true, nil
+			}
+			return runsummary.TokenUsage{}, false, nil
+		}
+		return finalUsage, true, nil
+	}
+	if finalErr != nil {
+		return runsummary.TokenUsage{}, false, finalErr
+	}
+	return runsummary.TokenUsage{}, false, nil
+}
+
+func resolveCodexSessionPath(codexHome, sessionID string) (string, error) {
+	sessionFiles, err := listCodexSessionFiles(filepath.Join(strings.TrimSpace(codexHome), defaultCodexSessionDir))
+	if err != nil {
+		return "", fmt.Errorf("list codex session files: %w", err)
+	}
+	if len(sessionFiles) == 0 {
+		return "", nil
+	}
+
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return sessionFiles[0], nil
+	}
+
+	for _, path := range sessionFiles {
+		currentID, err := parseCodexSessionID(path)
+		if err != nil {
+			continue
+		}
+		if strings.TrimSpace(currentID) == sessionID {
+			return path, nil
+		}
+	}
+	return "", nil
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -304,7 +304,13 @@ func RunWithExecutor(ex CommandExecutor) error {
 				closesSection = fmt.Sprintf("\n\nCloses #%d", cfg.IssueNumber)
 			}
 			runDuration := runsummary.FormatDuration(int64(time.Since(started).Seconds()))
-			body := runsummary.BuildPRBody(cfg.RunID, commitBody, agentOutput, runDuration, closesSection)
+			var totalTokens *int64
+			if usage, ok, err := runsummary.ReadRecordedTokenUsage(filepath.Join(cfg.MetaDir, runsummary.RecordedTokenUsageFile)); err != nil {
+				log.Printf("[%s] recorded token usage warning: %v", nowUTC(), err)
+			} else if ok && usage.TotalTokens > 0 {
+				totalTokens = &usage.TotalTokens
+			}
+			body := runsummary.BuildPRBody(cfg.RunID, commitBody, agentOutput, runDuration, closesSection, totalTokens)
 			if err := os.WriteFile(cfg.PRBodyPath, []byte(body), 0o644); err != nil {
 				return fmt.Errorf("write pr body: %w", err)
 			}


### PR DESCRIPTION
Record Codex run token usage from session JSONL token_count events, persist the
per-run total into run metadata, and use that explicit value for PR bodies and
completion comments without changing Goose behavior.

<details><summary>Agent Details</summary>

<pre><code>
    __( O)&gt;  ● new session · codex gpt-5.4
   \____)    20260317_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: &#34;/usr/local/bin/codex&#34;
Model: gpt-5.4
Reasoning effort: high
Skip git check: false
Prompt length: 4285 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Suggestion

The user has 7 extensions with 16 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
Consider asking if they&#39;d like to disable some extensions to improve tool selection accuracy.

# Response Guidelines

Use Markdown formatting for all responses.

Human: &lt;info-msg&gt;
It is currently 2026-03-17 21:37:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

&lt;/info-msg&gt;
# Rascal Run Instructions

Run ID: run_6c26bbb9545c2801
Task ID: rtzll/rascal#181
Repository: rtzll/rascal
Issue: #181

## Task

Add end-of-run token reporting for Codex-backed runs

## Summary
Add end-of-run token reporting for Rascal runs that use the `codex` runtime.

Goose already includes token reporting in the generated PR description / completion flow. Codex should offer the same user-facing outcome, but it cannot rely on the same data source because Codex usage is recorded in session JSONL usage events rather than in the final rendered answer.

## Problem
Today, Codex-backed runs do not have a reliable end-of-run token total available in the same places where Goose-backed runs do.

A naive implementation that reads the final session total at the end of the run is not sufficient, because Codex session totals are cumulative across the session. That will overcount as soon as session resume is enabled or multiple turns share the same session.

## Goal
Report Codex token usage at the end of a Rascal run without affecting Goose behavior.

## Requirements
- Scope this to `codex` runs only. Goose behavior should remain unchanged.
- Compute usage for the current run / turn, not the cumulative total for the entire Codex session.
- Avoid overcounting for resumed sessions.
- Surface the total in the same user-facing completion paths where Goose currently shows token usage.
- Keep the implementation robust even if Codex output text changes, since the source of truth is the session event stream.

## Implementation Notes
- Parse Codex usage events from the session JSONL and derive per-run usage from those events.
- Prefer per-turn accounting based on usage events or an equivalent baseline/final delta approach.
- Do **not** use the raw final cumulative session total by itself.
- Thread an explicit token total through Rascal&#39;s run/completion flow instead of trying to scrape it back out of the final answer text.
- Make sure the result is available both for PR body generation and for completion comments / notifications.

## Suggested Acceptance Criteria
- A successful Codex-backed run includes an end-of-run token summary in the same completion surfaces where Goose already reports tokens.
- Fresh-session Codex runs report the correct total.
- Resumed-session Codex runs report only the tokens consumed by the current run, not the entire session history.
- If usage data cannot be recovered, Rascal degrades gracefully instead of reporting an incorrect total.
- Automated tests cover at least:
  - fresh Codex session
  - resumed Codex session
  - missing / unparsable usage data

## Reference
A small reference implementation for reading Codex usage events from session files lives here:

- https://github.com/rtzll/codex-usage

That repo should be used only as implementation guidance. The important design choice here is to derive **per-run usage from usage events (or an equivalent baseline/final delta)** rather than reading the final cumulative session total.


## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run `make lint` and `make test` before finishing if those targets exist.
- If one of those commands does not exist or cannot run, explain exactly why and run the closest equivalent checks instead.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label &#39;rascal&#39; on issue #181


Assistant: 
Image files: 0
============================
{&#34;type&#34;:&#34;message&#34;,&#34;message&#34;:{&#34;id&#34;:null,&#34;role&#34;:&#34;assistant&#34;,&#34;created&#34;:1773784308,&#34;content&#34;:[{&#34;type&#34;:&#34;text&#34;,&#34;text&#34;:&#34;I’m tracing where Goose token totals are produced now, then I’ll add the Codex-specific path with per-run accounting from session usage events and thread that through the same completion surfaces.\n\nI found the existing token persistence and formatting path. Next I’m narrowing to the Codex session JSONL reader and the PR/completion summary code so the new accounting lands in the same surfaces Goose already uses.\n\nThe current path reads `agent.ndjson` and works for Goose, but that will overcount for Codex resumes. I’m checking how the runner already tracks Codex session files so I can derive a per-run delta without coupling to rendered text.\n\nI have the local integration points. I’m briefly checking the referenced `codex-usage` implementation for the event shape it expects, then I’ll mirror only the minimum logic needed here.\n\nI confirmed the reference tool is using `token_count` session events, which is the right direction for Codex. I’m implementing a small local parser for those events plus a run-scoped baseline/final delta, with the result written into run metadata so the rest of Rascal can stay runtime-agnostic.\n\nI’ve got the change scoped: add a Codex-only recorded usage artifact from the session JSONL, switch PR/comment formatting to accept an explicit token total, and keep Goose on the existing log-parsing path. I’m editing the parser and runner/orchestrator glue now.\n\nI’ve wired the Codex path end to end. Next I’m tightening tests around the session parser and the recorded-usage artifact so resumed sessions report only the current run and bad data degrades to “no tokens” instead of an inflated total.\n\nI’m extending the runner tests rather than relying only on formatter tests. That gives coverage for the actual Codex session artifact we now write: fresh session total, resumed-session delta, and invalid session usage producing no recorded total.\n\nThe code path is in place. I’m checking the repo’s verification targets now, then I’ll run the smallest useful test slice first to catch compile issues before the full `make lint` and `make test`.\n\nTargeted tests are down to `cmd/rascald`, which is the slow slice here. I’m letting that finish before moving to the repo-level checks.\n\n`make lint` and `make test` are both running; they share the codegen step first, then I’ll resolve anything that falls out of lint before closing this out.\n\nLint found three small issues: one unchecked `Close` in a test and two wrapped-error complaints on the new helpers. I’m fixing those and rerunning `make lint`.\n\nVerification is clean now. I’m writing the requested commit message artifact and then I’ll summarize the exact behavior change and test coverage.\n\nImplemented Codex-only end-of-run token reporting by recording per-run usage from Codex session `token_count` events and threading that explicit total through the existing completion surfaces.\n\nThe main changes are in [usage.go](/work/repo/internal/runsummary/usage.go), [codex_usage.go](/work/repo/internal/worker/codex_usage.go), [agent_runtime.go](/work/repo/internal/worker/agent_runtime.go), [worker.go](/work/repo/internal/worker/worker.go), and [notifications.go](/work/repo/internal/orchestrator/notifications.go). Fresh Codex runs now persist recorded usage from session JSONL, resumed Codex runs compute only the current run’s usage instead of the cumulative session total, and PR bodies / completion comments consume that explicit recorded value. Goose behavior stays on the existing log-parsing path.\n\nTests were added in [runsummary_test.go](/work/repo/internal/runsummary/runsummary_test.go), [main_test.go](/work/repo/cmd/rascal-runner/main_test.go), and [main_test.go](/work/repo/cmd/rascald/main_test.go) to cover fresh Codex sessions, resumed Codex sessions, and invalid/missing recorded usage. Verification passed with `make lint` and `make test`. The requested commit message was written to [commit_message.txt](/rascal-meta/commit_message.txt).&#34;}],&#34;metadata&#34;:{&#34;userVisible&#34;:true,&#34;agentVisible&#34;:true}}}
{&#34;type&#34;:&#34;complete&#34;,&#34;total_tokens&#34;:5697887}
</code></pre>

</details>

Closes #181

---

Rascal run `run_6c26bbb9545c2801` completed in 14m 19s · 5.70M tokens