### PR TITLE
docs(setup): document make smoke verification

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -111,3 +111,14 @@ You can run Rascal over host IP without a domain.
 rascal doctor --host YOUR_SERVER_IP
 rascal config view
 ```
+
+## Local Verification
+
+Before relying on a new setup, run the local smoke checks:
+
+```bash
+make smoke
+```
+
+This runs both smoke checks: `smoke-noop` and `smoke-docker`.
+The Docker-backed smoke check requires a working local Docker daemon.


### PR DESCRIPTION
<details><summary>Agent Details</summary>

<pre><code>
    __( O)&gt;  ● resuming · codex gpt-5.4
   \____)    20260329_1 · /work/repo
     L L     goose is ready
=== CODEX PROVIDER DEBUG ===
Command: &#34;/usr/local/bin/codex&#34;
Model: gpt-5.4
Reasoning effort: high
Skip git check: false
Prompt length: 3546 chars
Prompt: You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
goose is being developed as an open-source software project.
# Suggestion

The user has 7 extensions with 16 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
Consider asking if they&#39;d like to disable some extensions to improve tool selection accuracy.

# Response Guidelines

Use Markdown formatting for all responses.

Human: &lt;info-msg&gt;
It is currently 2026-03-29 18:35:00
Working directory: /work/repo

Current tasks and notes:
Once given a task, immediately update your todo with all explicit and implicit requirements

# Rascal Persistent Instructions

- Do not ask for interactive input.
- Do not require MCP tools.
- Keep changes minimal and scoped to the requested task.
- Do not overwrite, revert, or discard user changes you did not make unless the task explicitly requires it.
- Use the repository&#39;s existing patterns and conventions.
- Prefer the repository&#39;s documented workflow over inventing a new one.
- If the repository provides verification commands, run the relevant ones before finishing.
- Run `make lint` and `make test` before finishing if those targets exist.
- If one of those commands does not exist or cannot run, explain exactly why and run the closest equivalent checks instead.
- If you make changes, write /rascal-meta/commit_message.txt using a conventional commit title on the first line.
- Optionally add a commit body after a blank line in /rascal-meta/commit_message.txt.
- If working with GitHub branches or pull requests, only push to the designated Rascal branch for this run.
- If you must rewrite published history, prefer `git push --force-with-lease` over `git push --force`.
- Before finishing, ensure the working tree is clean unless the task explicitly requires uncommitted output.

&lt;/info-msg&gt;
# Rascal Run Instructions

Run ID: run_cf4f07ee083ed276
Task ID: rtzll/rascal#202
Repository: rtzll/rascal
Issue: #202

## Task

docs(setup): document make smoke as local verification step

Add a short local verification section to `docs/setup.md`.

Scope:
- recommend `make smoke`
- note that it runs both smoke checks
- mention that the Docker-backed smoke requires a working local Docker daemon

Acceptance criteria:
- `docs/setup.md` includes the new section
- no README changes


## Additional Context

Triggered by label &#39;rascal&#39; on issue #202

# Rascal Run Instructions

Run ID: run_1faaa89cd866f0dd
Task ID: rtzll/rascal#202
Repository: rtzll/rascal
Issue: #202

## Task

docs(setup): document make smoke as local verification step

Add a short local verification section to `docs/setup.md`.

Scope:
- recommend `make smoke`
- note that it runs both smoke checks
- mention that the Docker-backed smoke requires a working local Docker daemon

Acceptance criteria:
- `docs/setup.md` includes the new section
- no README changes


## Additional Context

Triggered by label &#39;rascal&#39; on issue #202

# Rascal Run Instructions

Run ID: run_d12aa364d058b18c
Task ID: rtzll/rascal#202
Repository: rtzll/rascal
Issue: #202

## Task

docs(setup): document make smoke as local verification step

Add a short local verification section to `docs/setup.md`.

Scope:
- recommend `make smoke`
- note that it runs both smoke checks
- mention that the Docker-backed smoke requires a working local Docker daemon

Acceptance criteria:
- `docs/setup.md` includes the new section
- no README changes


## Additional Context

Triggered by label &#39;rascal&#39; on issue #202


Assistant: 
Image files: 0
============================
{&#34;type&#34;:&#34;message&#34;,&#34;message&#34;:{&#34;id&#34;:null,&#34;role&#34;:&#34;assistant&#34;,&#34;created&#34;:1774809604,&#34;content&#34;:[{&#34;type&#34;:&#34;text&#34;,&#34;text&#34;:&#34;I’m checking the repository state, the current `docs/setup.md`, and the available `make` targets first so I can keep the edit scoped and verify it with the repo’s existing workflow.\n\nI’ve confirmed the worktree starts clean and `Makefile` has `lint`, `test`, and `smoke` targets. Next I’m checking the `smoke` target details so the new docs text matches the existing behavior exactly.\n\nI have enough context to patch the docs now. I’m adding a short local verification section to `docs/setup.md` without touching the README, and I’ll keep the wording aligned with the `Makefile` targets.\n\nThe docs edit is in place. I’m running the repo’s verification targets next, including the smoke target referenced by the new section, so I can report any environment-dependent failures precisely.\n\n`make lint` is still running. Once that finishes I’ll run `make test` and then `make smoke` to confirm whether the Docker-backed check is usable in this environment.\n\n`golangci-lint` is taking a while but still appears to be the active process. I’m letting it finish rather than interrupting it so the verification stays faithful to the repo’s normal workflow.\n\n`make lint` has gone quiet for a while. I’m checking the running process from a separate shell to distinguish a slow lint from a stalled one before deciding whether to keep waiting.\n\n`make lint` is still live after more than a minute, with `golangci-lint run` consuming the time. I’m giving it one more longer window because the repo explicitly asks for this target before finishing.\n\n`make test` is progressing normally; it has started returning package results. I’m waiting for the full target to complete before moving on to the smoke checks.\n\n`make test` failed in the existing suite, and the failure is unrelated to the docs change: `TestLoadConfigRespectsDirectoryOverrides` in `cmd/rascal-runner/config_test.go` expected a temp path but got `/rascal-meta/persistent_instructions.md`. I’m still running the smoke target because it is directly relevant to the new documentation.\n\nThe smoke target confirms the docs note: `smoke-noop` passes, and `smoke-docker` stops immediately because no local Docker daemon is running. I’m doing a final diff/status check now, then I’ll write the required commit message file and commit the scoped docs change so the tree ends clean.\n\nThe diff is scoped exactly to `docs/setup.md`, and the repo is already on the designated Rascal branch. I’m writing the required conventional commit message file and then committing this single docs change to leave the working tree clean.\n\n`git commit` was blocked because this checkout has no configured author identity. I’m setting a repo-local identity only, then I’ll retry the commit so the tree can still finish clean without touching global Git config.\n\nAdded a short `Local Verification` section to [docs/setup.md](/work/repo/docs/setup.md) recommending `make smoke`, stating that it runs both `smoke-noop` and `smoke-docker`, and noting that the Docker-backed smoke check requires a working local Docker daemon. `README` was not changed.\n\nVerification:\n- `make lint` passed.\n- `make test` failed in the existing suite at [cmd/rascal-runner/config_test.go#L119](/work/repo/cmd/rascal-runner/config_test.go#L119): `TestLoadConfigRespectsDirectoryOverrides` expected a temp meta path but got `/rascal-meta/persistent_instructions.md`.\n- `make smoke` confirmed the documented behavior: `smoke-noop` passed, and `smoke-docker` failed because no local Docker daemon was running.\n\nThe change is committed on the current Rascal branch as `1aa8a26`, and the worktree is clean.&#34;}],&#34;metadata&#34;:{&#34;userVisible&#34;:true,&#34;agentVisible&#34;:true}}}
{&#34;type&#34;:&#34;complete&#34;,&#34;total_tokens&#34;:735894}
</code></pre>

</details>

Closes #202

---

Rascal run `run_d12aa364d058b18c` completed in 5m 5s · 735K tokens