### PR TITLE
fix: update credential CLI to provider terminology

### DIFF
--- a/cmd/rascal/auth_credentials.go
+++ b/cmd/rascal/auth_credentials.go
@@ -31,8 +31,8 @@ func (a *app) newAuthCredentialsCmd() *cobra.Command {
 		Long:  "List, inspect, create, update, and change state for stored credentials managed by rascald.",
 		Example: strings.TrimSpace(`
 rascal auth credentials list
-rascal auth credentials create --auth-file ~/.codex/auth.json --scope personal --runtime codex
-rascal auth credentials create --auth-file oauth_token --scope shared --runtime claude
+rascal auth credentials create --auth-file ~/.codex/auth.json --scope personal --provider codex
+rascal auth credentials create --auth-file oauth_token --scope shared --provider anthropic
 rascal auth credentials disable cred_123
 rascal auth credentials cooldown cred_123 --for 30m --reason "upstream auth failures"
 `),
@@ -96,6 +96,7 @@ func (a *app) newAuthCredentialsCreateCmd() *cobra.Command {
 	var (
 		id          string
 		scope       string
+		provider    string
 		runtime     string
 		ownerUserID string
 		weight      int
@@ -105,11 +106,15 @@ func (a *app) newAuthCredentialsCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a stored credential",
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := a.requireServerAuth(); err != nil {
 				return err
 			}
 			resolvedScope, err := normalizeCredentialScope(scope)
+			if err != nil {
+				return err
+			}
+			resolvedProvider, err := resolveCredentialProvider(cmd, provider, runtime, true)
 			if err != nil {
 				return err
 			}
@@ -121,7 +126,7 @@ func (a *app) newAuthCredentialsCreateCmd() *cobra.Command {
 				ID:          strings.TrimSpace(id),
 				OwnerUserID: strings.TrimSpace(ownerUserID),
 				Scope:       resolvedScope,
-				Provider:    strings.TrimSpace(runtime),
+				Provider:    resolvedProvider,
 				AuthBlob:    resolvedAuthBlob,
 				Weight:      weight,
 			})
@@ -136,7 +141,11 @@ func (a *app) newAuthCredentialsCreateCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&id, "id", "", "credential id (auto-generated when empty)")
 	cmd.Flags().StringVar(&scope, "scope", "personal", "credential scope: personal|shared")
-	cmd.Flags().StringVar(&runtime, "runtime", "", "agent runtime this credential is for: codex|claude (default: codex)")
+	cmd.Flags().StringVar(&provider, "provider", "", "credential provider: codex|anthropic (default: codex)")
+	cmd.Flags().StringVar(&runtime, "runtime", "", "deprecated alias for --provider")
+	if err := cmd.Flags().MarkDeprecated("runtime", "use --provider instead"); err != nil {
+		panic(err)
+	}
 	cmd.Flags().StringVar(&ownerUserID, "owner-user-id", "", "owner user id for personal credentials (admin only)")
 	cmd.Flags().IntVar(&weight, "weight", 1, "selection weight")
 	cmd.Flags().StringVar(&authFile, "auth-file", "", "path to auth payload file to store")
@@ -147,6 +156,7 @@ func (a *app) newAuthCredentialsCreateCmd() *cobra.Command {
 func (a *app) newAuthCredentialsUpdateCmd() *cobra.Command {
 	var (
 		scope       string
+		provider    string
 		runtime     string
 		ownerUserID string
 		weight      int
@@ -172,8 +182,12 @@ func (a *app) newAuthCredentialsUpdateCmd() *cobra.Command {
 				req.Scope = &value
 				changed = true
 			}
-			if cmd.Flags().Changed("runtime") {
-				value := strings.TrimSpace(runtime)
+			resolvedProvider, err := resolveCredentialProvider(cmd, provider, runtime, false)
+			if err != nil {
+				return err
+			}
+			if cmd.Flags().Changed("provider") || cmd.Flags().Changed("runtime") {
+				value := resolvedProvider
 				req.Provider = &value
 				changed = true
 			}
@@ -212,7 +226,11 @@ func (a *app) newAuthCredentialsUpdateCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&scope, "scope", "", "credential scope: personal|shared")
-	cmd.Flags().StringVar(&runtime, "runtime", "", "agent runtime: codex|claude")
+	cmd.Flags().StringVar(&provider, "provider", "", "credential provider: codex|anthropic")
+	cmd.Flags().StringVar(&runtime, "runtime", "", "deprecated alias for --provider")
+	if err := cmd.Flags().MarkDeprecated("runtime", "use --provider instead"); err != nil {
+		panic(err)
+	}
 	cmd.Flags().StringVar(&ownerUserID, "owner-user-id", "", "owner user id for personal credentials (admin only)")
 	cmd.Flags().IntVar(&weight, "weight", 0, "selection weight")
 	cmd.Flags().StringVar(&authFile, "auth-file", "", "path to replacement auth payload file")
@@ -482,15 +500,54 @@ func normalizeCredentialScope(scope string) (state.CredentialScope, error) {
 	return resolved, nil
 }
 
+func resolveCredentialProvider(cmd *cobra.Command, provider, runtime string, defaultToCodex bool) (string, error) {
+	resolvedProvider, err := normalizeCredentialProvider(provider)
+	if err != nil {
+		return "", err
+	}
+	resolvedRuntime, err := normalizeCredentialProvider(runtime)
+	if err != nil {
+		return "", err
+	}
+	providerChanged := cmd.Flags().Changed("provider")
+	runtimeChanged := cmd.Flags().Changed("runtime")
+	if providerChanged && runtimeChanged && resolvedProvider != resolvedRuntime {
+		return "", &cliError{Code: exitInput, Message: "conflicting credential provider flags", Hint: "use --provider codex|anthropic"}
+	}
+	switch {
+	case providerChanged:
+		return resolvedProvider, nil
+	case runtimeChanged:
+		return resolvedRuntime, nil
+	case defaultToCodex:
+		return "codex", nil
+	default:
+		return "", nil
+	}
+}
+
+func normalizeCredentialProvider(provider string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "":
+		return "", nil
+	case "codex":
+		return "codex", nil
+	case "anthropic", "claude":
+		return "anthropic", nil
+	default:
+		return "", &cliError{Code: exitInput, Message: "invalid credential provider", Hint: "use codex or anthropic"}
+	}
+}
+
 func renderCredentialListTable(creds []credentialRecord) error {
 	tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-	if _, err := fmt.Fprintln(tw, "ID\tRUNTIME\tSCOPE\tOWNER\tSTATUS\tCOOLDOWN\tUPDATED"); err != nil {
+	if _, err := fmt.Fprintln(tw, "ID\tPROVIDER\tSCOPE\tOWNER\tSTATUS\tCOOLDOWN\tUPDATED"); err != nil {
 		return fmt.Errorf("write credential list header: %w", err)
 	}
 	for _, cred := range creds {
 		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			cred.ID,
-			credentialRuntimeLabel(cred.Provider),
+			credentialProviderLabel(cred.Provider),
 			firstNonEmpty(strings.TrimSpace(string(cred.Scope)), "-"),
 			credentialOwnerLabel(cred),
 			firstNonEmpty(strings.TrimSpace(string(cred.Status)), "-"),
@@ -510,7 +567,7 @@ func renderCredentialDetailTable(cred credentialRecord) error {
 	tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
 	rows := [][2]string{
 		{"id", cred.ID},
-		{"provider", credentialRuntimeLabel(cred.Provider)},
+		{"provider", credentialProviderLabel(cred.Provider)},
 		{"scope", string(cred.Scope)},
 		{"owner_user_id", credentialOwnerLabel(cred)},
 		{"status", string(cred.Status)},
@@ -531,12 +588,12 @@ func renderCredentialDetailTable(cred credentialRecord) error {
 	return nil
 }
 
-func credentialRuntimeLabel(runtime string) string {
-	runtime = strings.TrimSpace(runtime)
-	if runtime == "" {
+func credentialProviderLabel(provider string) string {
+	provider = strings.TrimSpace(provider)
+	if provider == "" {
 		return "codex"
 	}
-	return runtime
+	return provider
 }
 
 func credentialOwnerLabel(cred credentialRecord) string {

--- a/cmd/rascal/auth_credentials_test.go
+++ b/cmd/rascal/auth_credentials_test.go
@@ -160,6 +160,9 @@ func TestAuthCredentialsCreateUsesAuthFile(t *testing.T) {
 	if payload.Scope != "shared" {
 		t.Fatalf("payload scope = %q, want shared", payload.Scope)
 	}
+	if payload.Provider != "codex" {
+		t.Fatalf("payload provider = %q, want codex", payload.Provider)
+	}
 	if payload.Weight != 5 {
 		t.Fatalf("unexpected numeric payload: %+v", payload)
 	}
@@ -172,6 +175,55 @@ func TestAuthCredentialsCreateUsesAuthFile(t *testing.T) {
 	}
 	if out.Credential.ID != "cred_create" {
 		t.Fatalf("unexpected credential output: %+v", out.Credential)
+	}
+}
+
+func TestAuthCredentialsCreateDeprecatedRuntimeAliasMapsClaudeToAnthropic(t *testing.T) {
+	authPath := filepath.Join(t.TempDir(), "oauth_token")
+	if err := os.WriteFile(authPath, []byte("token"), 0o600); err != nil {
+		t.Fatalf("write auth file: %v", err)
+	}
+	var payload credentialCreateRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/v1/credentials" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(credentialGetResponse{
+			Credential: credentialRecord{
+				ID:        "cred_create",
+				Scope:     payload.Scope,
+				Weight:    payload.Weight,
+				Status:    "active",
+				CreatedAt: time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC),
+				UpdatedAt: time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC),
+			},
+		}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	a := newCredentialTestApp(srv)
+	cmd := a.newAuthCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{
+		"credentials", "create",
+		"--auth-file", authPath,
+		"--runtime", "claude",
+	})
+	if _, err := captureStdout(func() error { return cmd.Execute() }); err != nil {
+		t.Fatalf("credentials create with deprecated alias: %v", err)
+	}
+	if payload.Provider != "anthropic" {
+		t.Fatalf("payload provider = %q, want anthropic", payload.Provider)
 	}
 }
 
@@ -211,6 +263,7 @@ func TestAuthCredentialsUpdateSendsChangedFields(t *testing.T) {
 	cmd.SetArgs([]string{
 		"credentials", "update", "cred_update",
 		"--scope", "personal",
+		"--provider", "anthropic",
 		"--owner-user-id", "user_2",
 		"--weight", "9",
 		"--auth-blob", `{"token":"updated"}`,
@@ -220,6 +273,9 @@ func TestAuthCredentialsUpdateSendsChangedFields(t *testing.T) {
 	}
 	if raw.Scope == nil || *raw.Scope != "personal" {
 		t.Fatalf("unexpected scope payload: %v", raw.Scope)
+	}
+	if raw.Provider == nil || *raw.Provider != "anthropic" {
+		t.Fatalf("unexpected provider payload: %v", raw.Provider)
 	}
 	if raw.OwnerUserID == nil || *raw.OwnerUserID != "user_2" {
 		t.Fatalf("unexpected owner payload: %v", raw.OwnerUserID)

--- a/cmd/rascal/testdata/help/auth_credentials.golden
+++ b/cmd/rascal/testdata/help/auth_credentials.golden
@@ -6,8 +6,8 @@ Usage:
 
 Examples:
 rascal auth credentials list
-rascal auth credentials create --auth-file ~/.codex/auth.json --scope personal --runtime codex
-rascal auth credentials create --auth-file oauth_token --scope shared --runtime claude
+rascal auth credentials create --auth-file ~/.codex/auth.json --scope personal --provider codex
+rascal auth credentials create --auth-file oauth_token --scope shared --provider anthropic
 rascal auth credentials disable cred_123
 rascal auth credentials cooldown cred_123 --for 30m --reason "upstream auth failures"
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -307,7 +307,7 @@ Common failure and recovery cases:
 
 ## Credential Handling
 
-Rascal uses runtime-scoped stored credentials managed by `rascald`.
+Rascal uses stored credentials tagged by provider and managed by `rascald`.
 
 - Stored credentials are encrypted before being persisted in SQLite.
 - Each credential has a `provider` tag (`codex` or `anthropic`) that determines
@@ -329,7 +329,7 @@ Rascal uses runtime-scoped stored credentials managed by `rascald`.
 - Bootstrap and deploy can seed an initial shared stored credential from a local
   Codex auth file.
 - Operators can manage credentials with `rascal auth credentials ...` and use
-  `--runtime codex|anthropic` to tag credentials for specific providers.
+  `--provider codex|anthropic` to tag credentials for specific providers.
 
 ## Runner Environment Contract
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -74,15 +74,15 @@ rascal doctor --host YOUR_SERVER_IP
 
 ## Server Credential Settings
 
-Rascal uses encrypted, runtime-scoped stored credentials for agent runs.
+Rascal uses encrypted stored credentials tagged by provider for agent runs.
 
-Each credential is tagged with an `agent_runtime` (`codex` or `claude`). The
+Each credential is tagged with a `provider` (`codex` or `anthropic`). The
 broker automatically filters credentials matching the run's runtime:
 
-- `codex` credentials: used by `codex` and `goose` runtimes (auth.json format).
-- `claude` credentials: used by `claude` and `goose-claude` runtimes (OAuth
+- `codex` credentials: used by `codex` and `goose-codex` runtimes (auth.json format).
+- `anthropic` credentials: used by `claude` and `goose-claude` runtimes (OAuth
   token format).
-- Legacy credentials with no runtime tag are treated as `codex` credentials.
+- Legacy credentials with no provider tag are treated as `codex` credentials.
 
 - `RASCAL_CREDENTIAL_STRATEGY` Allocation strategy for choosing among eligible
   credentials. Default: `requester_own_then_shared`
@@ -98,6 +98,6 @@ broker automatically filters credentials matching the run's runtime:
   Recommended: set a dedicated encryption key instead of reusing the API token.
 
 Operators can manage stored credentials with `rascal auth credentials ...`. Use
-`--runtime codex` or `--runtime claude` when creating credentials to tag them
-for specific runtimes. Bootstrap and deploy flows can seed an initial shared
+`--provider codex` or `--provider anthropic` when creating credentials to tag
+them for specific runtimes. Bootstrap and deploy flows can seed an initial shared
 codex credential with `--codex-auth ~/.codex/auth.json`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -121,15 +121,15 @@ Agent runtime notes:
 
 ## Credential Leasing
 
-Rascal uses runtime-scoped leased stored credentials for all agent runs.
+Rascal uses leased stored credentials tagged by provider for all agent runs.
 
-Each credential is tagged with an `agent_runtime` (`codex` or `claude`). The
+Each credential is tagged with a `provider` (`codex` or `anthropic`). The
 broker automatically selects credentials matching the run's runtime:
 
-- `codex` and `goose` runs use `codex` credentials (auth.json format).
-- `claude` and `goose-claude` runs use `claude` credentials (OAuth token
+- `codex` and `goose-codex` runs use `codex` credentials (auth.json format).
+- `claude` and `goose-claude` runs use `anthropic` credentials (OAuth token
   format).
-- Legacy credentials with no runtime tag are treated as `codex` credentials.
+- Legacy credentials with no provider tag are treated as `codex` credentials.
 
 Operational notes:
 
@@ -140,7 +140,7 @@ Operational notes:
 - Stored credential payloads are encrypted at rest in SQLite using
   `RASCAL_CREDENTIAL_ENCRYPTION_KEY`.
 - Manage credentials with `rascal auth credentials ...`.
-- Use `--runtime codex` or `--runtime claude` when creating credentials.
+- Use `--provider codex` or `--provider anthropic` when creating credentials.
 - `rascal init --codex-auth ...` and `rascal deploy --codex-auth ...` seed or
   update a shared stored codex credential for the server.
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -73,8 +73,8 @@ rascal deploy \
 
 That `--codex-auth` value seeds or updates the shared stored codex credential
 used for Codex and Goose runs; it is not copied to a static server-side fallback
-file. For Claude and Goose-Claude runs, create a separate `claude` credential
-via `rascal auth credentials create --runtime claude --auth-file <path>`.
+file. For Claude and Goose-Claude runs, create a separate `anthropic` credential
+via `rascal auth credentials create --provider anthropic --auth-file <path>`.
 
 Inspect remote services:
 


### PR DESCRIPTION
Make --provider the primary credential flag while keeping --runtime as a deprecated alias.
Normalize legacy claude input to anthropic and update help, docs, and tests.

<details><summary>Agent Details</summary>

<pre><code>
    __( O)&gt;  ● new session · codex gpt-5.4
   \____)    20260319_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: &#34;/usr/local/bin/codex&#34;
Model: gpt-5.4
Reasoning effort: high
Skip git check: false
Prompt length: 2514 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Suggestion

The user has 7 extensions with 16 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
Consider asking if they&#39;d like to disable some extensions to improve tool selection accuracy.

# Response Guidelines

Use Markdown formatting for all responses.

Human: &lt;info-msg&gt;
It is currently 2026-03-19 22:07:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

&lt;/info-msg&gt;
# Rascal Run Instructions

Run ID: run_089f6f3b9c5d7877
Task ID: rtzll/rascal#189
Repository: rtzll/rascal
Issue: #189

## Task

fix: update credential CLI --runtime flag to use provider terminology

## Context

After the Runtime/Harness/Provider unification, credential records are tagged with a `provider` (`codex` or `anthropic`), but the CLI still uses `--runtime` flag with help text showing `codex|claude`:

- `cmd/rascal/auth_credentials.go` line 139: `&#34;agent runtime this credential is for: codex|claude (default: codex)&#34;`
- `cmd/rascal/auth_credentials.go` line 215: `&#34;agent runtime: codex|claude&#34;`
- Example text on line 35: `--runtime claude`

## Options

1. **Rename flag to `--provider`** with values `codex|anthropic` (matches internal model, breaking CLI change)
2. **Keep `--runtime` flag** but accept both `claude` and `anthropic` as input, mapping `claude` → `anthropic` internally (backwards-compatible)
3. **Add `--provider` as primary, keep `--runtime` as deprecated alias** (gradual migration)

## Scope

- Update flag name and/or help text
- Update example text in command Long description
- If keeping backwards compat: add input normalization (`claude` → `anthropic`)
- Update docs references


## Constraints

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Run `make lint` and `make test` before finishing if those targets exist.
- If one of those commands does not exist or cannot run, explain exactly why and run the closest equivalent checks instead.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.

## Additional Context

Triggered by label &#39;rascal&#39; on issue #189


Assistant: 
Image files: 0
============================
{&#34;type&#34;:&#34;message&#34;,&#34;message&#34;:{&#34;id&#34;:null,&#34;role&#34;:&#34;assistant&#34;,&#34;created&#34;:1773958719,&#34;content&#34;:[{&#34;type&#34;:&#34;text&#34;,&#34;text&#34;:&#34;I’m checking the credential CLI implementation and nearby docs/tests first so I can make the terminology change without breaking adjacent auth flows.\n\nI’ve confirmed the CLI still exposes `--runtime` and `claude` in command help/examples while the stored field is already `provider`. Next I’m checking the credential command tests and help golden files so the change stays consistent.\n\nThe main change surface is small: `cmd/rascal/auth_credentials.go`, help goldens, and likely a couple of command tests for flag parsing. I’m checking how provider values are validated so I can decide whether to keep a deprecated alias or just swap names.\n\nI found no provider-value validation in the API/store, so the CLI is the right place to normalize old input. I’m going with a gradual migration: primary `--provider`, deprecated `--runtime` alias, and `claude -&gt; anthropic` normalization so old scripts keep working.\n\nI’ve identified four docs sections that still describe credential tagging as `agent_runtime`/`claude`. I’m updating those along with the CLI so the user-facing terminology is consistent end to end.\n\nI have the edit plan pinned down now:\n- Replace the credential flag surface with primary `--provider`, deprecated `--runtime` alias, and normalize `claude` to `anthropic`.\n- Update credential command examples and output labels from runtime wording to provider wording.\n- Refresh the credential docs/help snapshots and add focused CLI tests for the new flag behavior.\n\n\nI’m editing the CLI now: flag parsing first, then the focused tests/docs that depend on it.\n\nI’ve finished the CLI code changes. Next I’m tightening the regression tests around default provider behavior, the new primary flag, and the old alias mapping.\n\nThe implementation is in place and formatted. I’m doing a quick pass over the diff and then I’ll run the required validation targets (`make lint`, `make test`).\n\nI found one remaining architecture sentence still calling credentials “runtime-scoped.” I’m fixing that wording before validation so the docs don’t contradict the flag change.\n\nValidation is running now. `make lint` and `make test` both kicked off from a clean codegen step; I’m waiting on the full results before writing the commit message file.\n\nThe test run is still pulling Go dependencies, so validation hasn’t reached package execution yet. I’m keeping both processes open until I have final pass/fail output.\n\nThe long-running checks are still active without new output, which usually means `golangci-lint` and `go test` are still chewing through packages. I’m checking the active processes once so I can tell whether this is genuine runtime or a hang.\n\nThe broad repo checks are still compiling/running in the background. I also started a narrow `cmd/rascal` test run so I can catch any CLI-specific regression quickly instead of waiting on the full suite first.\n\n`make lint` found a real issue: `errcheck` requires the deprecated-flag registration error to be handled explicitly. I’m patching that now, then I’ll rerun both lint and tests on the final state.\n\nThe lint fix is applied and formatted. I’ve restarted both required checks from the final tree and I’m waiting on the exit status now.\n\nValidation passed. I’m writing the requested conventional commit message file and then I’ll give you the concise change summary with the exact verification results.\n\nUpdated the credential CLI in [auth_credentials.go](/work/repo/cmd/rascal/auth_credentials.go#L27) to use provider terminology. `--provider` is now the primary flag for `create` and `update`, `--runtime` is kept as a deprecated alias, and legacy `claude` input is normalized to `anthropic`. I also updated the credential output label from `RUNTIME` to `PROVIDER` and refreshed the command examples in [auth_credentials.golden](/work/repo/cmd/rascal/testdata/help/auth_credentials.golden).\n\nAdded focused regression coverage in [auth_credentials_test.go](/work/repo/cmd/rascal/auth_credentials_test.go#L108) for default `codex`, deprecated alias mapping, and update payload behavior. Docs were aligned in [architecture.md](/work/repo/docs/architecture.md#L310), [config.md](/work/repo/docs/config.md#L77), [operations.md](/work/repo/docs/operations.md#L124), and [runbook.md](/work/repo/docs/runbook.md#L74). The requested commit message was written to [commit_message.txt](/rascal-meta/commit_message.txt).\n\nValidation: `make lint` passed. `make test` passed.&#34;}],&#34;metadata&#34;:{&#34;userVisible&#34;:true,&#34;agentVisible&#34;:true}}}
{&#34;type&#34;:&#34;complete&#34;,&#34;total_tokens&#34;:2531463}
</code></pre>

</details>

Closes #189

---

Rascal run `run_089f6f3b9c5d7877` completed in 10m 55s · 2.53M tokens